### PR TITLE
refactor: rename previous_pod to previously_terminated_container

### DIFF
--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -119,7 +119,7 @@ class PodLogsResponse(BaseModel):
 
     logs: PodLogs = Field(
         ...,
-        description="Pod logs with current_pod and previously_terminated_pod",
+        description="Container logs with current_container and previously_terminated_container",
     )
     diagnostic_context: PodLogsDiagnosticContext | None = Field(
         default=None,

--- a/src/services/k8s_models.py
+++ b/src/services/k8s_models.py
@@ -35,7 +35,7 @@ class InitContainerStatus(BaseModel):
 
 
 class PodLogsDiagnosticContext(BaseModel):
-    """Diagnostic context when pod logs are unavailable."""
+    """Diagnostic context when container logs are unavailable."""
 
     events: str = Field(..., description="Formatted text of recent pod events")
     container_statuses: dict[str, ContainerStatus] | None = Field(
@@ -49,17 +49,19 @@ class PodLogsDiagnosticContext(BaseModel):
 
 
 class PodLogs(BaseModel):
-    """Pod log contents."""
+    """Container log contents."""
 
-    current_pod: str = Field(..., description="Current pod logs as string with newlines")
-    previously_terminated_pod: str = Field(..., description="Previously terminated pod logs as string with newlines or unavailability message")
+    current_container: str = Field(..., description="Current container logs as string with newlines")
+    previously_terminated_container: str = Field(
+        ..., description="Previously terminated container logs as string with newlines or unavailability message"
+    )
 
 
 class PodLogsResult(BaseModel):
-    """Complete pod logs result with optional diagnostic context."""
+    """Complete container logs result with optional diagnostic context."""
 
-    logs: PodLogs = Field(..., description="Pod logs for current and previous containers")
+    logs: PodLogs = Field(..., description="Container logs for current and previously terminated container instances")
     diagnostic_context: PodLogsDiagnosticContext | None = Field(
         default=None,
-        description="Optional diagnostic information when current pod logs are unavailable",
+        description="Optional diagnostic information when current container logs are unavailable",
     )

--- a/tests/blackbox/src/api_tests/test_tools_api.py
+++ b/tests/blackbox/src/api_tests/test_tools_api.py
@@ -153,8 +153,8 @@ class TestK8sToolsAPI:
         logs_data = logs_response.json()
         assert "logs" in logs_data
         assert isinstance(logs_data["logs"], dict)
-        assert "current_pod" in logs_data["logs"]
-        assert "previously_terminated_pod" in logs_data["logs"]
+        assert "current_container" in logs_data["logs"]
+        assert "previously_terminated_container" in logs_data["logs"]
         assert "pod_name" in logs_data
         assert logs_data["pod_name"] == pod_name
         logger.info(f"Successfully fetched logs from {pod_namespace}/{pod_name}")

--- a/tests/integration/services/test_k8s.py
+++ b/tests/integration/services/test_k8s.py
@@ -385,15 +385,15 @@ class TestK8sClient:
         # the return type should be PodLogsResult (Pydantic model).
         assert result is not None
         assert hasattr(result, "logs")
-        assert hasattr(result.logs, "current_pod")
-        assert hasattr(result.logs, "previously_terminated_pod")
+        assert hasattr(result.logs, "current_container")
+        assert hasattr(result.logs, "previously_terminated_container")
 
         # Current logs should be a string
-        assert isinstance(result.logs.current_pod, str)
-        assert result.logs.current_pod != ""
+        assert isinstance(result.logs.current_container, str)
+        assert result.logs.current_container != ""
 
         # Previous logs might not be available for running pods
-        assert isinstance(result.logs.previously_terminated_pod, str)
+        assert isinstance(result.logs.previously_terminated_container, str)
 
     @pytest.mark.parametrize(
         "given_kind, expected_api_version",

--- a/tests/unit/agents/k8s/tools/test_logs.py
+++ b/tests/unit/agents/k8s/tools/test_logs.py
@@ -21,8 +21,8 @@ from services.k8s import IK8sClient
             None,
             {
                 "logs": {
-                    "current_pod": "line 1\nline 2\nline 3",
-                    "previously_terminated_pod": "Not available (container has not been restarted)",
+                    "current_container": "line 1\nline 2\nline 3",
+                    "previously_terminated_container": "Not available (container has not been restarted)",
                 },
                 "diagnostic_context": None,
             },
@@ -62,8 +62,8 @@ async def test_fetch_pod_logs_tool(
 
         k8s_client.fetch_pod_logs.return_value = PodLogsResult(
             logs=PodLogs(
-                current_pod=expected_logs_dict["logs"]["current_pod"],
-                previously_terminated_pod=expected_logs_dict["logs"]["previously_terminated_pod"],
+                current_container=expected_logs_dict["logs"]["current_container"],
+                previously_terminated_container=expected_logs_dict["logs"]["previously_terminated_container"],
             ),
             diagnostic_context=expected_logs_dict["diagnostic_context"],
         )

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -83,8 +83,8 @@ class MockK8sClient(IK8sClient):
             )
         return PodLogsResult(
             logs=PodLogs(
-                current_pod="Log line 1\nLog line 2\nLog line 3",
-                previously_terminated_pod="Not available (container has not been restarted)",
+                current_container="Log line 1\nLog line 2\nLog line 3",
+                previously_terminated_container="Not available (container has not been restarted)",
             )
         )
 

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -147,8 +147,8 @@ class MockK8sClient:
 
         return PodLogsResult(
             logs=PodLogs(
-                current_pod="",
-                previously_terminated_pod="Not available",
+                current_container="",
+                previously_terminated_container="Not available",
             ),
             diagnostic_context=None,
         )

--- a/tests/unit/routers/test_k8s_tools_api.py
+++ b/tests/unit/routers/test_k8s_tools_api.py
@@ -73,8 +73,8 @@ class TestLogsEndpoint:
         response_data = response.json()
         assert "logs" in response_data
         assert isinstance(response_data["logs"], dict)
-        assert "current_pod" in response_data["logs"]
-        assert "previously_terminated_pod" in response_data["logs"]
+        assert "current_container" in response_data["logs"]
+        assert "previously_terminated_container" in response_data["logs"]
 
     def test_logs_with_container_name(self, k8s_client_factory):
         """Test fetching logs with specific container name."""

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -1148,11 +1148,11 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Should show current logs successfully
-            current_logs = result.logs.current_pod
+            current_logs = result.logs.current_container
             assert all(line in current_logs for line in expected_sanitized_logs)
 
             # Should show previous logs not available (error message)
-            previous_logs = result.logs.previously_terminated_pod
+            previous_logs = result.logs.previously_terminated_container
             assert "not found" in previous_logs.lower() or "not available" in previous_logs.lower()
 
     @pytest.mark.asyncio
@@ -1237,7 +1237,7 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Should show current logs not available with diagnostic info
-            current_logs = result.logs.current_pod
+            current_logs = result.logs.current_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
 
             # Should have diagnostic context
@@ -1246,7 +1246,7 @@ class TestK8sClient:
             assert "Container is in CrashLoopBackOff state" in diagnostic_str
 
             # Should show previous logs successfully
-            previous_logs = result.logs.previously_terminated_pod
+            previous_logs = result.logs.previously_terminated_container
             assert all(line in previous_logs for line in expected_logs)
 
     @pytest.mark.asyncio
@@ -1306,8 +1306,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both current and previous logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1381,7 +1381,7 @@ class TestK8sClient:
             assert hasattr(result, "logs")
 
             # Current logs should succeed after retries
-            current_logs = result.logs.current_pod
+            current_logs = result.logs.current_container
             assert all(line in current_logs for line in success_logs)
 
             # Should have slept twice (after first and second failures)
@@ -1439,8 +1439,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1507,8 +1507,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or "failed" in current_logs.lower() or len(current_logs) == 0
             assert (
                 "failed" in previous_logs.lower() or "not available" in previous_logs.lower() or len(previous_logs) == 0
@@ -1643,8 +1643,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
 
             # Previous logs status depends on error code
@@ -1738,8 +1738,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1828,8 +1828,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1889,8 +1889,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_pod
-            previous_logs = result.logs.previously_terminated_pod
+            current_logs = result.logs.current_container
+            previous_logs = result.logs.previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- rename `current_pod` to `current_container`
- rename `previous_pod` to `previously_terminated_container`
- rename `is_terminated` arg to `previous`, as it is called in k8s, for more consistency 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
