### PR TITLE
fix: enhance query classification for agent task assignment

### DIFF
--- a/src/agents/supervisor/prompts.py
+++ b/src/agents/supervisor/prompts.py
@@ -12,15 +12,42 @@ PLANNER_STEP_INSTRUCTIONS = """
       - Prioritize recent messages in the conversation history.
 3. **Query Classification**:
     - Classify the query as General Queries (irrelevant to Kyma or Kubernetes) or Kyma/Kubernetes Queries
-4. **Cluster-wide Query Detection**:
-    - Identify queries that need data from both Kyma and Kubernetes agents, if yes then assign tasks to both agents with detailed description.
-    - If query is not explicitly mentioned whether is Kyma or Kubernetes queries, then assign tasks to kyma agent with detailed description.
-    - For all types of cluster scoped queries, assign tasks to both: Kyma and Kubernetes agents with detailed description.
-    - Create separate subtasks for both agents to ensure comprehensive coverage.
-    Example: 
-        Query: "list all resource in my cluster"
-        KymaAgent: "list everything Kyma related in my cluster"
-        KubernetesAgent: "list everything Kubernetes related in my cluster"
+4. **Cluster-wide and Namespace-wide quries without specific resources**:
+    - **True cluster-wide queries**: For comprehensive queries about the entire cluster including "list everything", "complete overview", "all resources", "check resources", "check resource", "cluster status", assign tasks to both Kyma and Kubernetes agents with detailed descriptions.
+    - **True namespace-wide queries**: For comprehensive queries about a specific namespace including "list everything in namespace X", "all resources in namespace Y", "check namespace Z", assign tasks to both Kyma and Kubernetes agents with namespace-specific descriptions.
+    - **Mixed domain queries**: For queries mentioning both Kubernetes and Kyma resources (e.g., "show pods and serverless functions"), split into separate subtasks for each agent based on their domain expertise.
+    - **Domain-specific queries**: For queries specific to one domain (e.g., "check all pods" → KubernetesAgent only, "list Kyma functions" → KymaAgent only), assign to the appropriate agent only.
+    - **Ambiguous queries**: If the query is not explicitly categorized as Kyma or Kubernetes, assign to KymaAgent with detailed description.
+    - **Cluster status queries**: Queries about cluster status, health, or overall state should go to both agents since cluster includes both Kyma and Kubernetes components.
+    - Create separate subtasks for each agent to ensure comprehensive coverage when multiple agents are needed.
+    
+    Examples: 
+        Query: "list all resources in my cluster" (true cluster-wide)
+        → KymaAgent: "list everything Kyma-related in my cluster"
+        → KubernetesAgent: "list everything Kubernetes-related in my cluster"
+        
+        Query: "check resource in the cluster" (true cluster-wide)
+        → KymaAgent: "check Kyma resources in the cluster"
+        → KubernetesAgent: "check Kubernetes resources in the cluster"
+        
+        Query: "what is the status of my cluster?" (cluster status - both agents needed)
+        → KymaAgent: "what is the status of my cluster?"
+        → KubernetesAgent: "what is the status of my cluster?"
+        
+        Query: "show all resources in default namespace" (true namespace-wide)
+        → KymaAgent: "show all Kyma resources in default namespace"
+        → KubernetesAgent: "show all Kubernetes resources in default namespace"
+        
+        Query: "list everything in kyma-system namespace" (true namespace-wide)
+        → KymaAgent: "list everything Kyma-related in kyma-system namespace"
+        → KubernetesAgent: "list everything Kubernetes-related in kyma-system namespace"
+        
+        Query: "show all pods and serverless functions" (mixed domain)
+        → KymaAgent: "show all Kyma serverless functions"  
+        → KubernetesAgent: "show all pods"
+        
+        Query: "check all pods in production namespace" (domain-specific namespace)
+        → KubernetesAgent: "check all pods in production namespace"
 5. **Response Handling**:
       - Create subtasks that directly mirrors the current query points.
       - Assign each subtask to the appropriate agent:

--- a/tests/integration/agents/supervisor/test_planner.py
+++ b/tests/integration/agents/supervisor/test_planner.py
@@ -44,13 +44,39 @@ def planner_correctness_metric(evaluator_model):
             # Test case 1: "List everything in my cluster" - should create subtasks for both agents
             [
                 SystemMessage(
-                    content="The user query is related to: "
-                    "{'resource_api_version': 'v1', 'resource_namespace': 'production'}"
+                    content="The user query is related to: {'resource_kind': 'Cluster', 'resource_scope': 'cluster'}"
                 ),
                 HumanMessage(content="list everything in my cluster"),
             ],
             '{"subtasks": [{"description": "list everything Kyma-related in my cluster", "assigned_to": "KymaAgent", "status": "pending"}, '
             '{"description": "list everything Kubernetes-related in my cluster", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
+            False,
+            0.8,
+        ),
+        (
+            # Test case 1: "List everything in my cluster" - should create subtasks for both agents
+            [
+                SystemMessage(
+                    content="The user query is related to: "
+                    "{'resource_api_version': 'v1', 'resource_namespace': 'production'}"
+                ),
+                HumanMessage(content="check resources in the cluster"),
+            ],
+            '{"subtasks": [{"description": "check Kyma resources in the cluster", "assigned_to": "KymaAgent", "status": "pending"}, '
+            '{"description": "check Kubernetes resources in the cluster", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
+            False,
+            0.8,
+        ),
+        (
+            # Test case 1: "check Kubernetes resources" - should create subtasks for both agents
+            [
+                SystemMessage(
+                    content="The user query is related to: {'resource_kind': 'Cluster', 'resource_scope': 'cluster'}"
+                ),
+                HumanMessage(content="check resources"),
+            ],
+            '{"subtasks": [{"description": "check Kyma resources", "assigned_to": "KymaAgent", "status": "pending"}, '
+            '{"description": "check Kubernetes resources", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
             False,
             0.8,
         ),
@@ -78,12 +104,24 @@ def planner_correctness_metric(evaluator_model):
                 HumanMessage(content="show all pods and serverless functions"),
             ],
             '{"subtasks": [{"description": "show all Kyma serverless functions", "assigned_to": "KymaAgent", "status": "pending"}, '
-            '{"description": "show all Kubernetes pods", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
+            '{"description": "show all pods", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
             False,
             0.8,
         ),
         (
-            # Test case 4: "List all services and API rules" - should create subtasks for both agents
+            # Test case 4: "Check all pods" - should only assign to KubernetesAgent
+            [
+                SystemMessage(
+                    content="The user query is related to: {'resource_kind': 'Cluster', 'resource_scope': 'cluster'}"
+                ),
+                HumanMessage(content="check all pods"),
+            ],
+            '{"subtasks": [{"description": "check all pods", "assigned_to": "KubernetesAgent", "status": "pending"}]}',
+            False,
+            0.8,
+        ),
+        (
+            # Test case 5: "List all services and API rules" - should create subtasks for both agents
             [
                 SystemMessage(
                     content="The user query is related to: "


### PR DESCRIPTION
**Description**
Assign the query to queries without any resource to both agents. For example, "check the resources" should be assigned to both Kyma and K8s agents.

Changes proposed in this pull request:

- Update the planner prompt instructions
- Update the integration tests