### PR TITLE
chore: add instructions for github actions to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
   "includePaths": [
     "pyproject.toml",
     "doc_indexer/pyproject.toml",
-    "tests/blackbox/pyproject.toml"
+    "tests/blackbox/pyproject.toml",
+    ".github/workflows/**"
   ],
   "extends": [
     "config:recommended",
@@ -16,7 +17,8 @@
     ":semanticCommitScopeDisabled"
   ],
   "enabledManagers": [
-    "poetry"
+    "poetry",
+    "github-actions"
   ],
   "packageRules": [
     {
@@ -51,6 +53,15 @@
         "tests/blackbox/pyproject.toml"
       ],
       "groupName": "Dependencies in tests/blackbox/pyproject.toml",
+      "addLabels": [
+        "dependencies"
+      ]
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
       "addLabels": [
         "dependencies"
       ]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable `github-actions` manager in Renovate so it tracks action versions in `.github/workflows/`
- Add `.github/workflows/**` to `includePaths`
- Add a `GitHub Actions` package rule that groups all action updates into a single PR with the `dependencies` label, on the same Monday schedule as Poetry deps

**References**

- [Renovate github-actions manager docs](https://docs.renovatebot.com/modules/manager/github-actions/)