### PR TITLE
creating conversation_id aka session_id without hyphens

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -20,7 +20,7 @@ def create_session_id() -> str:
     Returns:
         str: A new session ID.
     """
-    return str(uuid.uuid4())
+    return str(uuid.uuid4().hex)
 
 
 def is_empty_str(data: str | None) -> bool:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

[langchain's Redis history library](https://python.langchain.com/v0.2/docs/integrations/memory/redis_chat_message_history/) seems to have problems with hyphens in Redis key, so let us create `conversation_id` aka `session_id` without hyphens. This will not impact the quasi-uniqueness of the key.

- create UUIDs without a hyphen.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
