### PR TITLE
feat: add check-codeowner-auth composite action

### DIFF
--- a/.github/actions/check-codeowner-auth/action.yml
+++ b/.github/actions/check-codeowner-auth/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         script: |
           const TRUSTED_BOTS = [
-            'app/renovate',
+            'renovate[bot]',
           ];
 
           const org = 'kyma-project';
@@ -32,15 +32,25 @@ runs:
             });
             console.log(`Author ${prAuthor} is a codeowner - authorized.`);
             return;
-          } catch {}
+          } catch (e) {
+            if (e.status !== 404) throw e;
+          }
 
           // Not a codeowner - check for a codeowner approval
-          const reviews = await github.rest.pulls.listReviews({
+          const allReviews = await github.paginate(github.rest.pulls.listReviews, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: prNumber,
+            per_page: 100,
           });
-          const approvals = reviews.data.filter(r => r.state === 'APPROVED');
+          // Keep only the latest review state per reviewer (excludes comments)
+          const latestReviews = new Map();
+          for (const review of allReviews) {
+            if (review.state !== 'COMMENTED') {
+              latestReviews.set(review.user.login, review);
+            }
+          }
+          const approvals = [...latestReviews.values()].filter(r => r.state === 'APPROVED');
           for (const approval of approvals) {
             try {
               await github.rest.teams.getMembershipForUserInOrg({
@@ -50,7 +60,9 @@ runs:
               });
               console.log(`PR approved by codeowner ${approval.user.login} - authorized.`);
               return;
-            } catch {}
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
           }
 
           core.setFailed(

--- a/.github/actions/check-codeowner-auth/action.yml
+++ b/.github/actions/check-codeowner-auth/action.yml
@@ -43,7 +43,9 @@ runs:
             pull_number: prNumber,
             per_page: 100,
           });
-          // Keep only the latest review state per reviewer (excludes comments)
+          // Keep only the latest review state per reviewer (excludes comments).
+          // This filters out stale approvals: if a reviewer approved and later
+          // requested changes, only the CHANGES_REQUESTED state is kept.
           const latestReviews = new Map();
           for (const review of allReviews) {
             if (review.state !== 'COMMENTED') {

--- a/.github/actions/check-codeowner-auth/action.yml
+++ b/.github/actions/check-codeowner-auth/action.yml
@@ -1,0 +1,59 @@
+name: "Check codeowner authorization"
+description: "Fails if PR author is not a codeowner and PR has no codeowner approval. Trusted bots are always authorized."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check authorization
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const TRUSTED_BOTS = [
+            'app/renovate',
+          ];
+
+          const org = 'kyma-project';
+          const teamSlug = 'ai-force';
+          const prNumber = context.payload.pull_request.number;
+          const prAuthor = context.payload.pull_request.user.login;
+
+          // Trusted bots are always authorized
+          if (TRUSTED_BOTS.includes(prAuthor)) {
+            console.log(`Author ${prAuthor} is a trusted bot - authorized.`);
+            return;
+          }
+
+          // Check if PR author is a codeowner
+          try {
+            await github.rest.teams.getMembershipForUserInOrg({
+              org,
+              team_slug: teamSlug,
+              username: prAuthor,
+            });
+            console.log(`Author ${prAuthor} is a codeowner - authorized.`);
+            return;
+          } catch {}
+
+          // Not a codeowner - check for a codeowner approval
+          const reviews = await github.rest.pulls.listReviews({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          });
+          const approvals = reviews.data.filter(r => r.state === 'APPROVED');
+          for (const approval of approvals) {
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: teamSlug,
+                username: approval.user.login,
+              });
+              console.log(`PR approved by codeowner ${approval.user.login} - authorized.`);
+              return;
+            } catch {}
+          }
+
+          core.setFailed(
+            `PR author ${prAuthor} is not a codeowner and the PR has no codeowner approval. ` +
+            `A codeowner must approve the PR to allow tests to run.`
+          );


### PR DESCRIPTION
## Description

Adds a reusable composite action that checks whether a PR is authorized to run privileged workflows.

**Authorization logic:**
- Trusted bots (e.g. `renovate[bot]`) - always authorized
- PR author is a codeowner - authorized
- PR author is not a codeowner but PR has a codeowner approval - authorized (only the latest review state per reviewer is considered, so dismissed approvals do not count)
- Otherwise - `core.setFailed()` with a clear message

**Files changed:**
- `.github/actions/check-codeowner-auth/action.yml` - new composite action