### PR TITLE
fix: double rag initiation

### DIFF
--- a/src/agents/kyma/agent.py
+++ b/src/agents/kyma/agent.py
@@ -12,7 +12,7 @@ from agents.common.constants import (
 from agents.kyma.prompts import KYMA_AGENT_INSTRUCTIONS, KYMA_AGENT_PROMPT
 from agents.kyma.state import KymaAgentState
 from agents.kyma.tools.query import fetch_kyma_resource_version, kyma_query_tool
-from agents.kyma.tools.search import SEARCH_KYMA_DOC_TOOL_NAME, SearchKymaDocTool
+from agents.kyma.tools.search import SearchKymaDocTool
 from utils.models.factory import IModel
 from utils.settings import GRAPH_STEP_TIMEOUT_SECONDS, MAIN_MODEL_NAME
 
@@ -41,7 +41,7 @@ class KymaAgent(BaseAgent):
             ]
         ).partial(
             kyma_query_tool=kyma_query_tool.name,
-            search_kyma_doc=SEARCH_KYMA_DOC_TOOL_NAME,
+            search_kyma_doc=search_kyma_doc_tool.name,
         )
         super().__init__(
             name=KYMA_AGENT,

--- a/src/agents/kyma/agent.py
+++ b/src/agents/kyma/agent.py
@@ -12,7 +12,7 @@ from agents.common.constants import (
 from agents.kyma.prompts import KYMA_AGENT_INSTRUCTIONS, KYMA_AGENT_PROMPT
 from agents.kyma.state import KymaAgentState
 from agents.kyma.tools.query import fetch_kyma_resource_version, kyma_query_tool
-from agents.kyma.tools.search import SearchKymaDocTool
+from agents.kyma.tools.search import SEARCH_KYMA_DOC_TOOL_NAME, SearchKymaDocTool
 from utils.models.factory import IModel
 from utils.settings import GRAPH_STEP_TIMEOUT_SECONDS, MAIN_MODEL_NAME
 
@@ -26,10 +26,11 @@ class KymaAgent(BaseAgent):
 
     def __init__(self, models: dict[str, IModel | Embeddings]) -> None:
         """Initialize the KymaAgent with necessary tools and models."""
+        search_kyma_doc_tool = SearchKymaDocTool(models)
         tools: list[BaseTool] = [
             fetch_kyma_resource_version,
             kyma_query_tool,
-            SearchKymaDocTool(models),
+            search_kyma_doc_tool,
         ]
         agent_prompt = ChatPromptTemplate.from_messages(
             [
@@ -40,7 +41,7 @@ class KymaAgent(BaseAgent):
             ]
         ).partial(
             kyma_query_tool=kyma_query_tool.name,
-            search_kyma_doc=SearchKymaDocTool(models).name,
+            search_kyma_doc=SEARCH_KYMA_DOC_TOOL_NAME,
         )
         super().__init__(
             name=KYMA_AGENT,

--- a/src/agents/kyma/tools/search.py
+++ b/src/agents/kyma/tools/search.py
@@ -58,11 +58,11 @@ class SearchKymaDocTool(BaseTool):
             return "No relevant documentation found."
         return combined
 
-    async def arun_list(self, query: str) -> list[str]:
+    async def arun_list(self, query: str, top_k: int | None = None) -> list[str]:
         """Async implementation of the search through Kyma documentation. Returns list of document contents."""
         query_obj = Query(text=query)
         relevant_docs = await self.rag_system.aretrieve(
             query_obj,
-            top_k=self.top_k if self.top_k is not None else DEFAULT_TOP_K,
+            top_k=top_k if top_k is not None else (self.top_k if self.top_k is not None else DEFAULT_TOP_K),
         )
         return [doc.page_content for doc in relevant_docs if doc.page_content.strip()]

--- a/src/agents/kyma/tools/search.py
+++ b/src/agents/kyma/tools/search.py
@@ -63,6 +63,6 @@ class SearchKymaDocTool(BaseTool):
         query_obj = Query(text=query)
         relevant_docs = await self.rag_system.aretrieve(
             query_obj,
-            top_k=top_k if top_k is not None else (self.top_k if self.top_k is not None else DEFAULT_TOP_K),
+            top_k=top_k if top_k is not None else (self.top_k or DEFAULT_TOP_K),
         )
         return [doc.page_content for doc in relevant_docs if doc.page_content.strip()]

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -10,6 +10,7 @@ from fastapi import Depends, Header, HTTPException
 from langchain_core.embeddings import Embeddings
 from pydantic import BaseModel, Field
 
+from agents.kyma.tools.search import SearchKymaDocTool
 from services.data_sanitizer import DataSanitizer, IDataSanitizer
 from services.encryption import Encryption
 from services.encryption_cache import EncryptionCache, get_encryption_cache
@@ -251,6 +252,12 @@ class _ModelsCache:
     _instance: dict[str, IModel | Embeddings] | None = None
 
 
+class _SearchToolCache:
+    """Singleton cache for SearchKymaDocTool to avoid reinitializing RAGSystem on every request."""
+
+    _instance: SearchKymaDocTool | None = None
+
+
 def init_models_dict(
     config: Annotated[Config, Depends(init_config)],
 ) -> dict[str, IModel | Embeddings]:
@@ -273,6 +280,20 @@ def init_models_dict(
             ) from e
 
     return _ModelsCache._instance
+
+
+def init_search_tool(
+    models: Annotated[dict[str, IModel | Embeddings], Depends(init_models_dict)],
+) -> SearchKymaDocTool:
+    """
+    Initialize SearchKymaDocTool singleton.
+
+    Instantiates SearchKymaDocTool (and therefore RAGSystem) once and caches it.
+    Uses a class-level cache to avoid reinitializing RAGSystem on every request.
+    """
+    if _SearchToolCache._instance is None:
+        _SearchToolCache._instance = SearchKymaDocTool(models)
+    return _SearchToolCache._instance
 
 
 async def init_k8s_client(

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -267,7 +267,15 @@ class _SearchToolRegistry(metaclass=SingletonMeta):
     """Singleton registry for SearchKymaDocTool to avoid reinitializing RAGSystem on every request."""
 
     def __init__(self, models: dict[str, IModel | Embeddings]):
-        self.tool = SearchKymaDocTool(models)
+        try:
+            self.tool = SearchKymaDocTool(models)
+        except Exception as e:
+            logger.exception("Failed to initialize search tool")
+            SingletonMeta.reset_instance(_SearchToolRegistry)
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail=f"Failed to initialize search tool: {str(e)}",
+            ) from e
 
 
 def init_models_dict(

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -20,6 +20,7 @@ from utils.config import Config, get_config
 from utils.logging import get_logger
 from utils.models.factory import IModel, ModelFactory
 from utils.settings import ENCRYPTION_PRIVATE_KEY_B64
+from utils.singleton_meta import SingletonMeta
 
 logger = get_logger(__name__)
 
@@ -246,16 +247,27 @@ def init_data_sanitizer(
     return DataSanitizer(config.sanitization_config)
 
 
-class _ModelsCache:
-    """Singleton cache for models dict to avoid using global statement."""
+class _ModelsRegistry(metaclass=SingletonMeta):
+    """Singleton registry for the models dictionary."""
 
-    _instance: dict[str, IModel | Embeddings] | None = None
+    def __init__(self, config: Config):
+        try:
+            model_factory = ModelFactory(config=config)
+            self.models: dict[str, IModel | Embeddings] = model_factory.create_models()
+        except Exception as e:
+            logger.exception("Failed to initialize models")
+            SingletonMeta.reset_instance(_ModelsRegistry)
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail=f"Failed to initialize models: {str(e)}",
+            ) from e
 
 
-class _SearchToolCache:
-    """Singleton cache for SearchKymaDocTool to avoid reinitializing RAGSystem on every request."""
+class _SearchToolRegistry(metaclass=SingletonMeta):
+    """Singleton registry for SearchKymaDocTool to avoid reinitializing RAGSystem on every request."""
 
-    _instance: SearchKymaDocTool | None = None
+    def __init__(self, models: dict[str, IModel | Embeddings]):
+        self.tool = SearchKymaDocTool(models)
 
 
 def init_models_dict(
@@ -266,20 +278,9 @@ def init_models_dict(
 
     Creates a dict of model_name -> model instance for use by tools
     that require LLM models and embeddings.
-    Uses a class-level cache to avoid recreating models on every request.
+    Uses SingletonMeta to avoid recreating models on every request.
     """
-    if _ModelsCache._instance is None:
-        try:
-            model_factory = ModelFactory(config=config)
-            _ModelsCache._instance = model_factory.create_models()
-        except Exception as e:
-            logger.exception("Failed to initialize models")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail=f"Failed to initialize models: {str(e)}",
-            ) from e
-
-    return _ModelsCache._instance
+    return _ModelsRegistry(config).models
 
 
 def init_search_tool(
@@ -289,11 +290,9 @@ def init_search_tool(
     Initialize SearchKymaDocTool singleton.
 
     Instantiates SearchKymaDocTool (and therefore RAGSystem) once and caches it.
-    Uses a class-level cache to avoid reinitializing RAGSystem on every request.
+    Uses SingletonMeta to avoid reinitializing RAGSystem on every request.
     """
-    if _SearchToolCache._instance is None:
-        _SearchToolCache._instance = SearchKymaDocTool(models)
-    return _SearchToolCache._instance
+    return _SearchToolRegistry(models).tool
 
 
 async def init_k8s_client(

--- a/src/routers/kyma_tools_api.py
+++ b/src/routers/kyma_tools_api.py
@@ -9,7 +9,6 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException
-from langchain_core.embeddings import Embeddings
 
 from agents.kyma.tools.query import (
     fetch_kyma_resource_version,
@@ -25,12 +24,11 @@ from routers.common import (
     SearchKymaDocRequest,
     SearchKymaDocResponse,
     init_k8s_client,
-    init_models_dict,
+    init_search_tool,
 )
 from services.k8s import IK8sClient
 from utils.exceptions import K8sClientError
 from utils.logging import get_logger
-from utils.models.factory import IModel
 
 logger = get_logger(__name__)
 
@@ -128,7 +126,7 @@ async def get_resource_version(
 @router.post("/search", response_model=SearchKymaDocResponse)
 async def search_kyma_documentation(
     request: Annotated[SearchKymaDocRequest, Body()],
-    models: Annotated[dict[str, IModel | Embeddings], Depends(init_models_dict)],
+    search_tool: Annotated[SearchKymaDocTool, Depends(init_search_tool)],
 ) -> SearchKymaDocResponse:
     """
     Search Kyma documentation using semantic search.
@@ -136,8 +134,7 @@ async def search_kyma_documentation(
     logger.info(f"Search request: query={request.query}")
 
     try:
-        search_tool = SearchKymaDocTool(models=models, top_k=request.top_k)
-        results = await search_tool.arun_list(query=request.query)
+        results = await search_tool.arun_list(query=request.query, top_k=request.top_k)
         logger.info(f"Search completed successfully, returned {len(results)} documents")
         return SearchKymaDocResponse(
             results=results,

--- a/tests/unit/routers/test_common.py
+++ b/tests/unit/routers/test_common.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi import HTTPException
 
-from routers.common import get_k8s_auth_headers_from_encrypted_payload, init_k8s_client, init_models_dict
+from routers.common import (
+    get_k8s_auth_headers_from_encrypted_payload,
+    init_k8s_client,
+    init_models_dict,
+    init_search_tool,
+)
 from services.data_sanitizer import IDataSanitizer
 from services.encryption_cache import IEncryptionCache
 from services.k8s import K8sAuthHeaders
@@ -193,6 +198,60 @@ class TestInitModelsDict:
                 init_models_dict(mock_config)
 
             assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+class TestInitSearchTool:
+    """Tests for init_search_tool dependency (caching behavior)."""
+
+    @pytest.fixture
+    def mock_models(self):
+        return {"gpt-4": Mock()}
+
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        """Reset the search tool registry before each test."""
+        from routers.common import _SearchToolRegistry
+        from utils.singleton_meta import SingletonMeta
+
+        SingletonMeta.reset_instance(_SearchToolRegistry)
+        yield
+        SingletonMeta.reset_instance(_SearchToolRegistry)
+
+    def test_init_search_tool_caches_result(self, mock_models):
+        """Test that init_search_tool caches the tool instance (singleton behavior)."""
+        with patch("routers.common.SearchKymaDocTool") as mock_tool_class:
+            mock_tool = Mock()
+            mock_tool_class.return_value = mock_tool
+
+            result1 = init_search_tool(models=mock_models)
+            result2 = init_search_tool(models=mock_models)
+
+            assert result1 is result2
+            assert mock_tool_class.call_count == 1
+
+    def test_init_search_tool_raises_http_exception_on_error(self, mock_models):
+        """Test that init_search_tool raises HTTPException when tool creation fails."""
+        with patch("routers.common.SearchKymaDocTool") as mock_tool_class:
+            mock_tool_class.side_effect = Exception("RAG initialization failed")
+
+            with pytest.raises(HTTPException) as exc_info:
+                init_search_tool(models=mock_models)
+
+            assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def test_init_search_tool_allows_retry_after_error(self, mock_models):
+        """Test that a failed init does not permanently cache a broken instance."""
+        with patch("routers.common.SearchKymaDocTool") as mock_tool_class:
+            mock_tool_class.side_effect = Exception("transient error")
+            with pytest.raises(HTTPException):
+                init_search_tool(models=mock_models)
+
+        with patch("routers.common.SearchKymaDocTool") as mock_tool_class:
+            mock_tool = Mock()
+            mock_tool_class.return_value = mock_tool
+
+            result = init_search_tool(models=mock_models)
+            assert result is mock_tool
 
 
 @pytest.mark.asyncio

--- a/tests/unit/routers/test_common.py
+++ b/tests/unit/routers/test_common.py
@@ -156,12 +156,13 @@ class TestInitModelsDict:
 
     @pytest.fixture(autouse=True)
     def reset_cache(self):
-        """Reset the models cache before each test."""
-        from routers.common import _ModelsCache
+        """Reset the models registry before each test."""
+        from routers.common import _ModelsRegistry
+        from utils.singleton_meta import SingletonMeta
 
-        _ModelsCache._instance = None
+        SingletonMeta.reset_instance(_ModelsRegistry)
         yield
-        _ModelsCache._instance = None
+        SingletonMeta.reset_instance(_ModelsRegistry)
 
     def test_init_models_dict_caches_result(self, mock_config):
         """Test that init_models_dict caches models dict (singleton behavior)."""


### PR DESCRIPTION
`KymaAgent.__init__` called `SearchKymaDocTool(models)` twice — once for the tools list and once just to read `.name` for the prompt partial — instantiating `RAGSystem` and `LLMReranker` twice on every agent startup. The `POST /api/tools/kyma/search` endpoint had the same problem, reinitializing both on every request. Each initialization loads reranker model weights into memory, doubling the footprint and causing OOMKilled restarts in production (`kyma-companion` pod, memory limit: `1Gi`, 3 restarts observed).

Instantiate `SearchKymaDocTool` once in `KymaAgent.__init__` and reuse it. Use the exported `SEARCH_KYMA_DOC_TOOL_NAME` constant for the prompt partial instead of a throwaway instance. For the search endpoint, introduce `_SearchToolRegistry` using the existing `SingletonMeta` pattern (same as `_ModelsRegistry`, `Redis`, `Hana`, etc.) and inject it via FastAPI `Depends`.

Changes proposed in this pull request:
- instantiate `SearchKymaDocTool` once in `KymaAgent.__init__` and reuse in both tools list and prompt partial
- use exported `SEARCH_KYMA_DOC_TOOL_NAME` constant instead of creating a throwaway instance
- add `_SearchToolRegistry` singleton (via `SingletonMeta`) in `routers/common.py` and `init_search_tool` dependency
- update `POST /api/tools/kyma/search` to use the cached instance instead of instantiating per request
- add `top_k` parameter to `SearchKymaDocTool.arun_list` so per-request `top_k` works without re-instantiation
- add error handling in `_SearchToolRegistry.__init__` with `SingletonMeta.reset_instance` on failure, mirroring `_ModelsRegistry`
- add unit tests for `init_search_tool`: caching, error propagation, and retry-after-failure

**Testing**
Started app locally, hit `POST /api/tools/kyma/search` twice with different queries, both returned results. `Reranker initialized` and `RAG system initialized.` appear exactly once in logs across both requests:
```
{"name": "rag.reranker.reranker", "levelname": "INFO", "message": "Reranker initialized"}
{"name": "rag.system", "levelname": "INFO", "message": "RAG system initialized."}
{"name": "routers.kyma_tools_api", "levelname": "INFO", "message": "Search request: query=What are Kyma components?"}
{"name": "routers.kyma_tools_api", "levelname": "INFO", "message": "Search completed successfully, returned 2 documents"}
{"name": "routers.kyma_tools_api", "levelname": "INFO", "message": "Search request: query=How to troubleshoot Kyma Istio module?"}
{"name": "routers.kyma_tools_api", "levelname": "INFO", "message": "Search completed successfully, returned 3 documents"}
```

**Related issue(s)**
Resolves #1075
