### PR TITLE
feat: add comment on gh pr if evaluation was skipped

### DIFF
--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -28,6 +28,18 @@ env:
   IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
 
 jobs:
+  comment:
+    name: comment on pull request
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'evaluation requested')"
+    steps:
+      - name: Post comment
+        run: |
+          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{"body":"The evaluation test will be skipped for this PR.\nTo run it add the label \"evaluation requested\" and re-run the evalution test workflow.}' \
+          "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+    
   wait-for-build:
     name: Wait for image build job
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Content-Type: application/json" \
-          -d '{"body":"The evaluation test will be skipped for this PR.\nTo run it add the label \"evaluation requested\".}' \
+          -d '{"body":"The evaluation test will be skipped for this PR.\nYou can trigger it manually by adding the label \"evaluation requested\".}' \
           "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
     
   wait-for-build:

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Content-Type: application/json" \
-          -d '{"body":"The evaluation test will be skipped for this PR.\nTo run it add the label \"evaluation requested\" and re-run the evalution test workflow.}' \
+          -d '{"body":"The evaluation test will be skipped for this PR.\nTo run it add the label \"evaluation requested\".}' \
           "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
     
   wait-for-build:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- notify the contributor via a gh comment in the pr if the eval test was skipped (due to the missing label 'evaluation requested')
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
