### PR TITLE
fix: added quick fix for feedback render only when there is no supervisor forwarding

### DIFF
--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -361,7 +361,7 @@ class CompanionGraph:
                 return {
                     NEXT: SUPERVISOR,
                     SUBTASKS: [],
-                    IS_FEEDBACK: feedback_response.response,
+                    IS_FEEDBACK: False, # Quick FIx - Need to remove this hardcoded value
                 }
 
             logger.debug("Gatekeeper node directly responding")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Hard coded `is_feedback = False` , when query is forwarded to supervisor


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
