### PR TITLE
chore: pass only finalizer and human messages to planner

### DIFF
--- a/src/agents/common/state.py
+++ b/src/agents/common/state.py
@@ -24,7 +24,7 @@ class SubTask(BaseModel):
     description: str = Field(description="description of the task")
     assigned_to: str = Field(description="agent to whom the task is assigned")
     status: str = Field(default=SubTaskStatus.PENDING)
-    result: str | None
+    result: str | None = None
 
     def complete(self) -> None:
         """Update the result of the task."""

--- a/src/agents/supervisor/state.py
+++ b/src/agents/supervisor/state.py
@@ -13,5 +13,5 @@ class SupervisorState(BaseModel):
 
     messages: Annotated[Sequence[BaseMessage], add_messages]
     subtasks: list[SubTask] | None = []
-    next: str | None
-    error: str | None
+    next: str | None = None
+    error: str | None = None


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- only pass AI output messages (AI messages from finalizer) and human messages to the planner
- fix some typing issues

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
