### PR TITLE
fix: switch pull_request_target to pull_request and add auth gate

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,7 +2,7 @@ name: Lint PR Title
 run-name: ${{github.event.pull_request.title}}
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image for Indexer
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -27,12 +27,20 @@ on:
       - ".gitignore"
       - external-images.yaml
 
-permissions:
-  id-token: write # This is required for requesting the JWT token
-  contents: read # This is required for actions/checkout
+permissions: read-all
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   build:
+    needs: authorize
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kyma-companion-indexer

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image for Indexer
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
@@ -33,7 +33,7 @@ jobs:
       - name: Extract image name from JSON
         id: extract-image
         run: |
-          echo "IMAGE_NAME=$(echo '${{ needs.build.outputs.images }}' | jq -r '.[0]')" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(echo '${{ needs.build.outputs.images }}' | jq -r '.[0]')" >> "$GITHUB_ENV"
 
       - name: Test image
         run: ./scripts/shell/run-and-check-container.sh "$IMAGE_NAME" PR-${{ github.event.number }}-container

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -6,12 +6,20 @@ on:
     branches:
       - main
 
-permissions:
-  id-token: write # This is required for requesting the JWT token
-  contents: read # This is required for actions/checkout
+permissions: read-all
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   build:
+    needs: authorize
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kyma-companion

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -41,7 +41,8 @@ jobs:
       - name: Extract image name from JSON
         id: extract-image
         run: |
-          echo "IMAGE_NAME=$(echo '${{ needs.build.outputs.images }}' | jq -r '.[0]')" >> "$GITHUB_ENV"
+          IMAGE_NAMES='${{ needs.build.outputs.images }}'
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAMES" | jq -r '.[0]')" >> "$GITHUB_ENV"
 
       - name: Test image
         run: ./scripts/shell/run-and-check-container.sh "$IMAGE_NAME" PR-${{ github.event.number }}-container

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image LangFuse
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -9,12 +9,20 @@ on:
       - "Dockerfile.langfuse"
       - "Dockerfile.langfuse-worker"
 
-permissions:
-  id-token: write # This is required for requesting the JWT token
-  contents: read # This is required for actions/checkout
+permissions: read-all
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   build-langfuse:
+    needs: authorize
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse
@@ -24,6 +32,10 @@ jobs:
       platforms: |
         linux/amd64
   build-langfuse-worker:
+    needs: authorize
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse-worker

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -1,7 +1,7 @@
 name: Pull Build Image LangFuse
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -1,6 +1,6 @@
 name: Pull Gitleaks
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 env:
@@ -17,7 +17,7 @@ jobs:
         run: curl -Lso gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v${{ env.GITLEAKS_VERSION }}/gitleaks_${{ env.GITLEAKS_VERSION }}_linux_x64.tar.gz && tar -xvzf ./gitleaks.tar.gz
       - name: Run gitleaks
         # Scan commits between base and head of the pull request
-        run: ./gitleaks detect --log-opts=${PULL_BASE_SHA}...${PULL_HEAD_SHA} --verbose --redact
+        run: ./gitleaks detect --log-opts="${PULL_BASE_SHA}...${PULL_HEAD_SHA}" --verbose --redact
         env:
           PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PULL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -7,13 +7,21 @@ on:
       - "main"
       - "release-**"
 
-permissions:
-  pull-requests: write
+permissions: read-all
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+
   comment:
     name: Notes for PR
+    needs: authorize
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check if PR author is a codeowner
         id: check-author

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "external-images.yaml"
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:
       - main


### PR DESCRIPTION
## Description

Two changes:

**1. Switch 3 workflows from `pull_request_target` to `pull_request`**

These workflows require no named secrets and no OIDC token, so the elevated security context of `pull_request_target` is unnecessary.

- `pull-gitleaks.yml` - `pull_request_target` -> `pull_request`, fix unquoted shell vars
- `lint-pr-title.yml` - `pull_request_target` -> `pull_request`
- `sync-external-images.yml` - `pull_request_target` -> `pull_request` (keeps `push` trigger unchanged)

**2. Add codeowner auth gate to all remaining `pull_request_target` workflows**

These workflows must stay as `pull_request_target` (OIDC or write token required), but now gate execution behind the same `check-codeowner-auth` composite action used in PR #1108.

- `pull-build-image.yaml` - adds `authorize` job, sets `permissions: read-all`, moves `id-token: write` to `build` job
- `pull-build-image-indexer.yaml` - same pattern
- `pull-build-langfuse.yaml` - same pattern for both `build-langfuse` and `build-langfuse-worker` jobs
- `pull-request-comment.yaml` - adds `authorize` job, sets `permissions: read-all`, moves `pull-requests: write` to `comment` job

**Testing:**
- `actionlint` passes on all changed files