### PR TITLE
refactor: enhance readyness-checks

### DIFF
--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -139,13 +139,24 @@ jobs:
 
       - name: Companion Deploy - Wait for deployment
         run: |
-          echo "Waiting for companion deployment to be ready..."
-          kubectl wait --for=condition=Available deployment companion -n ai-system --timeout=300s
-          sleep 30
+          kubectl rollout status deployment/companion -n ai-system --timeout=300s
 
       - name: Companion Deploy - Test reachability through NodePort
+        env:
+          TIMEOUT_SECONDS: 300  # Default timeout (5 minutes)
+          INTERVAL_SECONDS: 10  # Default interval (10 seconds)
         run: |
-          curl http://localhost:32000/readyz
+          end_time=$((SECONDS + TIMEOUT_SECONDS))
+          while [ $SECONDS -lt $end_time ]; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:32000/readyz | grep -q 200; then
+              echo "Service is reachable";
+              exit 0;
+            fi
+            echo "Service not reachable yet, retrying in $INTERVAL_SECONDS seconds...";
+            sleep $INTERVAL_SECONDS;
+          done
+          echo "Service did not become reachable within $TIMEOUT_SECONDS seconds";
+          exit 1
 
       - name: Companion Deploy - Debug information
         if: failure()

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 
 
 def get_langfuse_service() -> ILangfuseService:
-    """Dependency to get the langfuse service instance"""
+    """Dependency to get the langfuse service instance."""
     return LangfuseService()
 
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- use [`kubectl rollout check`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_status/) to wait for the deployment
- check the readiness through the `NotePort` with a timeout and interval. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
