### PR TITLE
chore: fix setup-gardener-test-cluster to deploy/cleanup Kyma modules

### DIFF
--- a/.github/workflows/setup-test-cluster.yaml
+++ b/.github/workflows/setup-test-cluster.yaml
@@ -107,11 +107,14 @@ jobs:
           echo "Kyma is Ready"
           echo "::endgroup::"
 
+      - name: Deploy Kyma modules
+        run: |
+          echo "::group::Kyma - Deploy Kyma modules"
+          chmod +x ./scripts/shell/deploy_kyma_modules.sh
+          ./scripts/shell/deploy_kyma_modules.sh
+          echo "::endgroup::"
+
       - name: Deploy all single-namespace test-cases
         run: |
           chmod +x ./scripts/shell/deploy_test_scenarios.sh
           ./scripts/shell/deploy_test_scenarios.sh
-          if [ $? -ne 0 ]; then
-              echo "Failed to deploy all single-namespace test-cases"
-              exit 1
-          fi

--- a/scripts/shell/deploy_kyma_modules.sh
+++ b/scripts/shell/deploy_kyma_modules.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+##############################################################################
+# NOTE: This script is used in the GitHub Actions workflow.
+# Make sure any changes are compatible with the existing workflows.
+##############################################################################
+
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
+
+echo "### Deploy Istio ###"
+kubectl label namespace kyma-system istio-injection=enabled --overwrite
+kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
+kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
+
+echo "### Deploy API Gateway ###"
+kubectl apply -f https://github.com/kyma-project/api-gateway/releases/latest/download/api-gateway-manager.yaml
+kubectl apply -f https://github.com/kyma-project/api-gateway/releases/latest/download/apigateway-default-cr.yaml
+
+echo "### Deploy Serverless ###"
+kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/serverless-operator.yaml
+kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/default-serverless-cr.yaml -n kyma-system
+
+echo "### Deploy NATS ###"
+kubectl apply -f https://github.com/kyma-project/nats-manager/releases/latest/download/nats-manager.yaml
+kubectl apply -f https://github.com/kyma-project/nats-manager/releases/latest/download/nats-default-cr.yaml
+
+echo "### Deploy Eventing ###"
+kubectl apply -f https://github.com/kyma-project/eventing-manager/releases/latest/download/eventing-manager.yaml
+kubectl apply -f https://github.com/kyma-project/eventing-manager/releases/latest/download/eventing-default-cr.yaml


### PR DESCRIPTION
**Description**

Fix setup-gardener-test-cluster to deploy/cleanup Kyma modules:

- Deploy needed Kyma modules by the blackbox tests.
- Cleanup the deployed Kyma modules in the previous step.

**Example runs**

- https://github.com/kyma-project/kyma-companion/actions/runs/10769007826