### PR TITLE
feat: enhance Kyma agent prompts for too broad queries and delete managed fields from resources

### DIFF
--- a/src/services/data_sanitizer.py
+++ b/src/services/data_sanitizer.py
@@ -138,6 +138,8 @@ class DataSanitizer(metaclass=SingletonMeta):
         try:
             # First remove last-applied-configuration
             obj = self._remove_last_applied_configuration(obj)
+            # Then remove managedFields in metadata if exists
+            obj = self._remove_managed_fields_in_metadata(obj)
 
             # Handle template-based resources (Deployment, StatefulSet, DaemonSet)
             if "spec" in obj and "template" in obj["spec"]:
@@ -180,6 +182,8 @@ class DataSanitizer(metaclass=SingletonMeta):
 
         # First remove last-applied-configuration if exists
         result = self._remove_last_applied_configuration(result)
+        # Then remove managedFields in metadata if exists
+        result = self._remove_managed_fields_in_metadata(result)
 
         for key, value in data.items():
             # Check if the key should be excluded from sanitization
@@ -228,4 +232,11 @@ class DataSanitizer(metaclass=SingletonMeta):
             # Remove empty annotations dict if it's the last annotation
             if not data["metadata"]["annotations"]:
                 del data["metadata"]["annotations"]
+        return data
+
+    @staticmethod
+    def _remove_managed_fields_in_metadata(data: dict) -> dict:
+        """Remove managedFields in metadata if it exists."""
+        if "metadata" in data and "managedFields" in data["metadata"]:
+            del data["metadata"]["managedFields"]
         return data

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -165,6 +165,96 @@ def create_test_cases(k8s_client: IK8sClient):
             ),
             expected_goal="There is a syntax error in the JavaScript code. Date must be used instead of Dates.",
         ),
+        TestCase(
+            "Should ask more information from user for queries about Kyma resources status",
+            state=create_basic_state(
+                task_description="what is the status of all Kyma resources?",
+                messages=[
+                    HumanMessage(content="what is the status of all Kyma resources?"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about all Kyma resources in cluster",
+            state=create_basic_state(
+                task_description="check all Kyma resources",
+                messages=[
+                    HumanMessage(content="check all Kyma resources"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about Kyma resources health",
+            state=create_basic_state(
+                task_description="are all Kyma resources healthy?",
+                messages=[
+                    HumanMessage(content="are all Kyma resources healthy?"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about getting all Kyma resources",
+            state=create_basic_state(
+                task_description="get all Kyma resources",
+                messages=[
+                    HumanMessage(content="get all Kyma resources"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about all Kyma resources in cluster",
+            state=create_basic_state(
+                task_description="is there anything wrong with Kyma resources?",
+                messages=[
+                    HumanMessage(
+                        content="is there anything wrong with Kyma resources?"
+                    ),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about showing all Kyma resources",
+            state=create_basic_state(
+                task_description="show me all Kyma resources",
+                messages=[
+                    HumanMessage(content="show me all Kyma resources"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about all Kyma resources in cluster",
+            state=create_basic_state(
+                task_description="what is wrong with Kyma?",
+                messages=[
+                    HumanMessage(content="what is wrong with Kyma?"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
+        TestCase(
+            "Should ask more information from user for queries about Kyma cluster state",
+            state=create_basic_state(
+                task_description="show me the state of Kyma cluster",
+                messages=[
+                    HumanMessage(content="show me the state of Kyma cluster"),
+                ],
+                k8s_client=k8s_client,
+            ),
+            expected_goal="I need more information to answer this question. Please provide more information.",
+        ),
     ]
 
 

--- a/tests/unit/services/test_data_sanitizer.py
+++ b/tests/unit/services/test_data_sanitizer.py
@@ -1129,6 +1129,32 @@ class TestDataSanitizer:
                     },
                 },
             ),
+            # delete managedFields in metadata
+            (
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "name": "my-app",
+                        "managedFields": [{"name": "my-app"}],
+                    },
+                    "spec": {
+                        "replicas": 3,
+                        "selector": {"matchLabels": {"app": "my-app"}},
+                        "template": {"metadata": {"labels": {"app": "my-app"}}},
+                    },
+                },
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {"name": "my-app"},
+                    "spec": {
+                        "replicas": 3,
+                        "selector": {"matchLabels": {"app": "my-app"}},
+                        "template": {"metadata": {"labels": {"app": "my-app"}}},
+                    },
+                },
+            ),
         ],
     )
     def test_kubernetes_resources(self, test_data, expected_results):


### PR DESCRIPTION
**Description**
Kyma agent cannot handle too broad quries like "check all Kyma resources" not so well. We need to restrict it to certain resources for the time being. 
Delete managed fields field in metadata of k8s and kyma resources as it is not need to analyse resource.

Changes proposed in this pull request:

- Updated Kyma agent prompts to require clarification for broad queries about Kyma resources, improving user interaction.
- Added new test cases to validate the agent's response when more information is needed from the user.
- Implemented a method in DataSanitizer to remove managedFields from metadata, ensuring cleaner resource definitions.
- Enhanced unit tests for DataSanitizer to cover the removal of managedFields in various scenarios.