### PR TITLE
fix: added docx2txt dependency from forked repo

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install docx2txt
-        run: pip install docx2txt==0.8
+        run: pip install docx2txt
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -41,10 +41,10 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install setuptools
-        run: pip install setuptools==57.0.0
+        run: pip install setuptools wheel
 
       - name: Install docx2txt
-        run: pip install docx2txt==0.8
+        run: pip install --no-use-pep517 docx2txt==0.8
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -40,11 +40,8 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install setuptools
-        run: pip install setuptools==58.2.0
-
       - name: Install docx2txt
-        run: pip install --no-binary docx2txt docx2txt==0.8
+        run: pip install git+https://github.com/tanweersalah/python-docx2txt.git
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -41,10 +41,10 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install setuptools
-        run: pip install setuptools wheel
+        run: pip install setuptools==58.2.0
 
       - name: Install docx2txt
-        run: pip install --no-deps docx2txt==0.8
+        run: pip install docx2txt
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -44,7 +44,7 @@ jobs:
         run: pip install setuptools==58.2.0
 
       - name: Install docx2txt
-        run: pip install --no-binary docx2txt
+        run: pip install --no-binary docx2txt docx2txt==0.8
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -40,9 +40,6 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install docx2txt
-        run: pip install git+https://github.com/tanweersalah/python-docx2txt.git
-
       - name: Install dependencies
         run: poetry install --with dev
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -40,6 +40,9 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Install docx2txt
+        run: pip install docx2txt==0.8
+
       - name: Install dependencies
         run: poetry install --with dev
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -44,7 +44,7 @@ jobs:
         run: pip install setuptools==58.2.0
 
       - name: Install docx2txt
-        run: pip install docx2txt
+        run: pip install --no-binary docx2txt
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -40,8 +40,11 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Install setuptools
+        run: pip install setuptools==57.0.0
+
       - name: Install docx2txt
-        run: pip install --no-use-pep517 docx2txt==0.8
+        run: pip install docx2txt==0.8
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -44,7 +44,7 @@ jobs:
         run: pip install setuptools wheel
 
       - name: Install docx2txt
-        run: pip install --no-use-pep517 docx2txt==0.8
+        run: pip install --no-deps docx2txt==0.8
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install docx2txt
-        run: pip install docx2txt
+        run: pip install --no-use-pep517 docx2txt==0.8
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/poetry.lock
+++ b/poetry.lock
@@ -1009,7 +1009,7 @@ version = "0.8"
 description = "A pure python-based utility to extract text and images from docx files."
 optional = false
 python-versions = "*"
-groups = ["main", "test"]
+groups = ["test"]
 files = [
     {file = "docx2txt-0.8.tar.gz", hash = "sha256:2c06d98d7cfe2d3947e5760a57d924e3ff07745b379c8737723922e7009236e5"},
 ]
@@ -7183,4 +7183,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "8ba8bfc641e4e9fbf39445a69e98365001a7682586943829d14f7e9849cd4776"
+content-hash = "f41cf25f6c6225e839df20a0d728bd9e4f70d4821c82ea5d05321e025aae5b65"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5782,19 +5782,24 @@ unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
 name = "setuptools"
-version = "58.0.0"
+version = "78.0.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "setuptools-58.0.0-py3-none-any.whl", hash = "sha256:fa14855ea8332dc12cae21b8e18cf55573eeaabad9fe3b8b787e6a74e01885d3"},
-    {file = "setuptools-58.0.0.tar.gz", hash = "sha256:ee45f4d69c4bbd21a27b60a7f1f32cbdcd34755cb613e5c4edcb58145394a0a3"},
+    {file = "setuptools-78.0.1-py3-none-any.whl", hash = "sha256:1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e"},
+    {file = "setuptools-78.0.1.tar.gz", hash = "sha256:4321d2dc2157b976dee03e1037c9f2bc5fea503c0c47d3c9458e0e8e49e659ce"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
-testing = ["flake8-2020", "jaraco.envs", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=4.6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy ; platform_python_implementation != \"PyPy\"", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
 name = "shapely"
@@ -7199,4 +7204,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "cc0b1c4bedc9eb7836e8d08af0e5caef00078909b9055671fe11c16e484b1dad"
+content-hash = "9201adccab1b814f5c7886a45c205f828882654ad982688b4fb9be0e04af20ff"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1009,7 +1009,7 @@ version = "0.8"
 description = "A pure python-based utility to extract text and images from docx files."
 optional = false
 python-versions = "*"
-groups = ["test"]
+groups = ["main", "test"]
 files = [
     {file = "docx2txt-0.8.tar.gz", hash = "sha256:2c06d98d7cfe2d3947e5760a57d924e3ff07745b379c8737723922e7009236e5"},
 ]
@@ -5781,22 +5781,6 @@ tornado = ["tornado (>=6)"]
 unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
-name = "setuptools"
-version = "57.5.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.6"
-groups = ["test"]
-files = [
-    {file = "setuptools-57.5.0-py3-none-any.whl", hash = "sha256:60d78588f15b048f86e35cdab73003d8b21dd45108ee61a6693881a427f22073"},
-    {file = "setuptools-57.5.0.tar.gz", hash = "sha256:d9d3266d50f59c6967b9312844470babbdb26304fe740833a5f8d89829ba3a24"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
-testing = ["flake8-2020", "jaraco.envs", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=4.6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy ; platform_python_implementation != \"PyPy\"", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "shapely"
 version = "2.0.7"
 description = "Manipulation and analysis of geometric objects"
@@ -7199,4 +7183,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "feadc73a883abe9e120d77d4cee9b03b695555aeb2f037e1c3cb1ac57f9fcb2a"
+content-hash = "8ba8bfc641e4e9fbf39445a69e98365001a7682586943829d14f7e9849cd4776"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5781,6 +5781,22 @@ tornado = ["tornado (>=6)"]
 unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
+name = "setuptools"
+version = "58.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "setuptools-58.0.0-py3-none-any.whl", hash = "sha256:fa14855ea8332dc12cae21b8e18cf55573eeaabad9fe3b8b787e6a74e01885d3"},
+    {file = "setuptools-58.0.0.tar.gz", hash = "sha256:ee45f4d69c4bbd21a27b60a7f1f32cbdcd34755cb613e5c4edcb58145394a0a3"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
+testing = ["flake8-2020", "jaraco.envs", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=4.6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy ; platform_python_implementation != \"PyPy\"", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "shapely"
 version = "2.0.7"
 description = "Manipulation and analysis of geometric objects"
@@ -7183,4 +7199,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "74c2e9360d09d31c91311ffd7922a8050c539362b4bc87bdd2b0298cfe0d0a38"
+content-hash = "cc0b1c4bedc9eb7836e8d08af0e5caef00078909b9055671fe11c16e484b1dad"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5782,24 +5782,19 @@ unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
 name = "setuptools"
-version = "78.0.1"
+version = "57.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.9"
-groups = ["main"]
+python-versions = ">=3.6"
+groups = ["test"]
 files = [
-    {file = "setuptools-78.0.1-py3-none-any.whl", hash = "sha256:1cc9b32ee94f93224d6c80193cbb768004667aa2f2732a473d6949b0236c1d4e"},
-    {file = "setuptools-78.0.1.tar.gz", hash = "sha256:4321d2dc2157b976dee03e1037c9f2bc5fea503c0c47d3c9458e0e8e49e659ce"},
+    {file = "setuptools-57.5.0-py3-none-any.whl", hash = "sha256:60d78588f15b048f86e35cdab73003d8b21dd45108ee61a6693881a427f22073"},
+    {file = "setuptools-57.5.0.tar.gz", hash = "sha256:d9d3266d50f59c6967b9312844470babbdb26304fe740833a5f8d89829ba3a24"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
-core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+docs = ["furo", "jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-inline-tabs", "sphinxcontrib-towncrier"]
+testing = ["flake8-2020", "jaraco.envs", "jaraco.path (>=3.2.0)", "mock", "paver", "pip (>=19.1)", "pytest (>=4.6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy ; platform_python_implementation != \"PyPy\"", "pytest-virtualenv (>=1.2.7)", "pytest-xdist", "sphinx", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shapely"
@@ -7204,4 +7199,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "9201adccab1b814f5c7886a45c205f828882654ad982688b4fb9be0e04af20ff"
+content-hash = "feadc73a883abe9e120d77d4cee9b03b695555aeb2f037e1c3cb1ac57f9fcb2a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1010,9 +1010,14 @@ description = "A pure python-based utility to extract text and images from docx 
 optional = false
 python-versions = "*"
 groups = ["test"]
-files = [
-    {file = "docx2txt-0.8.tar.gz", hash = "sha256:2c06d98d7cfe2d3947e5760a57d924e3ff07745b379c8737723922e7009236e5"},
-]
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/tanweersalah/python-docx2txt.git"
+reference = "master"
+resolved_reference = "36c65ed363407fb2b257c28dfd5064e5f344df0f"
 
 [[package]]
 name = "dulwich"
@@ -7183,4 +7188,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.12.*"
-content-hash = "f41cf25f6c6225e839df20a0d728bd9e4f70d4821c82ea5d05321e025aae5b65"
+content-hash = "4f65fe0222f98d36a6ce449636a7e1e401ed0042ee06a50cdbc73ca3ed7f6af4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = "==3.12.*"
 dependencies = [
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
+  "docx2txt (>=0.8,<0.9)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",
   "generative-ai-hub-sdk[all] (>=4.1.1,<4.2.0)",
   "hdbcli (>=2.23.27,<3.0.0)",
@@ -40,7 +41,6 @@ packages = [{ include = "src" }]
 package-mode = false
 
 [tool.poetry.group.test.dependencies]
-setuptools = "<58.0.0"
 deepeval = "^2.5.3"
 fakeredis = "^2.27.0"
 prettytable = "^3.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 requires-python = "==3.12.*"
 dependencies = [
-  "setuptools (<=58.0.0)"
+  "setuptools (<=58.0.0)",
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",
@@ -34,8 +34,7 @@ dependencies = [
   "tenacity (>=9.0.0,<10.0.0)",
   "tiktoken (>=0.9.0,<0.10.0)",
   "uvicorn (>=0.34.0,<0.35.0)",
-  "uvicorn (>=0.34.0,<0.35.0)",
-
+  "uvicorn (>=0.34.0,<0.35.0)"
 ]
 [tool.poetry]
 packages = [{ include = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 ]
 requires-python = "==3.12.*"
 dependencies = [
+  "setuptools (<=58.0.0)"
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",
@@ -32,7 +33,9 @@ dependencies = [
   "scrubadub (>=2.0.1,<3.0.0)",
   "tenacity (>=9.0.0,<10.0.0)",
   "tiktoken (>=0.9.0,<0.10.0)",
-  "uvicorn (>=0.34.0,<0.35.0)"
+  "uvicorn (>=0.34.0,<0.35.0)",
+  "uvicorn (>=0.34.0,<0.35.0)",
+
 ]
 [tool.poetry]
 packages = [{ include = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 requires-python = "==3.12.*"
 dependencies = [
-  "setuptools (<=58.0.0)",
+  "setuptools (>=78.0.0)",
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ authors = [
 ]
 requires-python = "==3.12.*"
 dependencies = [
-  "setuptools (>=78.0.0)",
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",
@@ -41,6 +40,7 @@ packages = [{ include = "src" }]
 package-mode = false
 
 [tool.poetry.group.test.dependencies]
+setuptools = "<58.0.0"
 deepeval = "^2.5.3"
 fakeredis = "^2.27.0"
 prettytable = "^3.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ packages = [{ include = "src" }]
 package-mode = false
 
 [tool.poetry.group.test.dependencies]
+docx2txt = { git = "https://github.com/tanweersalah/python-docx2txt.git", rev = "master" }
 deepeval = "^2.5.3"
 fakeredis = "^2.27.0"
 prettytable = "^3.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ requires-python = "==3.12.*"
 dependencies = [
   "ai-core-sdk (>=2.4.2,<2.5.0)",
   "cryptography (>=44.0.2,<45.0.0)",
-  "docx2txt (>=0.8,<0.9)",
   "fastapi[standard] (>=0.115.11,<0.116.0)",
   "generative-ai-hub-sdk[all] (>=4.1.1,<4.2.0)",
   "hdbcli (>=2.23.27,<3.0.0)",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
 As docx2txt dependency has issue with the setup.cfg file, i have forked the official repo and fixed this issue. 
 
` setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.`
  
Changes proposed in this pull request:

-  added docx2txt dependency from forked repo

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
