### PR TITLE
fix: change workers to 1

### DIFF
--- a/tests/blackbox/src/common/config.py
+++ b/tests/blackbox/src/common/config.py
@@ -45,4 +45,4 @@ class Config:
         self.model_temperature = 0
         self.iterations = 3
         self.streaming_response_timeout = 10 * 60  # seconds
-        self.max_workers = 3
+        self.max_workers = 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

The evaluation tests continuously fail because of rate limiting error.

Changes proposed in this pull request:

- change worker to 1 to reduce parallelism

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#196 