### PR TITLE
fix: made resource_name as optional parameter for initial questions

### DIFF
--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -10,7 +10,7 @@ class InitConversationBody(BaseModel):
     """Request body for initializing a conversation endpoint."""
 
     resource_kind: str
-    resource_name: str
+    resource_name: str = ""
     resource_api_version: str = ""
     namespace: str = ""
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- made resource_name as optional parameter for initial questions. Because for cluster overview page, the name would be empty.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
