### PR TITLE
chore: fix blackbox deployment manifests

### DIFF
--- a/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_apirule_broken/deployment.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_apirule_broken/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kyma_app_apirule_broken
+  name: kyma-app-apirule-broken
   labels:
     istio-injection: enabled
 ---
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   selector:
     app: redis
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: redis-pv
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   capacity:
     storage: 10Mi
@@ -39,7 +39,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: redis
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 type: Opaque
 data:
   REDIS_PASSWORD: cGFzc3dvcmQ=
@@ -48,7 +48,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   serviceName: redis
   replicas: 1
@@ -89,7 +89,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: restapi
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   replicas: 1
   selector:
@@ -134,13 +134,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: restapi
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: restapi-access-role
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 rules:
   - apiGroups: [""]
     resources: ["pods", "services", "endpoints", "events", "configmaps"]
@@ -150,11 +150,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: restapi-access-role-binding
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 subjects:
   - kind: ServiceAccount
     name: restapi
-    namespace: kyma_app_apirule_broken
+    namespace: kyma-app-apirule-broken
 roleRef:
   kind: Role
   name: restapi-access-role
@@ -164,15 +164,15 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: restapi-config
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 data:
-  restapi-url: "http://func1.kyma_app_apirule_broken.svc.cluster.local:80"
+  restapi-url: "http://func1.kyma-app-apirule-broken.svc.cluster.local:80"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: restapi
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   selector:
     app: restapi
@@ -188,7 +188,7 @@ apiVersion: serverless.kyma-project.io/v1alpha2
 kind: Function
 metadata:
   name: func1
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
   labels:
     app: restapi
 spec:
@@ -230,11 +230,11 @@ metadata:
   labels:
     app.kubernetes.io/name: sub1
   name: sub1
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
   config:
     maxInFlightMessages: "10"
-  sink: http://restapi.kyma_app_apirule_broken.svc.cluster.local/api/v1/counter
+  sink: http://restapi.kyma-app-apirule-broken.svc.cluster.local/api/v1/counter
   source: noapp
   typeMatching: standard
   types:
@@ -244,12 +244,12 @@ apiVersion: gateway.kyma-project.io/v1beta1
 kind: APIRule
 metadata:
   name: restapi
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 spec:
-  host: kyma_app_apirule_broken.c-5cb6076.stage.kyma.ondemand.com
+  host: kyma-app-apirule-broken.c-5cb6076.stage.kyma.ondemand.com
   service:
     name: restapi
-    namespace: kyma_app_apirule_broken
+    namespace: kyma-app-apirule-broken
     port: 80
   gateway: kyma-system/kyma-gateway
   rules:

--- a/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_apirule_broken/scenario.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_apirule_broken/scenario.yml
@@ -1,10 +1,10 @@
-id: kyma_app_apirule_broken
+id: kyma-app-apirule-broken
 description: The Application uses an API Rule that has two accessStrategies handler, which will lead to an error stead
 resource:
   kind: APIRule
   api_version: gateway.kyma-project.io/v1beta1
   name: restapi
-  namespace: kyma_app_apirule_broken
+  namespace: kyma-app-apirule-broken
 expectations:
   - name: apirule_error
     statement: points out that the apirule is in an error state
@@ -48,7 +48,7 @@ expectations:
       - solution_finding
     complexity: 2
   - name: deployable_yaml_for_apirule
-    statement: provides a complete yaml formatted manifest for a apirule, with the name set to 'restapi', the namespace set to 'kyma_app_apirule_broken', that contains all required fields and that contains only one accessStrategyy
+    statement: provides a complete yaml formatted manifest for a apirule, with the name set to 'restapi', the namespace set to 'kyma-app-apirule-broken', that contains all required fields and that contains only one accessStrategyy
     categories:
       - kubernetes
       - yaml

--- a/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/deploy.sh
+++ b/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl apply -f deployment.yaml
+kubectl apply -f deployment.yml

--- a/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/deployment.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kyma_app_serverless_syntax_err
+  name: kyma-app-serverless-syntax-err
   labels:
     istio-injection: enabled
 ---
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   selector:
     app: redis
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: redis-pv
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   capacity:
     storage: 10Mi
@@ -39,7 +39,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: redis
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 type: Opaque
 data:
   REDIS_PASSWORD: cGFzc3dvcmQ=
@@ -48,7 +48,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   serviceName: redis
   replicas: 1
@@ -89,7 +89,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: restapi
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   replicas: 1
   selector:
@@ -134,13 +134,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: restapi
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: restapi-access-role
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 rules:
   - apiGroups: [""]
     resources: ["pods", "services", "endpoints", "events", "configmaps"]
@@ -150,11 +150,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: restapi-access-role-binding
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 subjects:
   - kind: ServiceAccount
     name: restapi
-    namespace: kyma_app_serverless_syntax_err
+    namespace: kyma-app-serverless-syntax-err
 roleRef:
   kind: Role
   name: restapi-access-role
@@ -164,7 +164,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: restapi-config
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 data:
   restapi-url: "http://func1.kyma-app-no-function.svc.cluster.local:80"
 ---
@@ -172,7 +172,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: restapi
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   selector:
     app: restapi
@@ -188,7 +188,7 @@ apiVersion: serverless.kyma-project.io/v1alpha2
 kind: Function
 metadata:
   name: func1
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
   labels:
     app: restapi
 spec:
@@ -234,7 +234,7 @@ metadata:
   labels:
     app.kubernetes.io/name: sub1
   name: sub1
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   config:
     maxInFlightMessages: "10"
@@ -248,7 +248,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: restapi
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 spec:
   gateways:
     - kyma-system/kyma-gateway

--- a/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/scenario.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/kyma_app_serverless_syntax_err/scenario.yml
@@ -1,10 +1,10 @@
-id: kyma_app_serverless_syntax_err
+id: kyma-app-serverless-syntax-err
 description: The serverless function has a syntax error; it calls Dates() instead of Date().
 resource:
   kind: Function
   api_version: "serverless.kyma-project.io/v1alpha2"
   name: func1
-  namespace: kyma_app_serverless_syntax_err
+  namespace: kyma-app-serverless-syntax-err
 expectations:
   - name: step_by_step_guide
     statement: contains step-by-step guidance
@@ -47,7 +47,7 @@ expectations:
       - solution_finding
     complexity: 3
   - name: deployable_yaml_with_complete_serverless_function
-    statement: provides a complete yaml formatted manifest for a serverless function with all required fields, name set to 'func1', namespace set to 'kyma_app_serverless_syntax_err' and  that calls 'Date()'
+    statement: provides a complete yaml formatted manifest for a serverless function with all required fields, name set to 'func1', namespace set to 'kyma-app-serverless-syntax-err' and  that calls 'Date()'
     categories:
       - kubernetes
       - yaml

--- a/tests/blackbox/data/evaluation/namespace-scoped/nginx_oom/deployment.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/nginx_oom/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nginx_oom
+  name: nginx-oom
   labels:
     istio-injection: enabled
 ---
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: nginx
   name: nginx
-  namespace: nginx_oom
+  namespace: nginx-oom
 spec:
   replicas: 1
   selector:

--- a/tests/blackbox/data/evaluation/namespace-scoped/nginx_oom/scenario.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/nginx_oom/scenario.yml
@@ -1,10 +1,10 @@
-id: nginx_oom
+id: nginx-oom
 description: The ngnix Deployment is configured to an insufficient amount of memory and will run out of memory
 resource:
   kind: Deployment
   api_version: apps/v1
   name: nginx
-  namespace: nginx_oom
+  namespace: nginx-oom
 expectations:
   - name: step_by_step_guide
     statement: contains a step-by-step guide
@@ -52,7 +52,7 @@ expectations:
       - solution_finding
     complexity: 2
   - name: fully_deployable_yaml
-    statement: provides a complete yaml formatted manifest for a Deployment, with the name set to 'nginx', the namespace set to 'nginx_oom', that contains all required fields and that contains the settings for a container with resource limits and/or resource requests
+    statement: provides a complete yaml formatted manifest for a Deployment, with the name set to 'nginx', the namespace set to 'nginx-oom', that contains all required fields and that contains the settings for a container with resource limits and/or resource requests
     categories:
       - kubernetes
       - yaml

--- a/tests/blackbox/data/evaluation/namespace-scoped/nginx_wrong_image/deployment.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/nginx_wrong_image/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nginx_wrong_image
+  name: nginx-wrong-image
   labels:
     istio-injection: enabled
 ---
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: nginx
   name: nginx
-  namespace: nginx_wrong_image
+  namespace: nginx-wrong-image
 spec:
   replicas: 1
   selector:

--- a/tests/blackbox/data/evaluation/namespace-scoped/nginx_wrong_image/scenario.yml
+++ b/tests/blackbox/data/evaluation/namespace-scoped/nginx_wrong_image/scenario.yml
@@ -1,10 +1,10 @@
-id: nginx_wrong_image
+id: nginx-wrong-image
 description: The name of the image in the Deployment is misspelled to 'ngix' instead of 'nginx'
 resource:
   kind: Deployment
   api_version: apps/v1
   name: nginx
-  namespace: nginx_wrong_image
+  namespace: nginx-wrong-image
 expectations:
   - name: step_by_step_guide
     statement: contains a step-by-step guide

--- a/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
+++ b/tests/blackbox/data/validation/kyma_app_apirule_broken.yml
@@ -1,5 +1,5 @@
 - description: This mock response contains a incomplete yaml-formatted manifest for an APIRule
-  scenario_id: kyma_app_apirule_broken
+  scenario_id: kyma-app-apirule-broken
   mock_response_content: |-
     "There seems to be a syntax error in the APIRule. It contains two accessStrategies but it should only contain one accessStrategy. Here is a corrected version of the APIRule:
       ```yaml

--- a/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
+++ b/tests/blackbox/data/validation/kyma_app_serverless_syntax_err.yml
@@ -1,5 +1,5 @@
 - description: This mock response contains a complete deployable yaml-formatted manifest for a serverless function
-  scenario_id: kyma_app_serverless_syntax_err
+  scenario_id: kyma-app-serverless-syntax-err
   mock_response_content: |-
     "There seems to be a syntax error in the serverless function 'func1'. The function calls Dates() instead of Date(). Here is a corrected version of the function:
       ```yaml
@@ -7,7 +7,7 @@
       kind: Function
       metadata:
         name: func1
-        namespace: kyma_app_serverless_syntax_err
+        namespace: kyma-app-serverless-syntax-err
         labels:
           app: restapi
       spec:

--- a/tests/blackbox/data/validation/nginx_oom.yml
+++ b/tests/blackbox/data/validation/nginx_oom.yml
@@ -1,6 +1,6 @@
 - description: Mock responses for a scenario where a nginx deployment is configured to an insufficient amount of memory that will lead to a pod that runs out of memory.
   mock_response_content: The pod has an OOM (out of memory) error. The container has an insufficient amount of memory. You should increase the memory limit or the memory request.
-  scenario_id: nginx_oom
+  scenario_id: nginx-oom
   expected_evaluations:
     - scenario_expectation_name: oom_error
       expected_evaluation: true
@@ -18,7 +18,7 @@
       expected_evaluation: false
 - description: False negative for the scenario where a nginx deployment is configured to an insufficient amount of memory that will lead to a pod that runs out of memory.
   mock_response_content: There is no problem; everything is fine.
-  scenario_id: nginx_oom
+  scenario_id: nginx-oom
   expected_evaluations:
     - scenario_expectation_name: oom_error
       expected_evaluation: false

--- a/tests/blackbox/data/validation/nginx_wrong_image.yml
+++ b/tests/blackbox/data/validation/nginx_wrong_image.yml
@@ -1,5 +1,5 @@
 - description: Mock responses for a scenario where the ngix image was not found
-  scenario_id: nginx_wrong_image
+  scenario_id: nginx-wrong-image
   mock_response_content: The image you try to use does not exist. You might have misspelled the image name. The correct image name would be 'nginx'.
   expected_evaluations:
     - scenario_expectation_name: step_by_step_guide


### PR DESCRIPTION
**Description**

Fix blackbox deployment manifests:

- Fixes the deployment manifests naming.

**Example run(s)**

- https://github.com/kyma-project/kyma-companion/actions/runs/10737401383
 
  > Note: the run failed because the required Kyma modules were not deployed, this will come in a follow-up PR.