### PR TITLE
fix: pull request triggers

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,7 +2,7 @@ name: Lint PR Title
 run-name: ${{github.event.pull_request.title}}
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image for Indexer
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image LangFuse
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -1,6 +1,6 @@
 name: Pull Gitleaks
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 env:

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "external-images.yaml"
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:
       - main


### PR DESCRIPTION
## Description

Switch 6 workflows from `pull_request_target` to `pull_request`. These workflows do not access named secrets and do not check out PR head code in a privileged context — `pull_request_target` was unnecessary.

| Workflow | Before | After |
|:--|:--|:--|
| `pull-gitleaks.yml` | `pull_request_target` | `pull_request` |
| `lint-pr-title.yml` | `pull_request_target` | `pull_request` |
| `pull-build-image.yaml` | `pull_request_target` | `pull_request` |
| `pull-build-langfuse.yaml` | `pull_request_target` | `pull_request` |
| `pull-build-image-indexer.yaml` | `pull_request_target` | `pull_request` |
| `sync-external-images.yml` | `push` + `pull_request_target` | `push` + `pull_request` |

The remaining `pull_request_target` workflows (`pull-integration-test`, `pull-evaluation-tests`, `pull-api-tests`, `pull-tests-doc-indexer`, `pull-request-comment`) require either named secrets or a write token for fork PRs and will be addressed separately via the `workflow_run` privilege-split pattern.