### PR TITLE
refactor: introduce global cache for init models

### DIFF
--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -14,7 +14,8 @@ from services.k8s import IK8sClient, K8sAuthHeaders, K8sClient
 from services.k8s_models import PodLogs, PodLogsDiagnosticContext
 from utils.config import Config, get_config
 from utils.logging import get_logger
-from utils.models.factory import IModel, ModelFactory
+from utils.models.factory import IModel
+from utils.models_cache import get_models
 
 logger = get_logger(__name__)
 
@@ -240,12 +241,6 @@ def init_data_sanitizer(
     return DataSanitizer(config.sanitization_config)
 
 
-class _ModelsCache:
-    """Singleton cache for models dict to avoid using global statement."""
-
-    _instance: dict[str, IModel | Embeddings] | None = None
-
-
 def init_models_dict(
     config: Annotated[Config, Depends(init_config)],
 ) -> dict[str, IModel | Embeddings]:
@@ -256,18 +251,14 @@ def init_models_dict(
     that require LLM models and embeddings.
     Uses a class-level cache to avoid recreating models on every request.
     """
-    if _ModelsCache._instance is None:
-        try:
-            model_factory = ModelFactory(config=config)
-            _ModelsCache._instance = model_factory.create_models()
-        except Exception as e:
-            logger.exception("Failed to initialize models")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail=f"Failed to initialize models: {str(e)}",
-            ) from e
-
-    return _ModelsCache._instance
+    try:
+        return get_models(config)
+    except Exception as e:
+        logger.exception("Failed to initialize models")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Failed to initialize models: {str(e)}",
+        ) from e
 
 
 def init_k8s_client(

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -22,6 +22,7 @@ from services.usage import IUsageTracker, UsageExceedReport, UsageTracker
 from utils.config import Config
 from utils.logging import get_logger
 from utils.models.factory import IModel, IModelFactory, ModelFactory
+from utils.models_cache import get_models
 from utils.settings import (
     MAIN_MODEL_MINI_NAME,
     TOKEN_LIMIT_PER_CLUSTER,
@@ -77,8 +78,12 @@ class ConversationService(metaclass=SingletonMeta):
         followup_questions_handler: IFollowUpQuestionsHandler | None = None,
     ) -> None:
         try:
-            self._model_factory = model_factory or ModelFactory(config=config)
-            models = self._model_factory.create_models()
+            if model_factory is not None:
+                self._model_factory = model_factory
+                models = self._model_factory.create_models()
+            else:
+                self._model_factory = ModelFactory(config=config)
+                models = get_models(config)
         except Exception:
             logger.exception("Failed to initialize models")
             raise

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -77,12 +77,12 @@ class ConversationService(metaclass=SingletonMeta):
         model_factory: IModelFactory | None = None,
         followup_questions_handler: IFollowUpQuestionsHandler | None = None,
     ) -> None:
-        try:
             if model_factory is not None:
                 self._model_factory = model_factory
                 models = self._model_factory.create_models()
             else:
                 models = get_models(config)
+                self._model_factory = None  # type: ignore
         except Exception:
             logger.exception("Failed to initialize models")
             raise

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -21,7 +21,7 @@ from services.k8s import IK8sClient
 from services.usage import IUsageTracker, UsageExceedReport, UsageTracker
 from utils.config import Config
 from utils.logging import get_logger
-from utils.models.factory import IModel, IModelFactory, ModelFactory
+from utils.models.factory import IModel, IModelFactory
 from utils.models_cache import get_models
 from utils.settings import (
     MAIN_MODEL_MINI_NAME,
@@ -67,7 +67,7 @@ class ConversationService(metaclass=SingletonMeta):
 
     _init_questions_handler: IInitialQuestionsHandler
     _kyma_graph: IGraph
-    _model_factory: IModelFactory
+    _model_factory: IModelFactory | None
     _usage_limiter: IUsageTracker
 
     def __init__(
@@ -82,7 +82,6 @@ class ConversationService(metaclass=SingletonMeta):
                 self._model_factory = model_factory
                 models = self._model_factory.create_models()
             else:
-                self._model_factory = ModelFactory(config=config)
                 models = get_models(config)
         except Exception:
             logger.exception("Failed to initialize models")

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -38,7 +38,9 @@ TOKEN_LIMIT = 16_000
 class IService(Protocol):
     """Service interface"""
 
-    async def new_conversation(self, k8s_client: IK8sClient, message: Message) -> list[str]:
+    async def new_conversation(
+        self, k8s_client: IK8sClient, message: Message
+    ) -> list[str]:
         """Initialize a new conversation."""
         ...
 
@@ -46,7 +48,9 @@ class IService(Protocol):
         """Generate follow-up questions for a conversation."""
         ...
 
-    def handle_request(self, conversation_id: str, message: Message, k8s_client: IK8sClient) -> AsyncGenerator[bytes]:
+    def handle_request(
+        self, conversation_id: str, message: Message, k8s_client: IK8sClient
+    ) -> AsyncGenerator[bytes]:
         """Handle a request for a conversation"""
         ...
 
@@ -54,7 +58,9 @@ class IService(Protocol):
         """Authorize the user to access the conversation."""
         ...
 
-    async def is_usage_limit_exceeded(self, cluster_id: str) -> UsageExceedReport | None:
+    async def is_usage_limit_exceeded(
+        self, cluster_id: str
+    ) -> UsageExceedReport | None:
         """Check if the token usage limit is exceeded for the given cluster_id."""
         ...
 
@@ -77,30 +83,39 @@ class ConversationService(metaclass=SingletonMeta):
         model_factory: IModelFactory | None = None,
         followup_questions_handler: IFollowUpQuestionsHandler | None = None,
     ) -> None:
+        try:
             if model_factory is not None:
                 self._model_factory = model_factory
                 models = self._model_factory.create_models()
             else:
+                self._model_factory = None
                 models = get_models(config)
-                self._model_factory = None  # type: ignore
         except Exception:
             logger.exception("Failed to initialize models")
             raise
 
         model_mini = cast(IModel, models[MAIN_MODEL_MINI_NAME])
         # Set up the initial question handler, which will handle all the logic to generate the inital questions.
-        self._init_questions_handler = initial_questions_handler or InitialQuestionsHandler(model=model_mini)
+        self._init_questions_handler = (
+            initial_questions_handler or InitialQuestionsHandler(model=model_mini)
+        )
 
         # Set up the followup question handler.
-        self._followup_questions_handler = followup_questions_handler or FollowUpQuestionsHandler(model=model_mini)
+        self._followup_questions_handler = (
+            followup_questions_handler or FollowUpQuestionsHandler(model=model_mini)
+        )
 
         # Set up the Kyma Graph which allows access to stored conversation histories.
         checkpointer = get_async_redis_saver()
-        self._usage_limiter = UsageTracker(checkpointer, TOKEN_LIMIT_PER_CLUSTER, TOKEN_USAGE_RESET_INTERVAL)
+        self._usage_limiter = UsageTracker(
+            checkpointer, TOKEN_LIMIT_PER_CLUSTER, TOKEN_USAGE_RESET_INTERVAL
+        )
 
         self._companion_graph = CompanionGraph(models, memory=checkpointer)
 
-    async def new_conversation(self, k8s_client: IK8sClient, message: Message) -> list[str]:
+    async def new_conversation(
+        self, k8s_client: IK8sClient, message: Message
+    ) -> list[str]:
         """Initialize a new conversation."""
 
         logger.info(
@@ -111,8 +126,10 @@ class ConversationService(metaclass=SingletonMeta):
         # Fetch the context for our questions from the Kubernetes cluster.
         k8s_context = "No relevant context found"
         try:
-            k8s_context = await self._init_questions_handler.fetch_relevant_data_from_k8s_cluster(
-                message=message, k8s_client=k8s_client
+            k8s_context = (
+                await self._init_questions_handler.fetch_relevant_data_from_k8s_cluster(
+                    message=message, k8s_client=k8s_client
+                )
             )
         except ApiException as exp:
             # if the status is 403, we just log the error and continue with an empty context.
@@ -121,7 +138,9 @@ class ConversationService(metaclass=SingletonMeta):
                 raise exp
 
         # Reduce the amount of tokens according to the limits.
-        k8s_context = self._init_questions_handler.apply_token_limit(k8s_context, TOKEN_LIMIT)
+        k8s_context = self._init_questions_handler.apply_token_limit(
+            k8s_context, TOKEN_LIMIT
+        )
 
         # Pass the context to the initial question handler to generate the questions.
         questions = self._init_questions_handler.generate_questions(context=k8s_context)
@@ -131,7 +150,9 @@ class ConversationService(metaclass=SingletonMeta):
     async def handle_followup_questions(self, conversation_id: str) -> list[str]:
         """Generate follow-up questions for a conversation."""
 
-        logger.info(f"Generating follow-up questions for conversation: ({conversation_id})")
+        logger.info(
+            f"Generating follow-up questions for conversation: ({conversation_id})"
+        )
 
         # Fetch the conversation history from the LangGraph.
         messages = await self._companion_graph.aget_messages(conversation_id)
@@ -143,7 +164,9 @@ class ConversationService(metaclass=SingletonMeta):
     ) -> AsyncGenerator[bytes]:
         """Handle a request"""
         try:
-            async for chunk in self._companion_graph.astream(conversation_id, message, k8s_client):
+            async for chunk in self._companion_graph.astream(
+                conversation_id, message, k8s_client
+            ):
                 yield chunk.encode()
         except Exception:
             logger.exception("Error during streaming")
@@ -155,12 +178,16 @@ class ConversationService(metaclass=SingletonMeta):
         owner = await self._companion_graph.aget_thread_owner(conversation_id)
         # If the owner is None, we can update the owner to the current user.
         if owner is None:
-            await self._companion_graph.aupdate_thread_owner(conversation_id, user_identifier)
+            await self._companion_graph.aupdate_thread_owner(
+                conversation_id, user_identifier
+            )
             return True
         # If the owner is the same as the user, we can authorize the user.
         return owner == user_identifier
 
-    async def is_usage_limit_exceeded(self, cluster_id: str) -> UsageExceedReport | None:
+    async def is_usage_limit_exceeded(
+        self, cluster_id: str
+    ) -> UsageExceedReport | None:
         """Check if the token usage limit is exceeded for the given cluster_id."""
         # Delete expired records before checking the usage limit.
         await self._usage_limiter.adelete_expired_records(cluster_id)

--- a/src/services/probes.py
+++ b/src/services/probes.py
@@ -4,7 +4,8 @@ from langchain_core.embeddings import Embeddings
 
 from utils.config import get_config
 from utils.logging import get_logger
-from utils.models.factory import IModel, ModelFactory
+from utils.models.factory import IModel
+from utils.models_cache import get_models
 from utils.singleton_meta import SingletonMeta
 
 USAGE_TRACKER_FAILURE_THRESHOLD = 3
@@ -115,7 +116,7 @@ class LLMProbe(metaclass=SingletonMeta):
 
 def _get_models() -> dict[str, IModel | Embeddings]:
     """Do not use this function directly to create Models. Use the ModelFactory instead."""
-    return ModelFactory(get_config()).create_models()
+    return get_models(get_config())
 
 
 def get_llm_probe() -> LLMProbe:

--- a/src/utils/models_cache.py
+++ b/src/utils/models_cache.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+
+from langchain_core.embeddings import Embeddings
+
+from utils.config import Config
+from utils.logging import get_logger
+from utils.models.factory import IModel, ModelFactory
+
+logger = get_logger(__name__)
+
+_lock = threading.Lock()
+
+
+class _ModelsCacheState:
+    key: tuple | None
+    models: dict[str, IModel | Embeddings] | None
+
+    def __init__(self) -> None:
+        self.key = None
+        self.models = None
+
+
+_state = _ModelsCacheState()
+
+
+def _model_name(model: object) -> str:
+    name = getattr(model, "name", None)
+    if isinstance(name, str):
+        return name
+    if isinstance(model, dict):
+        return str(model.get("name", ""))
+    return ""
+
+
+def _models_key(models: Iterable[object]) -> tuple:
+    """Generate a hashable key for models"""
+    return tuple(_model_name(m) for m in models)
+
+
+def reset_models_cache_for_tests() -> None:
+    """Reset the global models cache. Intended for unit tests only."""
+    with _lock:
+        _state.key = None
+        _state.models = None
+
+
+def get_models(config: Config) -> dict[str, IModel | Embeddings]:
+    """
+    This cache is shared across routers/services/probes so the process initializes
+    models only once.
+    """
+
+    key = _models_key(getattr(config, "models", []) or [])
+
+    with _lock:
+        if _state.models is not None and _state.key == key:
+            return _state.models
+
+        logger.info("Initializing shared models cache")
+        model_factory = ModelFactory(config=config)
+        _state.models = model_factory.create_models()
+        _state.key = key
+        return _state.models

--- a/src/utils/models_cache.py
+++ b/src/utils/models_cache.py
@@ -53,7 +53,7 @@ def get_models(config: Config) -> dict[str, IModel | Embeddings]:
     models only once.
     """
 
-    key = _models_key(getattr(config, "models", []) or [])
+    key = _models_key(config.models)
 
     with _lock:
         if _state.models is not None and _state.key == key:

--- a/tests/unit/routers/test_common.py
+++ b/tests/unit/routers/test_common.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 
 from routers.common import init_k8s_client, init_models_dict
 from services.data_sanitizer import IDataSanitizer
+from utils.models_cache import reset_models_cache_for_tests
 
 
 class TestInitK8sClient:
@@ -65,15 +66,13 @@ class TestInitModelsDict:
     @pytest.fixture(autouse=True)
     def reset_cache(self):
         """Reset the models cache before each test."""
-        from routers.common import _ModelsCache
-
-        _ModelsCache._instance = None
+        reset_models_cache_for_tests()
         yield
-        _ModelsCache._instance = None
+        reset_models_cache_for_tests()
 
     def test_init_models_dict_caches_result(self, mock_config):
         """Test that init_models_dict caches models dict (singleton behavior)."""
-        with patch("routers.common.ModelFactory") as mock_factory_class:
+        with patch("utils.models_cache.ModelFactory") as mock_factory_class:
             mock_factory = Mock()
             mock_models = {"gpt-4": Mock()}
             mock_factory.create_models.return_value = mock_models
@@ -91,7 +90,7 @@ class TestInitModelsDict:
 
     def test_init_models_dict_raises_http_exception_on_error(self, mock_config):
         """Test that init_models_dict raises HTTPException when model creation fails."""
-        with patch("routers.common.ModelFactory") as mock_factory_class:
+        with patch("utils.models_cache.ModelFactory") as mock_factory_class:
             mock_factory = Mock()
             mock_factory.create_models.side_effect = Exception("Model initialization failed")
             mock_factory_class.return_value = mock_factory

--- a/tests/unit/services/test_conversation.py
+++ b/tests/unit/services/test_conversation.py
@@ -61,9 +61,7 @@ class TestConversation:
             "chunk2",
             "chunk3",
         ]
-        with patch(
-            "services.conversation.CompanionGraph", return_value=mock_companion_graph
-        ) as mock:
+        with patch("services.conversation.CompanionGraph", return_value=mock_companion_graph) as mock:
             yield mock
 
     @pytest.fixture
@@ -115,9 +113,7 @@ class TestConversation:
     ) -> None:
         # Given:
         mock_handler = Mock()
-        mock_handler.fetch_relevant_data_from_k8s_cluster = (
-            fetch_relevant_data_from_k8s_cluster_mock
-        )
+        mock_handler.fetch_relevant_data_from_k8s_cluster = fetch_relevant_data_from_k8s_cluster_mock
         mock_handler.apply_token_limit = Mock(return_value=k8s_context)
         mock_handler.generate_questions = Mock(return_value=QUESTIONS)
 
@@ -131,14 +127,10 @@ class TestConversation:
         # When:
         if should_expect_exception:
             with pytest.raises(ApiException):
-                await conversation_service.new_conversation(
-                    k8s_client=mock_k8s_client, message=TEST_MESSAGE
-                )
+                await conversation_service.new_conversation(k8s_client=mock_k8s_client, message=TEST_MESSAGE)
             return
 
-        result = await conversation_service.new_conversation(
-            k8s_client=mock_k8s_client, message=TEST_MESSAGE
-        )
+        result = await conversation_service.new_conversation(k8s_client=mock_k8s_client, message=TEST_MESSAGE)
 
         # Then:
         assert result == QUESTIONS
@@ -172,21 +164,15 @@ class TestConversation:
         )
         conversation_service._followup_questions_handler = mock_handler
         # define mock for CompanionGraph.
-        conversation_service._companion_graph.aget_messages = AsyncMock(
-            return_value=dummy_conversation_history
-        )
+        conversation_service._companion_graph.aget_messages = AsyncMock(return_value=dummy_conversation_history)
 
         # When:
         result = await conversation_service.handle_followup_questions(CONVERSATION_ID)
 
         # Then:
         assert result == QUESTIONS
-        mock_handler.generate_questions.assert_called_once_with(
-            messages=dummy_conversation_history
-        )
-        conversation_service._companion_graph.aget_messages.assert_called_once_with(
-            CONVERSATION_ID
-        )
+        mock_handler.generate_questions.assert_called_once_with(messages=dummy_conversation_history)
+        conversation_service._companion_graph.aget_messages.assert_called_once_with(CONVERSATION_ID)
 
     @pytest.mark.asyncio
     async def test_handle_request(
@@ -204,10 +190,7 @@ class TestConversation:
 
         # Then:
         result = [
-            chunk
-            async for chunk in messaging_service.handle_request(
-                CONVERSATION_ID, TEST_MESSAGE, mock_k8s_client
-            )
+            chunk async for chunk in messaging_service.handle_request(CONVERSATION_ID, TEST_MESSAGE, mock_k8s_client)
         ]
         assert result == [b"chunk1", b"chunk2", b"chunk3"]
 
@@ -226,10 +209,7 @@ class TestConversation:
         messaging_service._companion_graph = mock_companion_graph
 
         result = [
-            chunk
-            async for chunk in messaging_service.handle_request(
-                CONVERSATION_ID, TEST_MESSAGE, mock_k8s_client
-            )
+            chunk async for chunk in messaging_service.handle_request(CONVERSATION_ID, TEST_MESSAGE, mock_k8s_client)
         ]
 
         error_response = json.dumps({ERROR: {ERROR: ERROR_RESPONSE}}).encode()
@@ -283,16 +263,12 @@ class TestConversation:
         conversation_service._companion_graph = mock_companion_graph
 
         # When
-        result = await conversation_service.authorize_user(
-            conversation_id, user_identifier
-        )
+        result = await conversation_service.authorize_user(conversation_id, user_identifier)
 
         # Then
         assert result == expected_result
         if thread_owner is None:
-            mock_companion_graph.aupdate_thread_owner.assert_called_once_with(
-                conversation_id, user_identifier
-            )
+            mock_companion_graph.aupdate_thread_owner.assert_called_once_with(conversation_id, user_identifier)
         else:
             mock_companion_graph.aupdate_thread_owner.assert_not_called()
 
@@ -333,9 +309,7 @@ class TestConversation:
         # Given
         mock_usage_limiter = Mock()
         mock_usage_limiter.adelete_expired_records = AsyncMock()
-        mock_usage_limiter.ais_usage_limit_exceeded = AsyncMock(
-            return_value=usage_limit_exceeded
-        )
+        mock_usage_limiter.ais_usage_limit_exceeded = AsyncMock(return_value=usage_limit_exceeded)
 
         conversation_service = ConversationService(config=mock_config)
         conversation_service._usage_limiter = mock_usage_limiter

--- a/tests/unit/services/test_conversation.py
+++ b/tests/unit/services/test_conversation.py
@@ -10,6 +10,7 @@ from agents.common.data import Message
 from services.conversation import TOKEN_LIMIT, ConversationService
 from services.usage import UsageExceedReport
 from utils.settings import MAIN_MODEL_MINI_NAME
+from utils.singleton_meta import SingletonMeta
 
 TIME_STAMP = 1.8
 QUESTIONS = ["question1?", "question2?", "question3?"]
@@ -36,13 +37,23 @@ TEST_MESSAGE = Message(
 
 
 class TestConversation:
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self):
+        """Reset singleton instance to ensure test isolation."""
+        SingletonMeta.reset_instance(ConversationService)
+        yield
+        SingletonMeta.reset_instance(ConversationService)
+
     @pytest.fixture
     def mock_model_factory(self):
         mock_model = Mock()
         mock_models = {MAIN_MODEL_MINI_NAME: mock_model}
-        with patch("services.conversation.ModelFactory") as mock:
-            mock.return_value.create_models.return_value = mock_models
-            yield mock
+        with (
+            patch("services.conversation.ModelFactory") as mock_factory,
+            patch("services.conversation.get_models") as mock_get_models,
+        ):
+            mock_get_models.return_value = mock_models
+            yield mock_factory
 
     @pytest.fixture
     def mock_companion_graph(self):
@@ -109,8 +120,6 @@ class TestConversation:
         mock_handler.apply_token_limit = Mock(return_value=k8s_context)
         mock_handler.generate_questions = Mock(return_value=QUESTIONS)
 
-        # Reset singleton instances to ensure test isolation.
-        ConversationService._instances = {}
         conversation_service = ConversationService(
             config=mock_config,
             initial_questions_handler=mock_handler,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Use shared cache across routers/services/probes, so the process initializes models only once
- Adjust tests according to the changes

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
