### PR TITLE
feat: handle feedback

### DIFF
--- a/src/agents/common/constants.py
+++ b/src/agents/common/constants.py
@@ -80,3 +80,5 @@ TOOL_RESPONSE_TOKEN_COUNT_LIMIT = defaultdict(
 )
 
 TOTAL_CHUNKS_LIMIT = 3  # Limit the number of allowed chunking of tool response
+
+FEEDBACK = "feedback"

--- a/src/agents/common/constants.py
+++ b/src/agents/common/constants.py
@@ -82,3 +82,5 @@ TOOL_RESPONSE_TOKEN_COUNT_LIMIT = defaultdict(
 TOTAL_CHUNKS_LIMIT = 3  # Limit the number of allowed chunking of tool response
 
 FEEDBACK = "feedback"
+
+IS_FEEDBACK = "is_feedback"

--- a/src/agents/common/state.py
+++ b/src/agents/common/state.py
@@ -60,6 +60,17 @@ class GatekeeperResponse(BaseModel):
     ]
 
 
+class FeedbackResponse(BaseModel):
+    """Feedback response data model."""
+
+    response: Annotated[
+        str,
+        Field(
+            description="return 'feedback' if user query is positive feedback, or 'forward' if user query is not positive feedback",
+        ),
+    ]
+
+
 class SubTask(BaseModel):
     """Sub-task data model."""
 
@@ -187,6 +198,7 @@ class CompanionState(BaseModel):
     subtasks: list[SubTask] | None = []
     error: str | None = None
     k8s_client: Annotated[Any, Field(default=None, exclude=True)]
+    is_feedback: bool = Field(default=False)
 
     # Model config for pydantic.
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/agents/common/state.py
+++ b/src/agents/common/state.py
@@ -64,9 +64,9 @@ class FeedbackResponse(BaseModel):
     """Feedback response data model."""
 
     response: Annotated[
-        str,
+        bool,
         Field(
-            description="return 'feedback' if user query is positive feedback, or 'forward' if user query is not positive feedback",
+            description="return 'True' if user query is feedback, 'False' if user query is not feedback",
         ),
     ]
 

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -25,6 +25,7 @@ from agents.common.constants import (
     CONTINUE,
     GATEKEEPER,
     INITIAL_SUMMARIZATION,
+    IS_FEEDBACK,
     MESSAGES,
     MESSAGES_SUMMARY,
     NEXT,
@@ -268,19 +269,19 @@ class CompanionGraph:
 
     async def _invoke_feedback_node(self, state: CompanionState) -> FeedbackResponse:
         """Invoke the Feedback node."""
-        response = await ainvoke_chain(
+        response: Any = await ainvoke_chain(
             self._feedback_chain,
             {
                 "messages": [state.messages[-1]],  # last human message
             },
         )
-        return response
+        return cast(FeedbackResponse, response)
 
     async def _invoke_gatekeeper_node(
         self, state: CompanionState
     ) -> GatekeeperResponse:
         """Invoke the Gatekeeper node."""
-        response = await ainvoke_chain(
+        response: Any = await ainvoke_chain(
             self._gatekeeper_chain,
             {
                 "messages": filter_valid_messages(
@@ -288,7 +289,7 @@ class CompanionGraph:
                 ),
             },
         )
-        return response
+        return cast(GatekeeperResponse, response)
 
     async def _gatekeeper_node(self, state: CompanionState) -> dict[str, Any]:
         """Gatekeeper node to handle general and queries that can answered from conversation history."""
@@ -303,7 +304,7 @@ class CompanionGraph:
                 return {
                     NEXT: SUPERVISOR,
                     SUBTASKS: [],
-                    "is_feedback": feedback_response.response,
+                    IS_FEEDBACK: feedback_response.response,
                 }
             logger.debug("Gatekeeper node responding directly")
             return {
@@ -315,7 +316,7 @@ class CompanionGraph:
                     )
                 ],
                 SUBTASKS: [],
-                "is_feedback": feedback_response.response,
+                IS_FEEDBACK: feedback_response.response,
             }
         except Exception:
             logger.exception("Error in gatekeeper node")
@@ -328,7 +329,7 @@ class CompanionGraph:
                     )
                 ],
                 SUBTASKS: [],
-                "is_feedback": feedback_response.response,
+                IS_FEEDBACK: feedback_response.response,
             }
 
     def _build_graph(self) -> CompiledStateGraph:

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -296,7 +296,11 @@ class CompanionGraph:
 
         try:
             feedback_response = await self._invoke_feedback_node(state)
+        except Exception:
+            logger.exception("Error in feedback node")
+            feedback_response = FeedbackResponse(response=False)
 
+        try:
             gatekeeper_response = await self._invoke_gatekeeper_node(state)
 
             if gatekeeper_response.forward_query:

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -58,6 +58,7 @@ from services.k8s import IK8sClient
 from services.usage import UsageTrackerCallback
 from utils.chain import ainvoke_chain
 from utils.logging import get_logger
+from utils.models.contants import GPT_41_NANO_MODEL_NAME
 from utils.models.factory import IModel
 from utils.settings import (
     MAIN_MODEL_MINI_NAME,
@@ -170,7 +171,7 @@ class CompanionGraph:
         self.members = [self.kyma_agent.name, self.k8s_agent.name, COMMON]
         self._common_chain = self._create_common_chain(cast(IModel, main_model_mini))
         self._feedback_chain = self._create_feedback_chain(
-            cast(IModel, models["gpt-4.1-nano"])
+            cast(IModel, models[GPT_41_NANO_MODEL_NAME])
         )
         self._gatekeeper_chain = self._create_gatekeeper_chain(cast(IModel, main_model))
         self.graph = self._build_graph()

--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -191,40 +191,19 @@ and determine whether to handle them directly or forward them.
 """
 
 FEEDBACK_PROMPT = """
-You are Kyma Companion, developed by SAP. Your purpose is to classify user queries as feedback or not feedback about your previous response.
+You are Kyma Companion, an assistant developed by SAP. Your single task is to classify a user's query about your previous response as either feedback (`True`) or not feedback (`False`).
 
-# CORE PRINCIPLE
-Feedback is any user response that contains an EVALUATION or ASSESSMENT of your previous answer. This evaluation can be explicit or implicit, positive or negative.
+The primary determinant is **evaluation**: Does the user's query assess, judge, or react to the quality, usefulness, or correctness of your last answer?
 
-# LINGUISTIC INDICATORS
+**Classify as `True` (Feedback) if the query contains any of the following:**
+* **Direct Evaluation:** Uses evaluative words (e.g., "great," "wrong," "helpful," "confusing").
+* **Emotional Reaction:** Expresses satisfaction, frustration, or gratitude regarding the response.
+* **Implicit Assessment:** Comments on the response's effectiveness or how it compares to their needs (e.g., "That's not what I meant," "Finally, that worked," "That's closer").
 
-## Feedback Indicators (True):
-- **Evaluative language**: Words that judge quality, effectiveness, or correctness
-- **Emotional responses**: Expressions of satisfaction, frustration, gratitude, or confusion about your response
-- **Assessment statements**: Any statement that rates, judges, or comments on your response's value
-- **Comparative language**: Comparing your response to expectations or needs
-- **Effectiveness statements**: Comments on whether your response achieved the desired outcome
+**Classify as `False` (Not Feedback) if the query's primary purpose is to:**
+* **Seek New Information:** Asks a follow-up question that isn't about the quality of the prior answer.
+* **Request Clarification:** Asks for more detail or an explanation of a concept.
+* **Explore Alternatives:** Poses a "what if" scenario or asks for a different approach.
 
-## Non-Feedback Indicators (False):
-- **Information-seeking language**: Questions asking for new or additional information
-- **Clarification requests**: Asking for explanation or elaboration of concepts
-- **Procedural questions**: How-to questions or requests for step-by-step guidance
-- **Scenario exploration**: Asking about different situations or alternatives
-- **Neutral acknowledgments**: Simple acknowledgments without evaluative content
-
-# DECISION FRAMEWORK
-Ask yourself:
-1. Is the user making a judgment about my previous response?
-2. Is the user expressing how they feel about my response?
-3. Is the user commenting on the quality, usefulness, or correctness of my answer?
-
-If YES to any of these → True (Feedback)
-If the user is primarily seeking new information or clarification → False (Not Feedback)
-
-# EDGE CASES
-- Mixed statements with both evaluation and new questions: If there's ANY evaluative component, classify as feedback
-- Brief responses: Consider the context and whether any evaluative element exists
-- Implicit feedback: Look for undertones that suggest assessment even without explicit evaluative words
-
-Classify as feedback (True) or not feedback (False) based on whether the primary purpose is to evaluate your previous response.
+**Crucial Rule:** Your classification should be a single boolean value: `True` or `False`.
 """

--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -189,3 +189,14 @@ and determine whether to handle them directly or forward them.
 - greeting is not a general knowledge query
 - asking about you and your capabilities is not a general knowledge query
 """
+
+FEEDBACK_PROMPT = """
+You are Kyma Companion, developed by SAP. Your purpose is to analyze user query and determine if it is positive feedback or not feedback.
+
+# INSTRUCTIONS
+1. Classify the user query as feedback or not feedback
+2. If it is feedback, classify the query to positive or negative feedback
+3. If it is positive feedback, return "feedback" string
+4. If it is bad feedback, return "forward" string for further processing
+5. In all other cases, return "forward" string for further processing
+"""

--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -196,14 +196,16 @@ You are Kyma Companion, an assistant developed by SAP. Your single task is to cl
 The primary determinant is **evaluation**: Does the user's query assess, judge, or react to the quality, usefulness, or correctness of your last answer?
 
 **Classify as `True` (Feedback) if the query contains any of the following:**
-* **Direct Evaluation:** Uses evaluative words (e.g., "great," "wrong," "helpful," "confusing").
-* **Emotional Reaction:** Expresses satisfaction, frustration, or gratitude regarding the response.
-* **Implicit Assessment:** Comments on the response's effectiveness or how it compares to their needs (e.g., "That's not what I meant," "Finally, that worked," "That's closer").
+* **Direct Evaluation:** Uses evaluative words to judge past performance (e.g., "great," "wrong," "helpful," "confusing," "useful," "incorrect").
+* **Emotional Reaction:** Expresses satisfaction, frustration, or gratitude regarding the response (e.g., "thanks," "that helped," "this is frustrating").
+* **Implicit Assessment:** Comments on the response's effectiveness or how it compares to their needs (e.g., "That's not what I meant," "Finally, that worked," "That's closer," "this doesn't work," "this is incomplete").
 
 **Classify as `False` (Not Feedback) if the query's primary purpose is to:**
+* **Request Clarification:** Asks for more detail, explanation, or improvement of the answer (e.g., "Can you clarify more?", "elaborate more", "I need more details", "give me a shorter explanation").
 * **Seek New Information:** Asks a follow-up question that isn't about the quality of the prior answer.
-* **Request Clarification:** Asks for more detail or an explanation of a concept.
 * **Explore Alternatives:** Poses a "what if" scenario or asks for a different approach.
 
-**Crucial Rule:** Your classification should be a single boolean value: `True` or `False`.
+**Critical Distinction:** 
+- **Feedback:** Judges/evaluates past performance → "This was helpful" / "This is wrong"
+- **Clarification:** Requests future improvement → "Can you explain better?" / "Can you clarify more?"
 """

--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -191,12 +191,40 @@ and determine whether to handle them directly or forward them.
 """
 
 FEEDBACK_PROMPT = """
-You are Kyma Companion, developed by SAP. Your purpose is to analyze user query and determine if it is positive feedback or not feedback.
+You are Kyma Companion, developed by SAP. Your purpose is to classify user queries as feedback or not feedback about your previous response.
 
-# INSTRUCTIONS
-1. Classify the user query as feedback or not feedback
-2. If it is feedback, classify the query to positive or negative feedback
-3. If it is positive feedback, return "feedback" string
-4. If it is bad feedback, return "forward" string for further processing
-5. In all other cases, return "forward" string for further processing
+# CORE PRINCIPLE
+Feedback is any user response that contains an EVALUATION or ASSESSMENT of your previous answer. This evaluation can be explicit or implicit, positive or negative.
+
+# LINGUISTIC INDICATORS
+
+## Feedback Indicators (True):
+- **Evaluative language**: Words that judge quality, effectiveness, or correctness
+- **Emotional responses**: Expressions of satisfaction, frustration, gratitude, or confusion about your response
+- **Assessment statements**: Any statement that rates, judges, or comments on your response's value
+- **Comparative language**: Comparing your response to expectations or needs
+- **Effectiveness statements**: Comments on whether your response achieved the desired outcome
+
+## Non-Feedback Indicators (False):
+- **Information-seeking language**: Questions asking for new or additional information
+- **Clarification requests**: Asking for explanation or elaboration of concepts
+- **Procedural questions**: How-to questions or requests for step-by-step guidance
+- **Scenario exploration**: Asking about different situations or alternatives
+- **Neutral acknowledgments**: Simple acknowledgments without evaluative content
+
+# DECISION FRAMEWORK
+Ask yourself:
+1. Is the user making a judgment about my previous response?
+2. Is the user expressing how they feel about my response?
+3. Is the user commenting on the quality, usefulness, or correctness of my answer?
+
+If YES to any of these → True (Feedback)
+If the user is primarily seeking new information or clarification → False (Not Feedback)
+
+# EDGE CASES
+- Mixed statements with both evaluation and new questions: If there's ANY evaluative component, classify as feedback
+- Brief responses: Consider the context and whether any evaluative element exists
+- Implicit feedback: Look for undertones that suggest assessment even without explicit evaluative words
+
+Classify as feedback (True) or not feedback (False) based on whether the primary purpose is to evaluate your previous response.
 """

--- a/src/utils/models/contants.py
+++ b/src/utils/models/contants.py
@@ -1,0 +1,1 @@
+GPT_41_NANO_MODEL_NAME = "gpt-4.1-nano"

--- a/src/utils/response.py
+++ b/src/utils/response.py
@@ -7,6 +7,7 @@ from agents.common.constants import (
     FINALIZER,
     GATEKEEPER,
     INITIAL_SUMMARIZATION,
+    IS_FEEDBACK,
     NEXT,
     PLANNER,
     SUMMARIZATION,
@@ -84,18 +85,18 @@ def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
     if agent == GATEKEEPER and agent_data.get(NEXT) == SUPERVISOR:
         # Mark Planning Task pending
         PLANNING_TASK["status"] = SubTaskStatus.PENDING
-        response = {
+        return {
             "agent": GATEKEEPER,
             "error": None,
             "answer": {
                 "content": "",
                 "tasks": [PLANNING_TASK],
+                IS_FEEDBACK: (
+                    agent_data.get(IS_FEEDBACK) if IS_FEEDBACK in agent_data else None
+                ),
                 NEXT: SUPERVISOR,
             },
         }
-        if "is_feedback" in agent_data:
-            response["answer"]["is_feedback"] = agent_data.get("is_feedback")
-        return response
 
     answer = {}
     if "messages" in agent_data and agent_data["messages"]:
@@ -106,8 +107,8 @@ def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
     # as of now 'next' field is provided by only SUPERVISOR and GATEKEEPER
     if agent in (SUPERVISOR, GATEKEEPER):
         answer[NEXT] = agent_data.get(NEXT)
-        if "is_feedback" in agent_data:
-            answer["is_feedback"] = agent_data.get("is_feedback")
+        if IS_FEEDBACK in agent_data:
+            answer[IS_FEEDBACK] = agent_data.get(IS_FEEDBACK)
     else:
         # for all other agent, decide next based on pending task
         if agent_data.get("subtasks"):

--- a/src/utils/response.py
+++ b/src/utils/response.py
@@ -69,7 +69,7 @@ def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
     if agent == GATEKEEPER and agent_data.get(NEXT) == SUPERVISOR:
         # Mark Planning Task pending
         PLANNING_TASK["status"] = SubTaskStatus.PENDING
-        return {
+        response = {
             "agent": GATEKEEPER,
             "error": None,
             "answer": {
@@ -78,6 +78,9 @@ def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
                 NEXT: SUPERVISOR,
             },
         }
+        if "is_feedback" in agent_data:
+            response["answer"]["is_feedback"] = agent_data.get("is_feedback")
+        return response
 
     answer = {}
     if "messages" in agent_data and agent_data["messages"]:
@@ -88,6 +91,8 @@ def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
     # as of now 'next' field is provided by only SUPERVISOR and GATEKEEPER
     if agent in (SUPERVISOR, GATEKEEPER):
         answer[NEXT] = agent_data.get(NEXT)
+        if "is_feedback" in agent_data:
+            answer["is_feedback"] = agent_data.get("is_feedback")
     else:
         # for all other agent, decide next based on pending task
         if agent_data.get("subtasks"):

--- a/src/utils/response.py
+++ b/src/utils/response.py
@@ -47,19 +47,34 @@ def reformat_subtasks(subtasks: list[dict[Any, Any]]) -> list[dict[str, Any]]:
     return tasks
 
 
-def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
-    """Process agent data and return the last message only."""
-    agent_data = data[agent]
+def handle_agent_error(
+    agent_data: dict[str, Any], agent: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Handle agent error cases and return error message and response if applicable."""
+
     agent_error = None
     if "error" in agent_data and agent_data["error"]:
         agent_error = agent_data["error"]
         if agent in (SUMMARIZATION, INITIAL_SUMMARIZATION):
             # we don't show summarization node, but only error
-            return {
+            error_response = {
                 "agent": None,
                 "error": agent_error,
                 "answer": {"content": "", "tasks": [], NEXT: END},
             }
+            return agent_error, error_response
+
+    return agent_error, None
+
+
+def process_response(data: dict[str, Any], agent: str) -> dict[str, Any] | None:
+    """Process agent data and return the last message only."""
+    agent_data = data[agent]
+
+    # Handle error cases
+    agent_error, error_response = handle_agent_error(agent_data, agent)
+    if error_response is not None:
+        return error_response
 
     # skip summarization node
     if agent in (SUMMARIZATION, INITIAL_SUMMARIZATION):

--- a/tests/integration/agents/test_gatekeeper_feedback.py
+++ b/tests/integration/agents/test_gatekeeper_feedback.py
@@ -132,6 +132,18 @@ from integration.conftest import create_mock_state
             ],
             False,
         ),
+        # I am still confused
+        (
+            "user is still confused",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Secret', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="I'm still confused about this."),
+            ],
+            True,
+        ),
         # Mixed feedback
         (
             "user gives partial positive with request for more info",
@@ -181,18 +193,6 @@ from integration.conftest import create_mock_state
                 ),
             ],
             False,
-        ),
-        # I am still confused
-        (
-            "user is still confused",
-            [
-                SystemMessage(
-                    content="The user query is related to: "
-                    "{'resource_kind': 'Secret', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
-                ),
-                HumanMessage(content="I'm still confused about this."),
-            ],
-            True,
         ),
         # Ambiguous feedback
         (

--- a/tests/integration/agents/test_gatekeeper_feedback.py
+++ b/tests/integration/agents/test_gatekeeper_feedback.py
@@ -1,0 +1,237 @@
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from agents.common.constants import FEEDBACK
+from integration.conftest import create_mock_state
+
+
+@pytest.mark.parametrize(
+    "test_description, messages, expected_answer",
+    [  # Implicit Kubernetes/Kyma queries that should be forwarded
+        (
+            "user gives good feedback",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Cluster', 'resource_api_version': '', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="your response is useful."),
+            ],
+            FEEDBACK,
+        ),
+        # Additional positive feedback variations
+        (
+            "user expresses gratitude",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Pod', 'resource_api_version': 'v1', 'resource_name': 'test-pod', 'namespace': 'default'}"
+                ),
+                HumanMessage(content="Thanks, that helped!"),
+            ],
+            FEEDBACK,
+        ),
+        (
+            "user confirms solution worked",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Deployment', 'resource_api_version': 'apps/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="Perfect, exactly what I needed"),
+            ],
+            FEEDBACK,
+        ),
+        (
+            "user gives enthusiastic positive feedback",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Service', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="Great explanation! This solved my problem."),
+            ],
+            FEEDBACK,
+        ),
+        (
+            "user gives bad feedback",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Cluster', 'resource_api_version': '', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="this is wrong response."),
+            ],
+            "forward",
+        ),
+        # Additional negative feedback variations
+        (
+            "user states solution doesn't work",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'ConfigMap', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="This doesn't work for my use case."),
+            ],
+            "forward",
+        ),
+        (
+            "user states response is off-topic",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Ingress', 'resource_api_version': 'networking.k8s.io/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="This is not what I asked for."),
+            ],
+            "forward",
+        ),
+        (
+            "user finds solution incomplete",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'StatefulSet', 'resource_api_version': 'apps/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="The solution is incomplete and missing steps."),
+            ],
+            "forward",
+        ),
+        # Neutral/clarifying feedback
+        (
+            "user requests more explanation",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'PersistentVolume', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="Can you explain this better?"),
+            ],
+            "forward",
+        ),
+        (
+            "user requests more details",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Job', 'resource_api_version': 'batch/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="I need more details about this approach."),
+            ],
+            "forward",
+        ),
+        (
+            "user asks about specific scenario",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'CronJob', 'resource_api_version': 'batch/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="What about high availability scenarios?"),
+            ],
+            "forward",
+        ),
+        # Mixed feedback
+        (
+            "user gives partial positive with request for more info",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Namespace', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(
+                    content="This is helpful but I need more information about security aspects."
+                ),
+            ],
+            "forward",
+        ),
+        (
+            "user gives neutral response",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'RoleBinding', 'resource_api_version': 'rbac.authorization.k8s.io/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="Alright."),
+            ],
+            "forward",
+        ),
+        # Specific technical feedback
+        (
+            "user points out technical error",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'CustomResourceDefinition', 'resource_api_version': 'apiextensions.k8s.io/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="The YAML syntax is incorrect in your example."),
+            ],
+            "forward",
+        ),
+        (
+            "user requests alternative approach",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'HorizontalPodAutoscaler', 'resource_api_version': 'autoscaling/v2', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(
+                    content="Is there a different way to achieve this without using HPA?"
+                ),
+            ],
+            "forward",
+        ),
+        # I am still confused
+        (
+            "user is still confused",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Secret', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="I'm still confused about this."),
+            ],
+            "forward",
+        ),
+        # Ambiguous feedback
+        (
+            "user gives minimal acknowledgment",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'ServiceAccount', 'resource_api_version': 'v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="Hmm, okay."),
+            ],
+            "forward",
+        ),
+        (
+            "user gives brief confirmation",
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_kind': 'Role', 'resource_api_version': 'rbac.authorization.k8s.io/v1', 'resource_name': '', 'namespace': ''}"
+                ),
+                HumanMessage(content="I see."),
+            ],
+            "forward",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_invoke_feedback_node(
+    test_description,
+    messages,
+    expected_answer,
+    companion_graph,
+):
+    """
+    Tests that the invoke_feedback_node feedback classification works as expected.
+    """
+    # Given: a conversation state with messages
+    state = create_mock_state(messages)
+
+    # When: the feedback node's invoke_feedback_node method is invoked
+    actual_response = await companion_graph._invoke_feedback_node(state)
+    assert actual_response.response == expected_answer

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,6 +64,7 @@ def app_models(init_config):
     return {
         MAIN_MODEL_MINI_NAME: model_factory.create_model(MAIN_MODEL_MINI_NAME),
         MAIN_MODEL_NAME: model_factory.create_model(MAIN_MODEL_NAME),
+        "gpt-4.1-nano": model_factory.create_model("gpt-4.1-nano"),
         MAIN_EMBEDDING_MODEL_NAME: model_factory.create_model(
             MAIN_EMBEDDING_MODEL_NAME
         ),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,7 @@ from agents.common.state import CompanionState, UserInput
 from agents.graph import CompanionGraph
 from agents.memory.async_redis_checkpointer import AsyncRedisSaver
 from utils.config import get_config
+from utils.models.contants import GPT_41_NANO_MODEL_NAME
 from utils.models.factory import ModelFactory
 from utils.settings import (
     MAIN_EMBEDDING_MODEL_NAME,
@@ -64,7 +65,7 @@ def app_models(init_config):
     return {
         MAIN_MODEL_MINI_NAME: model_factory.create_model(MAIN_MODEL_MINI_NAME),
         MAIN_MODEL_NAME: model_factory.create_model(MAIN_MODEL_NAME),
-        "gpt-4.1-nano": model_factory.create_model("gpt-4.1-nano"),
+        GPT_41_NANO_MODEL_NAME: model_factory.create_model(GPT_41_NANO_MODEL_NAME),
         MAIN_EMBEDDING_MODEL_NAME: model_factory.create_model(
             MAIN_EMBEDDING_MODEL_NAME
         ),

--- a/tests/unit/agents/test_graph.py
+++ b/tests/unit/agents/test_graph.py
@@ -6,7 +6,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.types import StateSnapshot
 
-from agents.common.constants import COMMON, GATEKEEPER
+from agents.common.constants import COMMON, GATEKEEPER, IS_FEEDBACK
 from agents.common.data import Message
 from agents.common.state import (
     CompanionState,
@@ -302,7 +302,7 @@ class TestCompanionGraph:
                     ],
                     "subtasks": [],
                     "next": "__end__",
-                    "is_feedback": True,
+                    IS_FEEDBACK: True,
                 },
                 None,
             ),
@@ -314,7 +314,7 @@ class TestCompanionGraph:
                 {
                     "subtasks": [],
                     "next": SUPERVISOR,
-                    "is_feedback": False,
+                    IS_FEEDBACK: False,
                 },
                 None,
             ),
@@ -332,7 +332,7 @@ class TestCompanionGraph:
                     ],
                     "subtasks": [],
                     "next": "__end__",
-                    "is_feedback": False,
+                    IS_FEEDBACK: False,
                 },
                 "Error in common node: Test error",
             ),

--- a/tests/unit/agents/test_graph.py
+++ b/tests/unit/agents/test_graph.py
@@ -17,6 +17,7 @@ from agents.common.state import (
 from agents.graph import CompanionGraph
 from agents.supervisor.agent import SUPERVISOR
 from services.k8s import IK8sClient
+from utils.models.contants import GPT_41_NANO_MODEL_NAME
 from utils.models.factory import IModel
 from utils.settings import (
     MAIN_EMBEDDING_MODEL_NAME,
@@ -39,7 +40,7 @@ def mock_models():
     return {
         MAIN_MODEL_MINI_NAME: main_model_mini,
         MAIN_MODEL_NAME: main_model,
-        "gpt-4.1-nano": MagicMock(spec=IModel),
+        GPT_41_NANO_MODEL_NAME: MagicMock(spec=IModel),
         MAIN_EMBEDDING_MODEL_NAME: main_embedding_model,
     }
 

--- a/tests/unit/utils/test_response.py
+++ b/tests/unit/utils/test_response.py
@@ -22,6 +22,7 @@ def test_process_response_gatekeeper_forwarded_to_supervisor():
 
     result = process_response(data, GATEKEEPER)
 
+    assert result is not None
     assert result["agent"] == GATEKEEPER
     assert result["error"] is None
     assert result["answer"]["content"] == ""
@@ -122,6 +123,38 @@ def test_process_response_gatekeeper_forwarded_to_supervisor():
             # expected
             b'{"event": "agent_action", "data": {"agent": "KubernetesAgent", "answer": {"t'
             b'asks": []}, "error": "Error occurred"}}',
+        ),
+        (
+            # Summarization agent with error - special error response
+            # input
+            b'{"Summarization": {"error": "Summarization failed", "messages": []}}',
+            # expected
+            b'{"event": "agent_action", "data": {"agent": null, "error": "Summarization f'
+            b'ailed", "answer": {"content": "", "tasks": [], "next": "__end__"}}}',
+        ),
+        (
+            # InitialSummarization agent with error - special error response
+            # input
+            b'{"InitialSummarization": {"error": "Initial summarization failed", "messages": []}}',
+            # expected
+            b'{"event": "agent_action", "data": {"agent": null, "error": "Initial summar'
+            b'ization failed", "answer": {"content": "", "tasks": [], "next": "__end__"}}}',
+        ),
+        (
+            # KymaAgent with error and empty subtasks
+            # input
+            b'{"KymaAgent": {"error": "Kyma service unavailable", "messages": [], "subtasks": []}}',
+            # expected
+            b'{"event": "agent_action", "data": {"agent": "KymaAgent", "answer": {"tasks"'
+            b': []}, "error": "Kyma service unavailable"}}',
+        ),
+        (
+            # Regular agent with error and some content
+            # input
+            b'{"Common": {"error": "Network timeout", "messages": [{"content": "Partial response", "name": "Common"}], "subtasks": []}}',
+            # expected
+            b'{"event": "agent_action", "data": {"agent": "Common", "answer": {"content":'
+            b' "Partial response", "tasks": []}, "error": "Network timeout"}}',
         ),
         (
             # Error response for invalid json


### PR DESCRIPTION
**Description**
Return feedback flag to the UI so that they can display feedback UI part for the end users

Changes proposed in this pull request:

- Implement the logic in a separate LLM call and return the is_feedback flag as a part of Gatekeeper response
- Add/Update the int and unit tests

**Related issue(s)**
#491 