### PR TITLE
fix: add codeowner auth gate to pull_request_target workflows

### DIFF
--- a/.github/github-comment.yaml
+++ b/.github/github-comment.yaml
@@ -4,7 +4,7 @@ post:
       ## Note(s) for PR Author:
       - The integration test will be skipped for the PR. You can trigger it manually after adding the label: `run-integration-test`.
       - The evaluation test will be skipped for the PR. You can trigger it manually after adding the label: `evaluation requested`.
-      - The doc-indexer tests run automatically if the PR author is a codeowner.
+      - The doc-indexer tests run automatically if the PR author is a codeowner or the PR is approved by a codeowner.
       - If any changes are made to the evaluation tests data, make sure that the integration tests are working as expected.
       - If any changes are made to how to run the unit tests, make sure to update the steps for unit-tests in the create-release.yml workflow as well.
       ## Note(s) for PR Reviewer(s):
@@ -13,11 +13,11 @@ post:
     template: |
       ## Note(s) for PR Author:
       - You are an external contributor. Workflows that require secrets will fail by design.
-      - A codeowner can apply the `ok-to-test` label to allow those workflows to run on your PR.
+      - A codeowner must approve the PR to allow secret-dependent workflows to run.
       - The integration test will be skipped for the PR. A codeowner can trigger it manually after adding the label: `run-integration-test`.
       - The evaluation test will be skipped for the PR. A codeowner can trigger it manually after adding the label: `evaluation requested`.
       - If any changes are made to the evaluation tests data, make sure that the integration tests are working as expected.
       - If any changes are made to how to run the unit tests, make sure to update the steps for unit-tests in the create-release.yml workflow as well.
       ## Note(s) for PR Reviewer(s):
       - Make sure that the integration and evaluation tests are working as expected.
-      - If you trust this PR, apply the `ok-to-test` label to allow secret-dependent workflows to run.
+      - If you trust this PR, approve it to allow secret-dependent workflows to run.

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -13,19 +13,28 @@ on:
       - ".github/workflows/pull-api-tests.yaml"
       - ".github/workflows/evaluation-test-reusable.yaml"
 
+permissions: read-all
+
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   wait-for-build:
     name: Wait for image build job
-    runs-on: ubuntu-latest
+    needs: authorize
     if: contains(github.event.pull_request.labels.*.name, 'api-tests')
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -7,19 +7,28 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   wait-for-build:
     name: Wait for image build job
-    runs-on: ubuntu-latest
+    needs: authorize
     if: contains(github.event.pull_request.labels.*.name, 'evaluation requested')
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -1,5 +1,8 @@
 name: Integration Test
 
+## **IMPORTANT**: If any changes are made to how to run the integration tests. Make sure to update the steps for
+## integration-tests in the create-release.yml workflow as well.
+
 on:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
@@ -7,34 +10,40 @@ on:
       - "main"
       - "release-**"
 
-## **IMPORTANT**: If any changes are made to how to run the integration tests. Make sure to update the steps for
-## integration-tests in the create-release.yml workflow as well.
 permissions: read-all
 
 jobs:
-  integration-test:
-    if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
+  authorize:
     runs-on: ubuntu-latest
     steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
+  integration-test:
+    needs: authorize
+    if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract Python version
-        id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: poetry install --with dev
@@ -43,5 +52,5 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
         run: |
-          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > $GITHUB_WORKSPACE/config/config.json
+          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
           poetry run poe test-integration

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -1,4 +1,4 @@
-name: pull-tests-doc-indexer
+name: Doc Indexer Tests
 
 on:
   pull_request_target:
@@ -36,7 +36,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract Python version
-        id: python-version
         working-directory: ./doc_indexer
         run: |
           ../scripts/shell/extract-python-version.sh

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -98,7 +98,7 @@ jobs:
     name: Tests (${{ matrix.test-type }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -111,7 +111,7 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -14,31 +14,12 @@ permissions: read-all
 jobs:
   check-author:
     runs-on: ubuntu-latest
-    outputs:
-      pr-number: ${{ steps.get-pr.outputs.pr-number }}
     steps:
-      - name: Resolve PR number and author
-        id: get-pr
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            core.setOutput('pr-number', prNumber);
-            core.setOutput('pr-author', pr.data.user.login);
-
       - name: Checkout code (for local action)
         uses: actions/checkout@v6
 
       - name: Check codeowner authorization
         uses: ./.github/actions/check-codeowner-auth
-        with:
-          pr-number: ${{ steps.get-pr.outputs.pr-number }}
-          pr-author: ${{ steps.get-pr.outputs.pr-author }}
 
   tests:
     needs: check-author
@@ -86,7 +67,7 @@ jobs:
           LOG_LEVEL: "DEBUG"
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
-          DOCS_TABLE_NAME: "kc_pr_${{ needs.check-author.outputs.pr-number }}"
+          DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
         run: |
           poetry run poe test-unit
 
@@ -97,7 +78,7 @@ jobs:
           LOG_LEVEL: "DEBUG"
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
-          DOCS_TABLE_NAME: "kc_pr_${{ needs.check-author.outputs.pr-number }}"
+          DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
           echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -23,7 +23,6 @@ jobs:
 
   tests:
     needs: check-author
-    if: needs.check-author.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -8,8 +8,6 @@ on:
       - "release-**"
     paths:
       - "doc_indexer/**"
-  pull_request_review:
-    types: [submitted]
 
 permissions: read-all
 
@@ -17,77 +15,34 @@ jobs:
   check-author:
     runs-on: ubuntu-latest
     outputs:
-      authorized: ${{ steps.check.outputs.authorized }}
-      pr-number: ${{ steps.check.outputs.pr-number }}
+      pr-number: ${{ steps.get-pr.outputs.pr-number }}
     steps:
-      - name: Check authorization
-        id: check
+      - name: Resolve PR number and author
+        id: get-pr
         uses: actions/github-script@v8
         with:
           script: |
-            const prNumber = context.payload.pull_request?.number ?? context.payload.review?.pull_request_url?.split('/').pop();
+            const prNumber = context.payload.pull_request.number;
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: parseInt(prNumber),
+              pull_number: prNumber,
             });
             core.setOutput('pr-number', prNumber);
+            core.setOutput('pr-author', pr.data.user.login);
 
-            // Check if PR touches doc_indexer/** (relevant when triggered by a review on an unrelated PR)
-            const files = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: parseInt(prNumber),
-              per_page: 100,
-            });
-            const touchesDocIndexer = files.data.some(f => f.filename.startsWith('doc_indexer/'));
-            if (!touchesDocIndexer) {
-              console.log('PR does not touch doc_indexer/ — skipping.');
-              core.setOutput('authorized', 'skip');
-              return;
-            }
+      - name: Checkout code (for local action)
+        uses: actions/checkout@v6
 
-            // Check if PR author is a codeowner
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org: 'kyma-project',
-                team_slug: 'ai-force',
-                username: pr.data.user.login,
-              });
-              console.log(`Author ${pr.data.user.login} is a codeowner — authorized.`);
-              core.setOutput('authorized', 'true');
-              return;
-            } catch {}
-
-            // Not a codeowner — check for a codeowner approval
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: parseInt(prNumber),
-            });
-            const approvals = reviews.data.filter(r => r.state === 'APPROVED');
-            for (const approval of approvals) {
-              try {
-                await github.rest.teams.getMembershipForUserInOrg({
-                  org: 'kyma-project',
-                  team_slug: 'ai-force',
-                  username: approval.user.login,
-                });
-                console.log(`PR approved by codeowner ${approval.user.login} — authorized.`);
-                core.setOutput('authorized', 'true');
-                return;
-              } catch {}
-            }
-
-            core.setOutput('authorized', 'false');
-            core.setFailed(
-              `PR author ${pr.data.user.login} is not a codeowner and the PR has no codeowner approval. ` +
-              `A codeowner must approve the PR to allow tests to run.`
-            );
+      - name: Check codeowner authorization
+        uses: ./.github/actions/check-codeowner-auth
+        with:
+          pr-number: ${{ steps.get-pr.outputs.pr-number }}
+          pr-author: ${{ steps.get-pr.outputs.pr-author }}
 
   tests:
     needs: check-author
-    if: needs.check-author.result == 'success' && needs.check-author.outputs.authorized == 'true'
+    if: needs.check-author.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -15,11 +15,8 @@ jobs:
   authorize:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code (for local action)
-        uses: actions/checkout@v6
-
       - name: Check codeowner authorization
-        uses: ./.github/actions/check-codeowner-auth
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
 
   tests:
     needs: authorize

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -12,7 +12,7 @@ on:
 permissions: read-all
 
 jobs:
-  check-author:
+  authorize:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code (for local action)
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/check-codeowner-auth
 
   tests:
-    needs: check-author
+    needs: authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -8,32 +8,89 @@ on:
       - "release-**"
     paths:
       - "doc_indexer/**"
+  pull_request_review:
+    types: [submitted]
+
+permissions: read-all
 
 jobs:
   check-author:
     runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+      pr-number: ${{ steps.check.outputs.pr-number }}
     steps:
-      - name: Check if PR author is a codeowner
+      - name: Check authorization
+        id: check
         uses: actions/github-script@v8
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (labels.includes('ok-to-test')) return;
+            const prNumber = context.payload.pull_request?.number ?? context.payload.review?.pull_request_url?.split('/').pop();
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber),
+            });
+            core.setOutput('pr-number', prNumber);
+
+            // Check if PR touches doc_indexer/** (relevant when triggered by a review on an unrelated PR)
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber),
+              per_page: 100,
+            });
+            const touchesDocIndexer = files.data.some(f => f.filename.startsWith('doc_indexer/'));
+            if (!touchesDocIndexer) {
+              console.log('PR does not touch doc_indexer/ — skipping.');
+              core.setOutput('authorized', 'skip');
+              return;
+            }
+
+            // Check if PR author is a codeowner
             try {
               await github.rest.teams.getMembershipForUserInOrg({
                 org: 'kyma-project',
                 team_slug: 'ai-force',
-                username: context.payload.pull_request.user.login,
+                username: pr.data.user.login,
               });
-            } catch {
-              core.setFailed(`PR author ${context.payload.pull_request.user.login} is not a codeowner. Apply the 'ok-to-test' label to allow tests to run.`);
+              console.log(`Author ${pr.data.user.login} is a codeowner — authorized.`);
+              core.setOutput('authorized', 'true');
               return;
+            } catch {}
+
+            // Not a codeowner — check for a codeowner approval
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber),
+            });
+            const approvals = reviews.data.filter(r => r.state === 'APPROVED');
+            for (const approval of approvals) {
+              try {
+                await github.rest.teams.getMembershipForUserInOrg({
+                  org: 'kyma-project',
+                  team_slug: 'ai-force',
+                  username: approval.user.login,
+                });
+                console.log(`PR approved by codeowner ${approval.user.login} — authorized.`);
+                core.setOutput('authorized', 'true');
+                return;
+              } catch {}
             }
+
+            core.setOutput('authorized', 'false');
+            core.setFailed(
+              `PR author ${pr.data.user.login} is not a codeowner and the PR has no codeowner approval. ` +
+              `A codeowner must approve the PR to allow tests to run.`
+            );
 
   tests:
     needs: check-author
-    if: ${{ needs.check-author.result == 'success' }}
+    if: needs.check-author.result == 'success' && needs.check-author.outputs.authorized == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +98,7 @@ jobs:
     name: Tests (${{ matrix.test-type }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -54,14 +111,14 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./doc_indexer
@@ -74,7 +131,7 @@ jobs:
           LOG_LEVEL: "DEBUG"
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
-          DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
+          DOCS_TABLE_NAME: "kc_pr_${{ needs.check-author.outputs.pr-number }}"
         run: |
           poetry run poe test-unit
 
@@ -85,8 +142,8 @@ jobs:
           LOG_LEVEL: "DEBUG"
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
-          DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
+          DOCS_TABLE_NAME: "kc_pr_${{ needs.check-author.outputs.pr-number }}"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > $CONFIG_PATH
+          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           poetry run poe test-integration


### PR DESCRIPTION
## Description

Replaces the `ok-to-test` label gate on the doc-indexer tests with an explicit authorization check, and adds the same auth gate to all other privileged `pull_request_target` workflows.

**Authorization logic:**

<details>
<summary>Decision tree</summary>

```mermaid
flowchart TD
    A[PR event] --> B{Author is trusted bot?}
    B -- yes --> E[authorized]
    B -- no --> C{Author is codeowner?}
    C -- yes --> E
    C -- no --> F{PR approved by a codeowner?}
    F -- yes --> E
    F -- no --> G[setFailed: codeowner must approve]
```

</details>

**Files changed:**
- `pull-tests-doc-indexer.yaml` - adds `authorize` job using composite action, replaces `ok-to-test` check, updates action versions to v6, renames workflow to `Doc Indexer Tests`
- `pull-integration-test.yaml` - adds `authorize` job, sets `permissions: read-all`, updates action versions to v6
- `pull-evaluation-tests.yaml` - adds `authorize` job, adds `permissions: read-all`, updates action versions to v6
- `pull-api-tests.yaml` - adds `authorize` job, adds `permissions: read-all`, updates action versions to v6
- `.github/github-comment.yaml` - updates `pr-notes-external` and `pr-notes-codeowner` templates to reflect the new authorization model