### PR TITLE
fix: matching names for grouping in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
         "poetry"
       ],
       "matchDepTypes": [
-        "dev-dependencies"
+        "dev"
       ],
       "addLabels": [
         "dependencies"
@@ -32,7 +32,7 @@
         "poetry"
       ],
       "matchDepTypes": [
-        "test-dependencies"
+        "test"
       ],
       "addLabels": [
         "dependencies"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix the names used for dependency grouping in `renovate`
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
