### PR TITLE
fix: remove `--no-dev` instruction from `poetry install` in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ COPY config ./config
 
 # Install Poetry and dependencies in one layer
 RUN pip install --no-cache-dir poetry \
-    && poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-interaction --no-ansi \
-    && pip uninstall -y poetry
+  && poetry config virtualenvs.create false \
+  && poetry install --no-interaction --no-ansi \
+  && pip uninstall -y poetry
 
 # Start a new stage for a smaller final image
 FROM python:3.12-slim-bullseye


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

In the penultimate version of `Poetry` the option `--no-dev` for the `install` command was marked as deprecated. It looks like the last version now removed this option. Since we still used it in our `dockerfile` the job `Pull Build Image` ran into errors. This PR removes this option.

The option used to skip the dev dependencies like formatters.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
