### PR TITLE
chore: use separate GHA secret for int tests

### DIFF
--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -90,5 +90,5 @@ jobs:
           DATABASE_PORT: ${{ steps.int-tests-configs.outputs.DATABASE_PORT }}
           DOCS_TABLE_NAME: ${{ steps.int-tests-configs.outputs.DOCS_TABLE_NAME }}
         run: |
-          echo "${{ secrets.MODELS_JSON }}" | base64 --decode | jq > $GITHUB_WORKSPACE/config/config.json
+          echo "${{ secrets.CONFIG_TEST }}" | base64 --decode | jq > $GITHUB_WORKSPACE/config/config.json
           poetry run poe test-integration


### PR DESCRIPTION
**Description**
Use separate GHA secret config json for integration tests. MODELS_JSON is used in other cases too. We need this test for rate limiting integration test.

**Related issue(s)**
#256 