### PR TITLE
fix: make temperature for models optional

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -14,7 +14,7 @@ class ModelConfig(BaseModel):
 
     name: str
     deployment_id: str
-    temperature: float
+    temperature: float = 0.0
 
 
 class Config(BaseModel):


### PR DESCRIPTION
**Description**
Make temperature optional as some other models like embedding don't need temperature

Changes proposed in this pull request:
- Make temperatur in model config optional

**Related issue(s)**
#200 