### PR TITLE
fix: update Dockerfile to install Poetry directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY src ./src
 COPY config ./config
 
 # Install Poetry and dependencies in one layer
-RUN apt update &&  apt dist-upgrade -y && apt install -y build-essential gcc python3.12 python3.12-venv python3.12-dev adduser \
+RUN apt update &&  apt dist-upgrade -y && apt install -y build-essential gcc python3.12 python3.12-venv adduser \
   && python3.12 -m venv ./venv \
   && ./venv/bin/pip install --no-cache-dir poetry>=2.1 \
   && ./venv/bin/poetry config virtualenvs.create false \


### PR DESCRIPTION
**Description**
Get rid of some dev and venv python packages that are needed for development. They have security vulnurabilites.
