### PR TITLE
fix: pass GIT_BOT_TOKEN for team membership checks

### DIFF
--- a/.github/actions/check-codeowner-auth/action.yml
+++ b/.github/actions/check-codeowner-auth/action.yml
@@ -1,12 +1,18 @@
 name: "Check codeowner authorization"
 description: "Fails if PR author is not a codeowner and PR has no codeowner approval. Trusted bots are always authorized."
 
+inputs:
+  github-token:
+    description: "Token with read:org scope for team membership checks (use GIT_BOT_TOKEN)."
+    required: true
+
 runs:
   using: "composite"
   steps:
     - name: Check authorization
       uses: actions/github-script@v8
       with:
+        github-token: ${{ inputs.github-token }}
         script: |
           const TRUSTED_BOTS = [
             'renovate[bot]',

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -88,6 +88,6 @@ jobs:
           DOCS_PATH: "/test-data"
           DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
         run: |
-          export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
+          export CONFIG_PATH="$GITHUB_WORKSPACE/config/config.json"
           echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           poetry run poe test-integration

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Check if PR author is a codeowner
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.GIT_BOT_TOKEN }}
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
             if (labels.includes('ok-to-test')) return;
@@ -61,7 +62,7 @@ jobs:
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./doc_indexer
@@ -88,5 +89,5 @@ jobs:
           DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > $CONFIG_PATH
+          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           poetry run poe test-integration


### PR DESCRIPTION
## Description

`GITHUB_TOKEN` lacks `read:org` scope and cannot call `getMembershipForUserInOrg`. This caused all codeowner checks to return 404, failing authorization for all users — including actual codeowners.

Fix: pass `GIT_BOT_TOKEN` (which has `read:org`) as the `github-token` input to `actions/github-script` wherever team membership is checked.

**Files changed:**
- `.github/actions/check-codeowner-auth/action.yml` - adds `github-token` input, passes it to `actions/github-script`
- `.github/workflows/pull-tests-doc-indexer.yaml` - passes `GIT_BOT_TOKEN` to the inline membership check, fixes unquoted shell vars

**Note:** All other workflows that use `check-codeowner-auth` are in open PRs (#1108, #1111) and will pick up this fix once those PRs rebase on main after this merges.