### PR TITLE
fix: group dep bumps by name but not by package file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,10 +22,10 @@
       "matchDepTypes": [
         "dev"
       ],
+      "groupName": "Dev Dependencies in {{packageFileName}} / {{packageName}}",
       "addLabels": [
         "dependencies"
-      ],
-      "groupName": "Development Dependencies"
+      ]
     },
     {
       "matchManagers": [
@@ -34,10 +34,10 @@
       "matchDepTypes": [
         "test"
       ],
+      "groupName": "Test Dependencies in {{packageFileName}} / {{packageName}}",
       "addLabels": [
         "dependencies"
-      ],
-      "groupName": "Test Dependencies"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- group PRs by package, not for multiple package file (don't mix `test` dependencies from the main package and from the `indexer` package)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
