### PR TITLE
chore: upgrade Dockerfile base image and hdbcli package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gardenlinux/gardenlinux:1592.11 AS builder
+FROM ghcr.io/gardenlinux/gardenlinux:1877.1 AS builder
 WORKDIR /app
 
 # Copy only necessary files

--- a/poetry.lock
+++ b/poetry.lock
@@ -2068,19 +2068,20 @@ files = [
 
 [[package]]
 name = "hdbcli"
-version = "2.24.26"
+version = "2.25.29"
 description = "SAP HANA Python Client"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "hdbcli-2.24.26-cp34-abi3-macosx_10_11_x86_64.whl", hash = "sha256:741589a3c49985f55067f07cbd7f93980a5bd819f9dbdda824ee28066caa7126"},
-    {file = "hdbcli-2.24.26-cp34-abi3-manylinux1_x86_64.whl", hash = "sha256:9ecb4e81facea1d3251a35da4dd102b06562b896cbe073cee14d5531327f77bd"},
-    {file = "hdbcli-2.24.26-cp34-abi3-manylinux2014_ppc64le.whl", hash = "sha256:4764283f11d7eb19d78d00e97d54272e5dd11aa6688050077daae9605450eac3"},
-    {file = "hdbcli-2.24.26-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:282235c9ec838cfe7b1f28069f0558e345535292e25582845167a37fc2da3d2d"},
-    {file = "hdbcli-2.24.26-cp36-abi3-win32.whl", hash = "sha256:220af424b10a4577f0292b76a088d6af6b8688aa26251c504410791aa79ee84c"},
-    {file = "hdbcli-2.24.26-cp36-abi3-win_amd64.whl", hash = "sha256:11fa023cbb1c5db4149f0929cca9b387ebce56c79b667e1467bf659c8d3eac10"},
-    {file = "hdbcli-2.24.26-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:74c4364c17b96650fd06d7de8ba6004491a9d6afbd07dc845c5907dcc6ac367c"},
+    {file = "hdbcli-2.25.29-cp38-abi3-macosx_10_15_x86_64.whl", hash = "sha256:736927bf8c9787e5529b7043879a57527d9fe81e717495df8c442b083b2eb000"},
+    {file = "hdbcli-2.25.29-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d0b23608b1448f3108d9d7ae1761bd4207b07b186c885f025f72fdce90706a5"},
+    {file = "hdbcli-2.25.29-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:44abac60f7437ff99ca938795d85ccd127d3fcedd7d3500ada93940e83d5dcca"},
+    {file = "hdbcli-2.25.29-cp38-abi3-manylinux2014_ppc64le.whl", hash = "sha256:fbc56f6f16e6eb5fb8195bad3d64038095f7ea3050d48a0995481a54f6dcb748"},
+    {file = "hdbcli-2.25.29-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:7aabc161e0f4d0fcd03a203518d50a9f6a8d83cb550e6fd48b5d0f86747c4885"},
+    {file = "hdbcli-2.25.29-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bbed7f23c8d6514e71cc1486eef1fff2117c77459a73e3bb035246f9d6647447"},
+    {file = "hdbcli-2.25.29-cp38-abi3-win32.whl", hash = "sha256:98d0860dadea1dd38b3c7b3c14ba5fbb77a0a243b2aa2c0e8b837ed569962d89"},
+    {file = "hdbcli-2.25.29-cp38-abi3-win_amd64.whl", hash = "sha256:0e6c8f123fa9be57de8427aa5ffc17a6849094493dadc6c552c12808a56c92c5"},
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**
Upgrade base image and packages to fix security issues.

Changes proposed in this pull request:

- Upgrade base image garden linux
- Upgrade hdbcli package