### PR TITLE
refactor: remove config classes

### DIFF
--- a/src/agents/common/state.py
+++ b/src/agents/common/state.py
@@ -10,8 +10,9 @@ from langchain_core.messages import (
 from langgraph.graph import add_messages
 from langgraph.managed import IsLastStep, RemainingSteps
 from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
 
-from agents.common.constants import COMMON, K8S_AGENT, K8S_CLIENT, KYMA_AGENT
+from agents.common.constants import COMMON, K8S_AGENT, KYMA_AGENT
 from services.k8s import IK8sClient
 
 
@@ -26,23 +27,30 @@ class SubTaskStatus(str, Enum):
 class GatekeeperResponse(BaseModel):
     """Gatekeeper response data model."""
 
-    direct_response: str = Field(description="For direct response.")
-    forward_query: bool = Field(
-        default=False,
-        description="For forwarding query",
-    )
+    direct_response: Annotated[str, Field(description="For direct response.")]
+    forward_query: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="For forwarding query",
+        ),
+    ]
 
 
 class SubTask(BaseModel):
     """Sub-task data model."""
 
-    description: str = Field(
-        description="user query with original wording for the assigned agent"
-    )
-    task_title: str = Field(
-        description="""Generate a title of 4 to 5 words, only use these:
+    description: Annotated[
+        str,
+        Field(description="user query with original wording for the assigned agent"),
+    ]
+    task_title: Annotated[
+        str,
+        Field(
+            description="""Generate a title of 4 to 5 words, only use these:
           'Retrieving', 'Fetching', 'Extracting' or 'Checking'. Never use 'Creating'."""
-    )
+        ),
+    ]
     assigned_to: Literal[KYMA_AGENT, K8S_AGENT, COMMON]  # type: ignore
     status: str = Field(default=SubTaskStatus.PENDING)
 
@@ -109,17 +117,23 @@ class CompanionState(BaseModel):
 
     """
 
-    input: UserInput | None = Field(
-        description="user input with user query and resource(s) contextual information",
-        default=None,
-    )
+    input: Annotated[
+        UserInput | None,
+        Field(
+            description="user input with user query and resource(s) contextual information",
+            default=None,
+        ),
+    ]
     thread_owner: str = ""
     messages: Annotated[Sequence[BaseMessage], add_messages]
     messages_summary: str = ""
     next: str | None = None
     subtasks: list[SubTask] | None = []
     error: str | None = None
-    k8s_client: IK8sClient | None = None
+    k8s_client: Annotated[IK8sClient | None, Field(default=None, exclude=True)]
+
+    # Model config for pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def get_messages_including_summary(self) -> list[MessageLikeRepresentation]:
         """Get messages including the summary message."""
@@ -132,17 +146,13 @@ class CompanionState(BaseModel):
             )
         return list(self.messages)
 
-    class Config:
-        arbitrary_types_allowed = True
-        fields = {"k8s_client": {"exclude": True}}
-
 
 class BaseAgentState(BaseModel):
     """Base state for KymaAgent and KubernetesAgent agents (subgraphs)."""
 
     messages: Annotated[Sequence[BaseMessage], add_messages]
     subtasks: list[SubTask] | None = []
-    k8s_client: IK8sClient
+    k8s_client: Annotated[IK8sClient, Field(exclude=True)]
 
     # Subgraph private fields
     agent_messages: Annotated[Sequence[BaseMessage], add_messages]
@@ -150,8 +160,10 @@ class BaseAgentState(BaseModel):
     my_task: SubTask | None = None
     is_last_step: IsLastStep
     error: str | None = None
-
     remaining_steps: RemainingSteps
+
+    # Model config for pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def get_agent_messages_including_summary(self) -> list[MessageLikeRepresentation]:
         """Get messages including the summary message."""
@@ -163,7 +175,3 @@ class BaseAgentState(BaseModel):
                 )
             )
         return list(self.agent_messages)
-
-    class Config:
-        arbitrary_types_allowed = True
-        fields = {K8S_CLIENT: {"exclude": True}}

--- a/src/agents/k8s/tools/logs.py
+++ b/src/agents/k8s/tools/logs.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 from pydantic import BaseModel
+from pydantic.config import ConfigDict
 
 from services.k8s import IK8sClient
 
@@ -18,8 +19,8 @@ class FetchPodLogsArgs(BaseModel):
     is_terminated: bool
     k8s_client: Annotated[IK8sClient, InjectedState("k8s_client")]
 
-    class Config:
-        arbitrary_types_allowed = True
+    # Model configuration for Pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 @tool(infer_schema=False, args_schema=FetchPodLogsArgs)

--- a/src/agents/k8s/tools/query.py
+++ b/src/agents/k8s/tools/query.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 from pydantic import BaseModel
+from pydantic.config import ConfigDict
 
 from services.k8s import IK8sClient
 
@@ -13,8 +14,8 @@ class K8sQueryToolArgs(BaseModel):
     uri: str
     k8s_client: Annotated[IK8sClient, InjectedState("k8s_client")]
 
-    class Config:
-        arbitrary_types_allowed = True
+    # Model configuration for Pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 @tool(infer_schema=False, args_schema=K8sQueryToolArgs)
@@ -36,6 +37,5 @@ def k8s_query_tool(
         return result
     except Exception as e:
         raise Exception(
-            f"failed executing k8s_query_tool with URI: {uri},"
-            f"raised the following error: {e}"
+            f"failed executing k8s_query_tool with URI: {uri},raised the following error: {e}"
         ) from e

--- a/src/agents/kyma/tools/query.py
+++ b/src/agents/kyma/tools/query.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 from pydantic import BaseModel
+from pydantic.config import ConfigDict
 
 from services.k8s import IK8sClient
 
@@ -13,8 +14,8 @@ class KymaQueryToolArgs(BaseModel):
     uri: str
     k8s_client: Annotated[IK8sClient, InjectedState("k8s_client")]
 
-    class Config:
-        arbitrary_types_allowed = True
+    # Model configuration for Pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 @tool(infer_schema=False, args_schema=KymaQueryToolArgs)
@@ -38,6 +39,5 @@ def kyma_query_tool(
         return result
     except Exception as e:
         raise Exception(
-            f"failed executing kyma_query_tool with URI: {uri},"
-            f"raised the following error: {e}"
+            f"failed executing kyma_query_tool with URI: {uri},raised the following error: {e}"
         ) from e


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

At the moment we get the warning:
```
 Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```
when we run our tests and/or application.

The [migration guides](https://docs.pydantic.dev/latest/migration/#changes-to-config) for pydantic state that:
a) config classes
```
class MyClass(BaseModel):
   class Config:
...
```
are deprecated and supposed to be replaced with `model_config = ConfigDict(...)`
b) `fields` configs are supposed to be replaced with `Annotate[... Field(...)]` 

And that is what this PR does.

In addition the `Annotate[...]` notation was used in all fields of the same files to get a more consistent (and thus readable) code.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
