### PR TITLE
feat: load validations as list from file

### DIFF
--- a/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
+++ b/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
@@ -1,29 +1,29 @@
-description: This mock response contains a incomplete yaml-formatted manifest for an APIRule
-scenario_id: kyma_app_apirule_broken
-mock_response_content: |-
-  "There seems to be a syntax error in the APIRule. It contains two accessStrategies but it should only contain one accessStrategy. Here is a corrected version of the APIRule:
-  ```yaml
-  apiVersion: gateway.kyma-project.io/v1beta1
-  kind: APIRule
-  spec:
-    rules:
-      - path: /.*
-        methods: ["GET", "POST"]
-        accessStrategies:
-          - handler: no_auth
-  ```"
-expected_evaluations:
-  - scenario_expectation_name: apirule_error
-    expected_evaluation: true
-  - scenario_expectation_name: apirule_with_two_accessStrategies
-    expected_evaluation: true
-  - scenario_expectation_name: step_by_step_guide
-    expected_evaluation: false
-  - scenario_expectation_name: some_yaml
-    expected_evaluation: true
-  - scenario_expectation_name: partial_yaml_for_apirule
-    expected_evaluation: true
-  - scenario_expectation_name: complete_yaml_for_apirule
-    expected_evaluation: false
-  - scenario_expectation_name: deployable_yaml_for_apirule
-    expected_evaluation: false
+- description: This mock response contains a incomplete yaml-formatted manifest for an APIRule
+  scenario_id: kyma_app_apirule_broken
+  mock_response_content: |-
+    "There seems to be a syntax error in the APIRule. It contains two accessStrategies but it should only contain one accessStrategy. Here is a corrected version of the APIRule:
+      ```yaml
+      apiVersion: gateway.kyma-project.io/v1beta1
+      kind: APIRule
+      spec:
+        rules:
+          - path: /.*
+          methods: ["GET", "POST"]
+          accessStrategies:
+            - handler: no_auth
+            ```"
+  expected_evaluations:
+    - scenario_expectation_name: apirule_error
+      expected_evaluation: true
+    - scenario_expectation_name: apirule_with_two_accessStrategies
+      expected_evaluation: true
+    - scenario_expectation_name: step_by_step_guide
+      expected_evaluation: false
+    - scenario_expectation_name: some_yaml
+      expected_evaluation: true
+    - scenario_expectation_name: partial_yaml_for_apirule
+      expected_evaluation: true
+    - scenario_expectation_name: complete_yaml_for_apirule
+      expected_evaluation: false
+    - scenario_expectation_name: deployable_yaml_for_apirule
+      expected_evaluation: false

--- a/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
+++ b/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
@@ -11,7 +11,7 @@
           methods: ["GET", "POST"]
           accessStrategies:
             - handler: no_auth
-            ```"
+      ```"
   expected_evaluations:
     - scenario_expectation_name: apirule_error
       expected_evaluation: true

--- a/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
+++ b/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
@@ -1,28 +1,28 @@
-description: This mock response contains a complete deployable yaml-formatted manifest for a serverless function
-scenario_id: kyma_app_serverless_syntax_err
-mock_response_content: |-
-  "There seems to be a syntax error in the serverless function 'func1'. The function calls Dates() instead of Date(). Here is a corrected version of the function:
-  ```yaml
-  apiVersion: serverless.kyma-project.io/v1alpha2
-  kind: Function
-  metadata:
-    name: func1
-    namespace: kyma_app_serverless_syntax_err
-    labels:
-      app: restapi
-  spec:
-    runtime: nodejs20
-    source:
-      inline:
-        dependencies: |-
-          {
-            "name": "func1",
-            "version": "1.0.0",
-            "dependencies": {}
-          }
-        source: |
-          module.exports = {
-            main: async function (event, context) {
+- description: This mock response contains a complete deployable yaml-formatted manifest for a serverless function
+  scenario_id: kyma_app_serverless_syntax_err
+  mock_response_content: |-
+    "There seems to be a syntax error in the serverless function 'func1'. The function calls Dates() instead of Date(). Here is a corrected version of the function:
+      ```yaml
+      apiVersion: serverless.kyma-project.io/v1alpha2
+      kind: Function
+      metadata:
+        name: func1
+        namespace: kyma_app_serverless_syntax_err
+        labels:
+          app: restapi
+      spec:
+        runtime: nodejs20
+        source:
+          inline:
+            dependencies: |-
+            {
+              "name": "func1",
+              "version": "1.0.0",
+              "dependencies": {}
+            }
+          source: |
+            module.exports = {
+              main: async function (event, context) {
                 const now = new Date();
                 const response = {
                 statusCode: 200,
@@ -31,24 +31,24 @@ mock_response_content: |-
                   status: 'success',
                   utcDatetime: now
                 }
-              };
+            };
               console.log('Response:', response);
               return response;
             }
           }
-  ```"
-expected_evaluations:
-  - scenario_expectation_name: step_by_step_guide
-    expected_evaluation: false
-  - scenario_expectation_name: syntax_error
-    expected_evaluation: true
-  - scenario_expectation_name: syntax_fix
-    expected_evaluation: true
-  - scenario_expectation_name: some_yaml
-    expected_evaluation: true
-  - scenario_expectation_name: yaml_with_serverless_function
-    expected_evaluation: true
-  - scenario_expectation_name: yaml_with_complete_serverless_function
-    expected_evaluation: true
-  - scenario_expectation_name: deployable_yaml_with_complete_serverless_function
-    expected_evaluation: true
+      ```"
+  expected_evaluations:
+    - scenario_expectation_name: step_by_step_guide
+      expected_evaluation: false
+    - scenario_expectation_name: syntax_error
+      expected_evaluation: true
+    - scenario_expectation_name: syntax_fix
+      expected_evaluation: true
+    - scenario_expectation_name: some_yaml
+      expected_evaluation: true
+    - scenario_expectation_name: yaml_with_serverless_function
+      expected_evaluation: true
+    - scenario_expectation_name: yaml_with_complete_serverless_function
+      expected_evaluation: true
+    - scenario_expectation_name: deployable_yaml_with_complete_serverless_function
+      expected_evaluation: true

--- a/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
+++ b/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
@@ -15,27 +15,27 @@
         source:
           inline:
             dependencies: |-
-            {
-              "name": "func1",
-              "version": "1.0.0",
-              "dependencies": {}
-            }
-          source: |
-            module.exports = {
-              main: async function (event, context) {
-                const now = new Date();
-                const response = {
-                statusCode: 200,
-                result: {
-                  message: 'Serverless function is up and running',
-                  status: 'success',
-                  utcDatetime: now
+              {
+                "name": "func1",
+                "version": "1.0.0",
+                "dependencies": {}
                 }
-            };
-              console.log('Response:', response);
-              return response;
+            source: |
+              module.exports = {
+                main: async function (event, context) {
+                  const now = new Date();
+                  const response = {
+                  statusCode: 200,
+                  result: {
+                    message: 'Serverless function is up and running',
+                    status: 'success',
+                    utcDatetime: now
+                  }
+                };
+                console.log('Response:', response);
+                return response;
+              }
             }
-          }
       ```"
   expected_evaluations:
     - scenario_expectation_name: step_by_step_guide

--- a/tests/blackbox/data/validation/nginx_oom.yml
+++ b/tests/blackbox/data/validation/nginx_oom.yml
@@ -1,18 +1,36 @@
-description: Mock responses for a scenario where a nginx deployment is configured to an insufficient amount of memory that will lead to a pod that runs out of memory.
-mock_response_content: The pod has an OOM (out of memory) error. The container has an insufficient amount of memory. You should increase the memory limit or the memory request.
-scenario_id: nginx_oom
-expected_evaluations:
-  - scenario_expectation_name: oom_error
-    expected_evaluation: true
-  - scenario_expectation_name: insufficient_memory
-    expected_evaluation: true
-  - scenario_expectation_name: propose_memory_increase
-    expected_evaluation: true
-  - scenario_expectation_name: some_yaml
-    expected_evaluation: false
-  - scenario_expectation_name: yaml_with_deployment
-    expected_evaluation: false
-  - scenario_expectation_name: yaml_with_deployment_and_resources
-    expected_evaluation: false
-  - scenario_expectation_name: fully_deployable_yaml
-    expected_evaluation: false
+- description: Mock responses for a scenario where a nginx deployment is configured to an insufficient amount of memory that will lead to a pod that runs out of memory.
+  mock_response_content: The pod has an OOM (out of memory) error. The container has an insufficient amount of memory. You should increase the memory limit or the memory request.
+  scenario_id: nginx_oom
+  expected_evaluations:
+    - scenario_expectation_name: oom_error
+      expected_evaluation: true
+    - scenario_expectation_name: insufficient_memory
+      expected_evaluation: true
+    - scenario_expectation_name: propose_memory_increase
+      expected_evaluation: true
+    - scenario_expectation_name: some_yaml
+      expected_evaluation: false
+    - scenario_expectation_name: yaml_with_deployment
+      expected_evaluation: false
+    - scenario_expectation_name: yaml_with_deployment_and_resources
+      expected_evaluation: false
+    - scenario_expectation_name: fully_deployable_yaml
+      expected_evaluation: false
+- description: False negative for the scenario where a nginx deployment is configured to an insufficient amount of memory that will lead to a pod that runs out of memory.
+  mock_response_content: There is no problem; everything is fine.
+  scenario_id: nginx_oom
+  expected_evaluations:
+    - scenario_expectation_name: oom_error
+      expected_evaluation: false
+    - scenario_expectation_name: insufficient_memory
+      expected_evaluation: false
+    - scenario_expectation_name: propose_memory_increase
+      expected_evaluation: false
+    - scenario_expectation_name: some_yaml
+      expected_evaluation: false
+    - scenario_expectation_name: yaml_with_deployment
+      expected_evaluation: false
+    - scenario_expectation_name: yaml_with_deployment_and_resources
+      expected_evaluation: false
+    - scenario_expectation_name: fully_deployable_yaml
+      expected_evaluation: false

--- a/tests/blackbox/data/validation/nginx_wrong_image.yml
+++ b/tests/blackbox/data/validation/nginx_wrong_image.yml
@@ -1,18 +1,18 @@
-description: Mock responses for a scenario where the ngix image was not found
-scenario_id: nginx_wrong_image
-mock_response_content: The image you try to use does not exist. You might have misspelled the image name. The correct image name would be 'nginx'.
-expected_evaluations:
-  - scenario_expectation_name: step_by_step_guide
-    expected_evaluation: false
-  - scenario_expectation_name: image_not_found
-    expected_evaluation: true
-  - scenario_expectation_name: image_typo
-    expected_evaluation: true
-  - scenario_expectation_name: should_be_nginx
-    expected_evaluation: true
-  - scenario_expectation_name: uses_yaml
-    expected_evaluation: false
-  - scenario_expectation_name: complete_yaml
-    expected_evaluation: false
-  - scenario_expectation_name: useable_yaml
-    expected_evaluation: false
+- description: Mock responses for a scenario where the ngix image was not found
+  scenario_id: nginx_wrong_image
+  mock_response_content: The image you try to use does not exist. You might have misspelled the image name. The correct image name would be 'nginx'.
+  expected_evaluations:
+    - scenario_expectation_name: step_by_step_guide
+      expected_evaluation: false
+    - scenario_expectation_name: image_not_found
+      expected_evaluation: true
+    - scenario_expectation_name: image_typo
+      expected_evaluation: true
+    - scenario_expectation_name: should_be_nginx
+      expected_evaluation: true
+    - scenario_expectation_name: uses_yaml
+      expected_evaluation: false
+    - scenario_expectation_name: complete_yaml
+      expected_evaluation: false
+    - scenario_expectation_name: useable_yaml
+      expected_evaluation: false

--- a/tests/blackbox/src/validation/utils/data_loader.py
+++ b/tests/blackbox/src/validation/utils/data_loader.py
@@ -1,5 +1,4 @@
 import os
-from typing import List
 
 import yaml
 from common.logger import get_logger

--- a/tests/blackbox/src/validation/utils/data_loader.py
+++ b/tests/blackbox/src/validation/utils/data_loader.py
@@ -17,7 +17,9 @@ def load_data(data_dir) -> list[ScenarioMockResponses]:
                 file_path = os.path.join(data_dir, filename)
                 with open(file_path) as file:
                     yaml_data = yaml.safe_load(file)
-                    mock_responses = [ScenarioMockResponses(**data) for data in yaml_data]
+                    mock_responses = [
+                        ScenarioMockResponses(**data) for data in yaml_data
+                    ]
                     for mock_response in mock_responses:
                         results.append(mock_response)
     except Exception:

--- a/tests/blackbox/src/validation/utils/data_loader.py
+++ b/tests/blackbox/src/validation/utils/data_loader.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 import yaml
 from common.logger import get_logger
@@ -17,8 +18,9 @@ def load_data(data_dir) -> list[ScenarioMockResponses]:
                 file_path = os.path.join(data_dir, filename)
                 with open(file_path) as file:
                     yaml_data = yaml.safe_load(file)
-                    mock_response = ScenarioMockResponses(**yaml_data)
-                    results.append(mock_response)
+                    mock_responses = [ScenarioMockResponses(**data) for data in yaml_data]
+                    for mock_response in mock_responses:
+                        results.append(mock_response)
     except Exception:
         logger.exception(
             f"Failed to load validation data from the directory: {data_dir}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- one validation file can now contain more than one mock response.
- added another mock response

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
