### PR TITLE
fix: doc indexer workflow fails if PR author is not a codeowner

### DIFF
--- a/.github/github-comment.yaml
+++ b/.github/github-comment.yaml
@@ -1,5 +1,5 @@
 post:
-  pr-notes:
+  pr-notes-codeowner:
     template: |
       ## Note(s) for PR Author:
       - The integration test will be skipped for the PR. You can trigger it manually after adding the label: `run-integration-test`.
@@ -9,3 +9,15 @@ post:
       - If any changes are made to how to run the unit tests, make sure to update the steps for unit-tests in the create-release.yml workflow as well.
       ## Note(s) for PR Reviewer(s):
       - Make sure that the integration and evaluation tests are working as expected.
+  pr-notes-external:
+    template: |
+      ## Note(s) for PR Author:
+      - You are an external contributor. Workflows that require secrets will fail by design.
+      - A codeowner can apply the `ok-to-test` label to allow those workflows to run on your PR.
+      - The integration test will be skipped for the PR. A codeowner can trigger it manually after adding the label: `run-integration-test`.
+      - The evaluation test will be skipped for the PR. A codeowner can trigger it manually after adding the label: `evaluation requested`.
+      - If any changes are made to the evaluation tests data, make sure that the integration tests are working as expected.
+      - If any changes are made to how to run the unit tests, make sure to update the steps for unit-tests in the create-release.yml workflow as well.
+      ## Note(s) for PR Reviewer(s):
+      - Make sure that the integration and evaluation tests are working as expected.
+      - If you trust this PR, apply the `ok-to-test` label to allow secret-dependent workflows to run.

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -28,6 +28,7 @@ jobs:
               });
               core.setOutput('is-codeowner', 'true');
             } catch {
+              // Note: both 403 (token lacks org read scope) and 404 (not a member) are treated as external contributor.
               core.setOutput('is-codeowner', 'false');
             }
 

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -9,24 +9,51 @@ on:
 
 permissions:
   pull-requests: write
+
 jobs:
   comment:
     name: Notes for PR
     runs-on: ubuntu-latest
     steps:
+      - name: Check if PR author is a codeowner
+        id: check-author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: 'kyma-project',
+                team_slug: 'ai-force',
+                username: context.payload.pull_request.user.login,
+              });
+              core.setOutput('is-codeowner', 'true');
+            } catch {
+              core.setOutput('is-codeowner', 'false');
+            }
+
       - name: Install comment cli
         uses: shmokmt/actions-setup-github-comment@v2.1.1
 
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Post comment
+      - name: Post comment (codeowner)
+        if: steps.check-author.outputs.is-codeowner == 'true'
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GH_COMMENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_COMMENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           github-comment post \
-            --template-key pr-notes \
+            --template-key pr-notes-codeowner \
             --config .github/github-comment.yaml
 
+      - name: Post comment (external contributor)
+        if: steps.check-author.outputs.is-codeowner == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_COMMENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          github-comment post \
+            --template-key pr-notes-external \
+            --config .github/github-comment.yaml
 

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check if PR author is a codeowner
         id: check-author
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -27,10 +27,10 @@ jobs:
                 username: context.payload.pull_request.user.login,
               });
               core.setOutput('is-codeowner', 'true');
-            } catch {
-              // Note: both 403 (token lacks org read scope) and 404 (not a member) are treated as external contributor.
-              core.setOutput('is-codeowner', 'false');
-            }
+            } catch (e) {
+            core.warning(`Team membership check failed: ${e.status} ${e.message}`);
+            core.setOutput('is-codeowner', 'false');
+            }    
 
       - name: Install comment cli
         uses: shmokmt/actions-setup-github-comment@v2.1.1

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -32,7 +32,7 @@ jobs:
 
   tests:
     needs: check-author
-    if: success()
+    if: ${{ needs.check-author.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -12,28 +12,27 @@ on:
 jobs:
   check-author:
     runs-on: ubuntu-latest
-    outputs:
-      is-codeowner: ${{ steps.check.outputs.result }}
     steps:
       - name: Check if PR author is a codeowner
-        id: check
         uses: actions/github-script@v8
         with:
           script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.includes('ok-to-test')) return;
             try {
               await github.rest.teams.getMembershipForUserInOrg({
                 org: 'kyma-project',
                 team_slug: 'ai-force',
                 username: context.payload.pull_request.user.login,
               });
-              return true;
             } catch {
-              return false;
+              core.setFailed(`PR author ${context.payload.pull_request.user.login} is not a codeowner. Apply the 'ok-to-test' label to allow tests to run.`);
+              return;
             }
 
   tests:
     needs: check-author
-    if: needs.check-author.outputs.is-codeowner == 'true'
+    if: success()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

- `pull-tests-doc-indexer.yaml`: workflow now fails explicitly for non-codeowners instead of silently skipping. Added `ok-to-test` label as a codeowner override - if the label is present, the membership check is bypassed.
- `pull-request-comment.yaml`: checks team membership on PR open and posts a tailored comment - codeowners get the standard notes, external contributors get an explanation of the authorization model and how to request the `ok-to-test` label.
- `github-comment.yaml`: split `pr-notes` into `pr-notes-codeowner` and `pr-notes-external` templates.