### PR TITLE
fix: reference to env var

### DIFF
--- a/tests/blackbox/src/common/config.py
+++ b/tests/blackbox/src/common/config.py
@@ -37,8 +37,10 @@ class Config:
         self.test_cluster_url = get_env("TEST_CLUSTER_URL")
         self.test_cluster_ca_data = get_env("TEST_CLUSTER_CA_DATA")
         self.test_cluster_auth_token = get_env("TEST_CLUSTER_AUTH_TOKEN")
-        self.aicore_deployment_id_gpt4_mini = get_env("AICORE_DEPLOYMENT_ID_GPT4")
-        self.aicore_configuration_id_gpt4_mini = get_env("AICORE_CONFIGURATION_ID_GPT4")
+        self.aicore_deployment_id_gpt4_mini = get_env("AICORE_DEPLOYMENT_ID_GPT4_MINI")
+        self.aicore_configuration_id_gpt4_mini = get_env(
+            "AICORE_CONFIGURATION_ID_GPT4_MINI"
+        )
         self.model_name = get_env("MODEL_NAME", False, "gpt4.o-mini")
         self.model_temperature = 0
         self.iterations = 3


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- for setting up the gpt4.o mini model use the right env var
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
