### PR TITLE
fix: add missing gh actions permissions

### DIFF
--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -1,6 +1,8 @@
 name: Lint Markdown Links
 run-name: ${{github.event.pull_request.title}}
 on: [ pull_request ]
+permissions:
+  contents: read
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
         with:
           use-verbose-mode: 'no'
           config-file: '.mlc.config.json'

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 env:
   GITLEAKS_VERSION: 8.18.2
 

--- a/.github/workflows/pull-lint-doc-indexer.yaml
+++ b/.github/workflows/pull-lint-doc-indexer.yaml
@@ -9,6 +9,9 @@ on:
     paths:
       - "doc_indexer/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-lint-tests-blackbox.yaml
+++ b/.github/workflows/pull-lint-tests-blackbox.yaml
@@ -9,6 +9,9 @@ on:
     paths:
       - "tests/blackbox/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-evaluation-tests.yaml
+++ b/.github/workflows/run-evaluation-tests.yaml
@@ -12,6 +12,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   evaluation:
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main

--- a/.github/workflows/setup-test-cluster.yaml
+++ b/.github/workflows/setup-test-cluster.yaml
@@ -2,6 +2,9 @@ name: "Setup Gardener Test Cluster"
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 env:
   KYMA_VERSION: "2.20.5" # Required Kyma version.
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-stale: 60
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'  # Runs daily at midnight
   workflow_dispatch: # Allows manual triggering of the workflow
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**

adding explicit least-privilege `permissions` blocks to all affected workflows. Also bumps outdated action versions in the same files.

Changes:
- `pull-lint-tests-blackbox.yaml`, `pull-lint-doc-indexer.yaml`, `pull-gitleaks.yml`, `lint-markdown-links.yml`, `run-evaluation-tests.yaml`, `setup-test-cluster.yaml`: add `permissions: contents: read`
- `stale.yml`: add `permissions: issues: write, pull-requests: write` (required to label and close stale items)
- `actions/checkout`: v3/v4 -> v6
- `actions/setup-python`: v4 -> v6
- `actions/stale`: v9 -> v10
- `gaurav-nelson/github-action-markdown-link-check`: v1 -> 1.0.17

**Related issue(s)**