### PR TITLE
feat: fetch logs for all containers when no container name given

### DIFF
--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -121,9 +121,11 @@ class PodLogsRequest(BaseModel):
 class PodLogsResponse(BaseModel):
     """Response model for pod logs."""
 
-    logs: PodLogs = Field(
+    logs: dict[str, PodLogs] = Field(
         ...,
-        description="Container logs with current_container and previously_terminated_container",
+        description=(
+            "Container logs keyed by container name, each with current_container and previously_terminated_container"
+        ),
     )
     diagnostic_context: PodLogsDiagnosticContext | None = Field(
         default=None,

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -572,17 +572,82 @@ class K8sClient:
         """Fetch logs of Kubernetes Pod - attempts both current and previous logs.
 
         Strategy:
-        1. Try fetching both current AND previous logs in parallel
-        2. Return structured response with current_container and previously_terminated_container logs
-        3. If current logs unavailable, include diagnostic_context
+        - If container_name is provided: fetch logs for that container only.
+        - If container_name is empty: discover all containers from the pod spec and
+          fetch logs for all of them in parallel.
 
         Returns:
-            PodLogsResult with logs and optional diagnostic_context
+            PodLogsResult with logs keyed by container name and optional diagnostic_context
 
         Raises:
             K8sClientError: For authentication (401) or authorization (403) errors
+            NoLogsAvailableError: When no logs or diagnostic info is available for any container
         """
-        # Step 1: Try fetching both current and previous logs in parallel
+        if container_name:
+            return await self._fetch_single_container_logs(name, namespace, container_name, tail_limit)
+
+        # Discover all containers from the pod spec
+        container_names = self._get_pod_container_names(name, namespace)
+        if not container_names:
+            # Fall back to fetching without a container name (k8s picks the first)
+            return await self._fetch_single_container_logs(name, namespace, "", tail_limit)
+
+        # Fetch logs for all containers in parallel
+        tasks = [
+            asyncio.create_task(self._fetch_single_container_logs(name, namespace, cname, tail_limit))
+            for cname in container_names
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        logs: dict[str, PodLogs] = {}
+        diagnostic_context: PodLogsDiagnosticContext | None = None
+        response_status_code: int = HTTPStatus.OK
+
+        for cname, result in zip(container_names, results, strict=False):
+            if isinstance(result, K8sClientError) and self._is_auth_error(result):
+                raise result
+            if isinstance(result, BaseException):
+                # Skip containers with no data, collect others
+                continue
+            logs[cname] = next(iter(result.logs.values()))
+            if result.diagnostic_context is not None and diagnostic_context is None:
+                diagnostic_context = result.diagnostic_context
+            if result.status_code != HTTPStatus.OK and response_status_code == HTTPStatus.OK:
+                response_status_code = result.status_code
+
+        if not logs:
+            raise NoLogsAvailableError(
+                message=f"No logs or diagnostic information available for pod '{name}' in namespace '{namespace}'",
+                pod=name,
+                namespace=namespace,
+                container="",
+            )
+
+        return PodLogsResult(
+            logs=logs,
+            diagnostic_context=diagnostic_context,
+            status_code=response_status_code,
+        )
+
+    def _get_pod_container_names(self, name: str, namespace: str) -> list[str]:
+        """Return the list of container names for a pod, or empty list on error."""
+        try:
+            pod = self.get_resource("v1", "Pod", name, namespace)
+            containers: list[dict] = pod.get("spec", {}).get("containers", [])
+            return [c["name"] for c in containers if c.get("name")]
+        except Exception:
+            logger.warning(f"Could not retrieve container list for pod '{name}' in namespace '{namespace}'")
+            return []
+
+    async def _fetch_single_container_logs(
+        self,
+        name: str,
+        namespace: str,
+        container_name: str,
+        tail_limit: int,
+    ) -> PodLogsResult:
+        """Fetch logs for a single container. Returns PodLogsResult with one entry in logs dict."""
+        # Try fetching both current and previous logs in parallel
         current_task = asyncio.create_task(
             self._try_fetch_logs(name, namespace, container_name, previous=False, tail_limit=tail_limit)
         )
@@ -593,34 +658,28 @@ class K8sClient:
         has_current_logs, current_logs, current_error = await current_task
         has_previous_logs, previous_logs, previous_error = await previous_task
 
-        # Step 2: Check for authentication/authorization errors - these should fail fast
-        # Check current logs error first as it's more critical
+        # Check for authentication/authorization errors - these should fail fast
         if current_error is not None and self._is_auth_error(current_error):
             raise current_error
-        # Also check previous logs error in case current succeeded but previous failed due to auth
         if previous_error is not None and self._is_auth_error(previous_error):
             raise previous_error
 
-        # Step 3: Build structured response
         current_container_logs: str
         previously_terminated_container_logs: str
         has_diagnostic_info = False
         diagnostic_context: PodLogsDiagnosticContext | None = None
-        response_status_code: int = HTTPStatus.OK  # Default to 200
+        response_status_code: int = HTTPStatus.OK
 
         # Current logs section
         if has_current_logs and current_logs is not None:
             current_container_logs = "\n".join(current_logs)
         else:
-            # Current logs failed - provide explanation
             current_container_logs = f"Logs not available. {self._get_error_reason(current_error)}"
 
-            # Add diagnostic context when current logs unavailable
             has_diagnostic_info, diagnostic_context = await self._gather_pod_diagnostic_context_structured(
                 name, namespace, container_name, tail_limit
             )
 
-            # Forward the status code from K8s API (e.g., 400 for invalid container)
             if isinstance(current_error, K8sClientError):
                 response_status_code = current_error.status_code
 
@@ -628,7 +687,6 @@ class K8sClient:
         if has_previous_logs and previous_logs is not None:
             previously_terminated_container_logs = "\n".join(previous_logs)
         else:
-            # Previous logs not available - this is often expected
             if isinstance(previous_error, K8sClientError):
                 if previous_error.status_code in (HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND):
                     previously_terminated_container_logs = "Not available (container has not been restarted)"
@@ -637,7 +695,6 @@ class K8sClient:
             else:
                 previously_terminated_container_logs = f"Failed to fetch. {self._get_error_reason(previous_error)}"
 
-        # Check if we have any meaningful data - if not, raise exception
         has_any_data = has_current_logs or has_previous_logs or has_diagnostic_info
         if not has_any_data:
             raise NoLogsAvailableError(
@@ -647,11 +704,14 @@ class K8sClient:
                 container=container_name,
             )
 
+        log_key = container_name if container_name else name
         return PodLogsResult(
-            logs=PodLogs(
-                current_container=current_container_logs,
-                previously_terminated_container=previously_terminated_container_logs,
-            ),
+            logs={
+                log_key: PodLogs(
+                    current_container=current_container_logs,
+                    previously_terminated_container=previously_terminated_container_logs,
+                )
+            },
             diagnostic_context=diagnostic_context,
             status_code=response_status_code,
         )

--- a/src/services/k8s_models.py
+++ b/src/services/k8s_models.py
@@ -60,7 +60,9 @@ class PodLogs(BaseModel):
 class PodLogsResult(BaseModel):
     """Complete container logs result with optional diagnostic context."""
 
-    logs: PodLogs = Field(..., description="Container logs for current and previously terminated container instances")
+    logs: dict[str, PodLogs] = Field(
+        ..., description="Container logs keyed by container name, each with current and previously terminated instances"
+    )
     diagnostic_context: PodLogsDiagnosticContext | None = Field(
         default=None,
         description="Optional diagnostic information when current container logs are unavailable",

--- a/tests/blackbox/src/api_tests/test_tools_api.py
+++ b/tests/blackbox/src/api_tests/test_tools_api.py
@@ -158,8 +158,10 @@ class TestK8sToolsAPI:
             logs_data = logs_response.json()
             assert "logs" in logs_data
             assert isinstance(logs_data["logs"], dict)
-            assert "current_container" in logs_data["logs"]
-            assert "previously_terminated_container" in logs_data["logs"]
+            # logs is keyed by container name; each entry has current and previous logs
+            for _container, container_logs in logs_data["logs"].items():
+                assert "current_container" in container_logs
+                assert "previously_terminated_container" in container_logs
             assert "pod_name" in logs_data
             assert logs_data["pod_name"] == pod_name
             logger.info(f"Successfully retrieved logs for pod {pod_name}")

--- a/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
+++ b/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
@@ -288,8 +288,10 @@ class TestK8sToolsAPI:
             logs_data = logs_response.json()
             assert "logs" in logs_data
             assert isinstance(logs_data["logs"], dict)
-            assert "current_container" in logs_data["logs"]
-            assert "previously_terminated_container" in logs_data["logs"]
+            # logs is keyed by container name; each entry has current and previous logs
+            for _container, container_logs in logs_data["logs"].items():
+                assert "current_container" in container_logs
+                assert "previously_terminated_container" in container_logs
             assert "pod_name" in logs_data
             assert logs_data["pod_name"] == pod_name
             logger.info(f"Successfully retrieved logs for pod {pod_name}")

--- a/tests/integration/services/test_k8s.py
+++ b/tests/integration/services/test_k8s.py
@@ -385,15 +385,15 @@ class TestK8sClient:
         # the return type should be PodLogsResult (Pydantic model).
         assert result is not None
         assert hasattr(result, "logs")
-        assert hasattr(result.logs, "current_container")
-        assert hasattr(result.logs, "previously_terminated_container")
+        assert isinstance(result.logs, dict)
+        assert container_name in result.logs
 
         # Current logs should be a string
-        assert isinstance(result.logs.current_container, str)
-        assert result.logs.current_container != ""
+        assert isinstance(result.logs[container_name].current_container, str)
+        assert result.logs[container_name].current_container != ""
 
         # Previous logs might not be available for running pods
-        assert isinstance(result.logs.previously_terminated_container, str)
+        assert isinstance(result.logs[container_name].previously_terminated_container, str)
 
     @pytest.mark.parametrize(
         "given_kind, expected_api_version",

--- a/tests/unit/agents/k8s/tools/test_logs.py
+++ b/tests/unit/agents/k8s/tools/test_logs.py
@@ -30,8 +30,10 @@ class ToolTestState(TypedDict):
             None,
             {
                 "logs": {
-                    "current_container": "line 1\nline 2\nline 3",
-                    "previously_terminated_container": "Not available (container has not been restarted)",
+                    "my-container": {
+                        "current_container": "line 1\nline 2\nline 3",
+                        "previously_terminated_container": "Not available (container has not been restarted)",
+                    }
                 },
                 "diagnostic_context": None,
                 "status_code": 200,
@@ -77,10 +79,14 @@ async def test_fetch_pod_logs_tool(
         from services.k8s_models import PodLogs, PodLogsResult
 
         k8s_client.fetch_pod_logs.return_value = PodLogsResult(
-            logs=PodLogs(
-                current_container=expected_logs_dict["logs"]["current_container"],
-                previously_terminated_container=expected_logs_dict["logs"]["previously_terminated_container"],
-            ),
+            logs={
+                given_container_name: PodLogs(
+                    current_container=expected_logs_dict["logs"][given_container_name]["current_container"],
+                    previously_terminated_container=expected_logs_dict["logs"][given_container_name][
+                        "previously_terminated_container"
+                    ],
+                )
+            },
             diagnostic_context=expected_logs_dict["diagnostic_context"],
             status_code=expected_logs_dict["status_code"],
         )

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -94,6 +94,9 @@ class MockK8sClient(IK8sClient):
                 uri=f"/api/v1/namespaces/{namespace}/pods/{name}/log",
             )
 
+        # Determine the key to use for the logs dict
+        log_key = container_name if container_name else name
+
         # Return different scenarios based on logs_scenario parameter
         if self.logs_scenario == "no_logs_no_diagnostic":
             # No logs and no diagnostic information - raise exception
@@ -106,10 +109,12 @@ class MockK8sClient(IK8sClient):
         elif self.logs_scenario == "no_logs_with_diagnostic":
             # No logs but has diagnostic information
             return PodLogsResult(
-                logs=PodLogs(
-                    current_container="Logs not available. Container is waiting",
-                    previously_terminated_container="Not available (container has not been restarted)",
-                ),
+                logs={
+                    log_key: PodLogs(
+                        current_container="Logs not available. Container is waiting",
+                        previously_terminated_container="Not available (container has not been restarted)",
+                    )
+                },
                 diagnostic_context=PodLogsDiagnosticContext(
                     events="LAST SEEN   TYPE      REASON    MESSAGE\n"
                     "2m ago      Warning   Failed    Failed to pull image",
@@ -126,31 +131,51 @@ class MockK8sClient(IK8sClient):
         elif self.logs_scenario == "previous_logs_only":
             # Only previous logs available
             return PodLogsResult(
-                logs=PodLogs(
-                    current_container="Logs not available. Container restarted",
-                    previously_terminated_container="Previous log line 1\nPrevious log line 2",
-                ),
+                logs={
+                    log_key: PodLogs(
+                        current_container="Logs not available. Container restarted",
+                        previously_terminated_container="Previous log line 1\nPrevious log line 2",
+                    )
+                },
             )
         elif self.logs_scenario == "invalid_container":
             # Invalid container name - return result with 400 status code
             return PodLogsResult(
-                logs=PodLogs(
-                    current_container=f"Logs not available. container {container_name} is not valid for pod {name}",
-                    previously_terminated_container="Not available (container has not been restarted)",
-                ),
+                logs={
+                    log_key: PodLogs(
+                        current_container=f"Logs not available. container {container_name} is not valid for pod {name}",
+                        previously_terminated_container="Not available (container has not been restarted)",
+                    )
+                },
                 diagnostic_context=PodLogsDiagnosticContext(
                     events="No recent pod events found.",
                     container_statuses={"nginx": ContainerStatus(state="Running", restart_count=0)},
                 ),
                 status_code=HTTPStatus.BAD_REQUEST,
             )
+        elif self.logs_scenario == "multi_container":
+            # Multiple containers returned when no container_name specified
+            return PodLogsResult(
+                logs={
+                    "main": PodLogs(
+                        current_container="Main container log line 1",
+                        previously_terminated_container="Not available (container has not been restarted)",
+                    ),
+                    "sidecar": PodLogs(
+                        current_container="Sidecar log line 1",
+                        previously_terminated_container="Not available (container has not been restarted)",
+                    ),
+                },
+            )
         else:
             # Default success scenario
             return PodLogsResult(
-                logs=PodLogs(
-                    current_container="Log line 1\nLog line 2\nLog line 3",
-                    previously_terminated_container="Not available (container has not been restarted)",
-                ),
+                logs={
+                    log_key: PodLogs(
+                        current_container="Log line 1\nLog line 2\nLog line 3",
+                        previously_terminated_container="Not available (container has not been restarted)",
+                    )
+                },
             )
 
     def list_not_running_pods(self, namespace: str) -> list[dict]:

--- a/tests/unit/routers/test_k8s_tools_api.py
+++ b/tests/unit/routers/test_k8s_tools_api.py
@@ -73,8 +73,10 @@ class TestLogsEndpoint:
         response_data = response.json()
         assert "logs" in response_data
         assert isinstance(response_data["logs"], dict)
-        assert "current_container" in response_data["logs"]
-        assert "previously_terminated_container" in response_data["logs"]
+        # When no container_name is given, logs dict is keyed by pod name
+        for _container, logs in response_data["logs"].items():
+            assert "current_container" in logs
+            assert "previously_terminated_container" in logs
 
     def test_logs_with_container_name(self, k8s_client_factory):
         """Test fetching logs with specific container name."""
@@ -94,6 +96,31 @@ class TestLogsEndpoint:
         )
 
         assert response.status_code == HTTPStatus.OK
+
+    def test_logs_returns_all_containers_when_no_container_name(self, k8s_client_factory):
+        """Test that logs for all containers are returned when no container_name is given."""
+        client = k8s_client_factory(logs_scenario="multi_container")
+        headers = get_sample_headers()
+        request_body = {
+            "name": "test-pod",
+            "namespace": "default",
+            # no container_name
+        }
+
+        response = client.post(
+            "/api/tools/k8s/pods/logs",
+            json=request_body,
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        response_data = response.json()
+        assert "logs" in response_data
+        assert isinstance(response_data["logs"], dict)
+        assert "main" in response_data["logs"]
+        assert "sidecar" in response_data["logs"]
+        assert "Main container log line 1" in response_data["logs"]["main"]["current_container"]
+        assert "Sidecar log line 1" in response_data["logs"]["sidecar"]["current_container"]
 
     def test_logs_handles_fetch_error(self, k8s_client_factory):
         """Test that logs endpoint handles fetch errors gracefully."""
@@ -180,6 +207,8 @@ class TestLogsEndpoint:
         # Verify diagnostic context has useful information
         assert "Failed to pull image" in response_data["diagnostic_context"]["events"]
         assert "container_statuses" in response_data["diagnostic_context"]
+        # logs is now a dict keyed by container name
+        assert isinstance(response_data["logs"], dict)
 
     def test_logs_returns_200_when_only_previous_logs_available(self, k8s_client_factory):
         """Test that 200 is returned when only previous logs are available."""
@@ -200,10 +229,12 @@ class TestLogsEndpoint:
         assert response.status_code == HTTPStatus.OK
         response_data = response.json()
         assert "logs" in response_data
+        assert isinstance(response_data["logs"], dict)
+        container_logs = response_data["logs"]["main"]
         # Current logs should indicate unavailability
-        assert "Logs not available" in response_data["logs"]["current_container"]
+        assert "Logs not available" in container_logs["current_container"]
         # Previous logs should contain actual log content
-        assert "Previous log line 1" in response_data["logs"]["previously_terminated_container"]
+        assert "Previous log line 1" in container_logs["previously_terminated_container"]
 
     def test_logs_returns_400_for_invalid_container(self, k8s_client_factory):
         """Test that 400 is returned with diagnostic context for invalid container name."""
@@ -226,8 +257,10 @@ class TestLogsEndpoint:
         # Should have normal response structure
         assert "logs" in response_data
         assert "diagnostic_context" in response_data
+        assert isinstance(response_data["logs"], dict)
+        container_logs = response_data["logs"]["_nginx"]
         # Error message should be in current_container
-        assert "not valid for pod" in response_data["logs"]["current_container"]
+        assert "not valid for pod" in container_logs["current_container"]
         # Diagnostic context should show valid containers
         assert response_data["diagnostic_context"] is not None
         assert "container_statuses" in response_data["diagnostic_context"]

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -1149,11 +1149,11 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Should show current logs successfully
-            current_logs = result.logs.current_container
+            current_logs = result.logs["app"].current_container
             assert all(line in current_logs for line in expected_sanitized_logs)
 
             # Should show previous logs not available (error message)
-            previous_logs = result.logs.previously_terminated_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not found" in previous_logs.lower() or "not available" in previous_logs.lower()
 
     @pytest.mark.asyncio
@@ -1238,7 +1238,7 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Should show current logs not available with diagnostic info
-            current_logs = result.logs.current_container
+            current_logs = result.logs["app"].current_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
 
             # Should have diagnostic context
@@ -1247,7 +1247,7 @@ class TestK8sClient:
             assert "Container is in CrashLoopBackOff state" in diagnostic_str
 
             # Should show previous logs successfully
-            previous_logs = result.logs.previously_terminated_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert all(line in previous_logs for line in expected_logs)
 
     @pytest.mark.asyncio
@@ -1307,8 +1307,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both current and previous logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1382,7 +1382,7 @@ class TestK8sClient:
             assert hasattr(result, "logs")
 
             # Current logs should succeed after retries
-            current_logs = result.logs.current_container
+            current_logs = result.logs["app"].current_container
             assert all(line in current_logs for line in success_logs)
 
             # Should have slept twice (after first and second failures)
@@ -1442,8 +1442,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1512,8 +1512,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or "failed" in current_logs.lower() or len(current_logs) == 0
             assert (
                 "failed" in previous_logs.lower() or "not available" in previous_logs.lower() or len(previous_logs) == 0
@@ -1650,8 +1650,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
 
             # Previous logs status depends on error code
@@ -1745,8 +1745,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1835,8 +1835,8 @@ class TestK8sClient:
             assert hasattr(result, "diagnostic_context")
 
             # Both logs should be error messages or empty
-            current_logs = result.logs.current_container
-            previous_logs = result.logs.previously_terminated_container
+            current_logs = result.logs["app"].current_container
+            previous_logs = result.logs["app"].previously_terminated_container
             assert "not available" in current_logs.lower() or len(current_logs) == 0
             assert "not available" in previous_logs.lower() or len(previous_logs) == 0
 
@@ -1953,12 +1953,66 @@ class TestK8sClient:
 
             # then: result should have 400 status code and diagnostic context
             assert result.status_code == HTTPStatus.BAD_REQUEST
-            assert "not valid for pod" in result.logs.current_container
+            assert "not valid for pod" in result.logs["_nginx"].current_container
             assert result.diagnostic_context is not None
             assert "nginx" in result.diagnostic_context.container_statuses
 
+    @pytest.mark.asyncio
+    async def test_fetch_pod_logs_all_containers_when_no_container_name(self, k8s_client):
+        """Test that when no container_name is given, logs are fetched for all containers."""
+        k8s_client.api_server = "https://api.example.com"
+        k8s_client.k8s_auth_headers = K8sAuthHeaders(
+            x_cluster_url=k8s_client.api_server,
+            x_cluster_certificate_authority_data="abc",
+            x_k8s_authorization="test-token",
+            x_client_certificate_data=None,
+            x_client_key_data=None,
+        )
+        k8s_client.data_sanitizer = None
 
-class TestParseContainerState:
+        # Mock get_resource to return pod with two containers
+        k8s_client.get_resource = Mock(
+            return_value={
+                "spec": {
+                    "containers": [
+                        {"name": "main"},
+                        {"name": "sidecar"},
+                    ]
+                }
+            }
+        )
+
+        with aioresponses() as aio_mock_response:
+            for container in ("main", "sidecar"):
+                current_url = (
+                    f"{k8s_client.api_server}/api/v1/namespaces/default/pods/test-pod/log"
+                    f"?container={container}&tailLines=100"
+                )
+                previous_url = (
+                    f"{k8s_client.api_server}/api/v1/namespaces/default/pods/test-pod/log"
+                    f"?container={container}&tailLines=100&previous=true"
+                )
+                aio_mock_response.get(current_url, body=f"{container} log line 1", status=HTTPStatus.OK)
+                aio_mock_response.get(
+                    previous_url,
+                    body='{"message": "not found"}',
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+
+            result = await k8s_client.fetch_pod_logs(
+                name="test-pod",
+                namespace="default",
+                container_name="",
+                tail_limit=100,
+            )
+
+        assert result is not None
+        assert isinstance(result.logs, dict)
+        assert "main" in result.logs
+        assert "sidecar" in result.logs
+        assert "main log line 1" in result.logs["main"].current_container
+        assert "sidecar log line 1" in result.logs["sidecar"].current_container
+
     """Test _parse_container_state helper method."""
 
     @pytest.mark.asyncio


### PR DESCRIPTION
When the logs endpoint is called without a `container_name`, it previously fetched logs for a single (default) container. For multi-container pods this meant the caller had to know the container name upfront and make multiple requests to get logs from all containers.

When `container_name` is empty, the endpoint now discovers all containers from the pod spec and fetches their logs in parallel. The response `logs` field is now a `dict[str, PodLogs]` keyed by container name, which also makes single-container responses self-describing.

Changes proposed in this pull request:

- change `PodLogsResult.logs` and `PodLogsResponse.logs` from `PodLogs` to `dict[str, PodLogs]`
- add `_fetch_single_container_logs` to handle one container (current + previous logs in parallel)
- add `_get_pod_container_names` to read container names from the pod spec
- update `fetch_pod_logs` to dispatch: single container when `container_name` is given, all containers in parallel when it is empty
- update all unit, integration, and blackbox tests to match the new response structure

**Testing**

Tested against a local k3d cluster with purpose-built pods in namespace `log-test`:
- `single-running` — 1 container (`app`), running
- `multi-running` — 2 containers (`frontend`, `backend`), both running
- `crash-loop` — 1 container (`crasher`), CrashLoopBackOff
- `image-pull-fail` — 1 container (`app`), ImagePullBackOff

All requests:
```
curl -s -X POST http://localhost:8000/api/tools/k8s/pods/logs \
  -H "Content-Type: application/json" \
  -H "x-cluster-url: $K3D_SERVER" \
  -H "x-cluster-certificate-authority-data: $K3D_CA" \
  -H "x-client-certificate-data: $K3D_CERT" \
  -H "x-client-key-data: $K3D_KEY" \
  -d '<body>'
```

**1. Single-container, explicit `container_name`**

`{"name": "single-running", "namespace": "log-test", "container_name": "app", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "app": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 single-container log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "pod_name": "single-running",
  "container_name": "app"
}
```

**2. Single-container, no `container_name` — auto-discovers the one container**

`{"name": "single-running", "namespace": "log-test", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "app": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 single-container log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "pod_name": "single-running",
  "container_name": ""
}
```

**3. Multi-container, no `container_name` — all containers returned**

`{"name": "multi-running", "namespace": "log-test", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "frontend": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 frontend log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    },
    "backend": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 backend log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "pod_name": "multi-running",
  "container_name": ""
}
```

**4. Multi-container, explicit `container_name=frontend`**

`{"name": "multi-running", "namespace": "log-test", "container_name": "frontend", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "frontend": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 frontend log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "pod_name": "multi-running",
  "container_name": "frontend"
}
```

**5. Multi-container, explicit `container_name=backend`**

`{"name": "multi-running", "namespace": "log-test", "container_name": "backend", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "backend": {
      "current_container": "Fri Apr  3 13:05:43 UTC 2026 backend log line\n...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "pod_name": "multi-running",
  "container_name": "backend"
}
```

**6. CrashLoopBackOff — current + previous logs both present**

`{"name": "crash-loop", "namespace": "log-test", "tail_lines": 5}`

```json
HTTP 200
{
  "logs": {
    "crasher": {
      "current_container": "starting up\nabout to crash",
      "previously_terminated_container": "unable to retrieve container logs for containerd://3d7d356..."
    }
  },
  "pod_name": "crash-loop",
  "container_name": ""
}
```

**7. ImagePullBackOff — no logs, diagnostic context with events and container status**

`{"name": "image-pull-fail", "namespace": "log-test", "container_name": "app", "tail_lines": 5}`

```json
HTTP 400
{
  "logs": {
    "app": {
      "current_container": "Logs not available. Failed to fetch logs for pod image-pull-fail...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "diagnostic_context": {
    "events": "Recent Pod Events:\n  [Failed] (x5) Error: ImagePullBackOff\n  [BackOff] (x5) Back-off pulling image \"this-image-does-not-exist-xyz:latest\"\n  [Failed] (x4) Error: ErrImagePull\n...",
    "container_statuses": {
      "app": {
        "state": "Waiting",
        "reason": "ImagePullBackOff",
        "message": "Back-off pulling image \"this-image-does-not-exist-xyz:latest\"",
        "restartCount": 0
      }
    }
  },
  "pod_name": "image-pull-fail",
  "container_name": "app"
}
```

**8. Invalid `container_name` — 400 with diagnostic context showing valid containers**

`{"name": "single-running", "namespace": "log-test", "container_name": "nonexistent", "tail_lines": 5}`

```json
HTTP 400
{
  "logs": {
    "nonexistent": {
      "current_container": "Logs not available. Failed to fetch logs for pod single-running... container nonexistent is not valid...",
      "previously_terminated_container": "Not available (container has not been restarted)"
    }
  },
  "diagnostic_context": {
    "events": "Recent Pod Events:\n  [Started] Started container app\n...",
    "container_statuses": {
      "app": {
        "state": "Running",
        "restartCount": 0
      }
    }
  },
  "pod_name": "single-running",
  "container_name": "nonexistent"
}
```

**Related issue(s)**
Resolves #1040
