### PR TITLE
refactor: remove unuse decorator

### DIFF
--- a/tests/unit/rag/reranker/test_reranker.py
+++ b/tests/unit/rag/reranker/test_reranker.py
@@ -26,13 +26,11 @@ from unit.rag.reranker.fixtures import (
 )
 
 
-@pytest.mark.asyncio
 class TestLLMReranker:
     """
     Test class for the LLMReranker class.
     """
 
-    @pytest.mark.asyncio
     def test_init(self):
         """
         Test the initialization of the LLMReranker class.
@@ -64,8 +62,7 @@ class TestLLMReranker:
         "expected_docs_list",
         [
             (
-                "given (duplicate documents and exception raised) "
-                "return unique relevant documents",
+                "given (duplicate documents and exception raised) return unique relevant documents",
                 [
                     # duplicate documents
                     [doc1, doc4, doc7],
@@ -88,8 +85,7 @@ class TestLLMReranker:
                 [doc1, doc2, doc3, doc4, doc5],
             ),
             (
-                "given (duplicate documents and exception not raised) "
-                "return unique relevant documents",
+                "given (duplicate documents and exception not raised) return unique relevant documents",
                 [
                     # duplicate documents
                     [doc1, doc4, doc7],


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

At the moment, when we run the unit tests, we get the warning:

```
tests/unit/rag/reranker/test_reranker.py::TestLLMReranker::test_init
  tests/unit/rag/reranker/test_reranker.py:35: PytestWarning: The test <Function test_init> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove the asyncio mark. If the test is not marked explicitly, check for global marks applied via 'pytestmark'.
    def test_init(self):
```

so this PR will remove the decorators.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
