### PR TITLE
chore: limit permissions of lint and unit

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -11,18 +11,14 @@ on:
       - CODEOWNERS
       - LICENSE
 
-permissions:
-  contents: read
-
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  pull-requests: read
-  # Optional: Allow write access to checks to allow the action to annotate code in the PR.
-  checks: write
 
 jobs:
   code-linter:
     name: "Run mypy linting"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: none
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -9,10 +9,14 @@ on:
       - edited
       - synchronize
 
+permissions: read-all
+
 jobs:
   check:
     name: Check Title
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
     steps:
       - uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9
         env:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,6 +18,10 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: none
+      metadata: read 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -21,7 +21,6 @@ jobs:
     permissions:
       contents: read
       actions: none
-      metadata: read 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- limit the `permissions` of the lint and unit-test workflows

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
