### PR TITLE
feat: add a gh action linting action

### DIFF
--- a/.github/workflows/build-langfuse-reusable.yaml
+++ b/.github/workflows/build-langfuse-reusable.yaml
@@ -24,7 +24,7 @@ jobs:
       TAG_FILE: "./tmp/version.${{ inputs.IMAGE_NAME }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get tag from Dockerfile
         id: get_tag
         run: scripts/shell/get_langfuse_tag.sh

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Check if release tag already exists
         run: |
-          if [ $(git tag -l "${RELEASE_TAG}") ]; then
+          if [ "$(git tag -l "${RELEASE_TAG}")" ]; then
             echo "Warning: Release tag ${RELEASE_TAG} already exists"
           fi
 
@@ -73,7 +73,7 @@ jobs:
           MINOR=$(echo "$RELEASE_TAG" | cut -d. -f2)
           export RELEASE_BRANCH="release-$MAJOR.$MINOR"
           echo "exporting branch name: $RELEASE_BRANCH"
-          echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
     outputs:
       release_branch: ${{ steps.export-branch-name.outputs.release_branch }}
 
@@ -96,21 +96,21 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: poetry install --with dev
@@ -142,21 +142,21 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./doc_indexer
@@ -196,21 +196,21 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: poetry install --with dev
@@ -219,7 +219,7 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
         run: |
-          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > $GITHUB_WORKSPACE/config/config.json
+          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
           poetry run poe test-integration
 
   run-integration-tests-indexer:
@@ -241,21 +241,21 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./doc_indexer
@@ -271,7 +271,7 @@ jobs:
           DOCS_TABLE_NAME: "kc_pr_release_${{ inputs.name }}"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > $CONFIG_PATH
+          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           poetry run poe test-integration
 
   get-image-sha:
@@ -291,7 +291,7 @@ jobs:
 
       - name: Get the last commit's SHA of the release branch
         id: get_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   run-evaluation-tests:
     name: Run evaluation tests
@@ -326,7 +326,7 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Update sec-scanners-config.yaml
         if: ${{ inputs.sec-scanners-config }}
@@ -341,16 +341,16 @@ jobs:
           GIT_EMAIL: ${{ vars.GIT_BOT_EMAIL }}
           GH_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         run: |
-          prs=$(gh pr list -A ${{ vars.GIT_BOT_NAME }} --state open --json headRefName | jq -r '.[] | .headRefName')
-          if echo $prs | tr " " '\n' | grep -F -q -x ${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}; then
+          prs=$(gh pr list -A "${{ vars.GIT_BOT_NAME }}" --state open --json headRefName | jq -r '.[] | .headRefName')
+          if echo "$prs" | tr " " '\n' | grep -F -q -x "${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}"; then
             echo "PR already exists, no need to create a new one"
-            echo "PR_NUMBER=$(gh pr list --search "base:${{ env.RELEASE_BRANCH }} head:${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}" --json number | jq -r '.[] | .number')" >> $GITHUB_ENV
+            echo "PR_NUMBER=$(gh pr list --search "base:${{ env.RELEASE_BRANCH }} head:${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}" --json number | jq -r '.[] | .number')" >> "$GITHUB_ENV"
           elif [ -z "$(git status --porcelain)" ]; then
             echo "Nothing changed, no need to create PR"
-            echo "PR_NUMBER=-1" >> $GITHUB_ENV
+            echo "PR_NUMBER=-1" >> "$GITHUB_ENV"
           else
             PR_STATUS=$(./scripts/shell/create_sec_scanner_bump_pr.sh "${RELEASE_TAG}" "${RELEASE_BRANCH}")
-            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV
+            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> "$GITHUB_ENV"
           fi
 
       - name: Await PR merge (user input required)
@@ -383,7 +383,7 @@ jobs:
       - name: Check if the checked out branch is the release branch.
         run: |
           git branch --show-current
-          git branch --show-current | grep -q ${RELEASE_BRANCH}
+          git branch --show-current | grep -q "${RELEASE_BRANCH}"
 
       - name: Create git tag
         run: |
@@ -450,7 +450,7 @@ jobs:
           ./scripts/shell/create_draft_release.sh
           RELEASE_ID=$(cat release_id.txt)
           echo "Release ID: $RELEASE_ID"
-          echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}
 
@@ -476,16 +476,16 @@ jobs:
           GIT_EMAIL: ${{ vars.GIT_BOT_EMAIL }}
           GH_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
         run: |
-          prs=$(gh pr list -A ${{ vars.GIT_BOT_NAME }} --state open --json headRefName | jq -r '.[] | .headRefName')
-          if echo $prs | tr " " '\n' | grep -F -q -x ${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}; then
+          prs=$(gh pr list -A "${{ vars.GIT_BOT_NAME }}" --state open --json headRefName | jq -r '.[] | .headRefName')
+          if echo "$prs" | tr " " '\n' | grep -F -q -x "${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}"; then
             echo "PR already exists, no need to create a new one"
-            echo "PR_NUMBER=$(gh pr list --search "base:main head:${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}" --json number | jq -r '.[] | .number')" >> $GITHUB_ENV
+            echo "PR_NUMBER=$(gh pr list --search "base:main head:${{ env.BUMP_SEC_SCANNERS_BRANCH_NAME }}" --json number | jq -r '.[] | .number')" >> "$GITHUB_ENV"
           elif [ -z "$(git status --porcelain)" ]; then
             echo "Nothing changed, no need to create PR"
-            echo "PR_NUMBER=-1" >> $GITHUB_ENV
+            echo "PR_NUMBER=-1" >> "$GITHUB_ENV"
           else
             PR_STATUS=$(./scripts/shell/create_sec_scanner_bump_pr.sh "${RELEASE_TAG}")
-            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV
+            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> "$GITHUB_ENV"
           fi
 
       - name: Await PR merge (user input required)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # fetch all the branches and tags.
           ref: "main"
@@ -89,7 +89,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
 
@@ -103,7 +103,7 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
 
@@ -149,7 +149,7 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -189,7 +189,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
 
@@ -203,7 +203,7 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -234,7 +234,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
 
@@ -248,7 +248,7 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -284,7 +284,7 @@ jobs:
       sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - name: Checkout target branch from another repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.REPOSITORY_FULL_NAME }}
           ref: ${{ env.RELEASE_BRANCH }}
@@ -319,7 +319,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
 
@@ -374,7 +374,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # checkout the release branch. This is the branch where the release tag will be created.
           fetch-depth: 0 # fetch all the branches and tags.
           ref: ${{ needs.validate-input-params.outputs.release_branch }}
@@ -395,12 +395,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # release scripts are used from main branch.
           ref: main
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -436,7 +436,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: # draft release is linked to the release tag. So we run the release scripts from main branch.
           fetch-depth: 0 # fetch all the branches and tags.
           ref: main
@@ -460,7 +460,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -507,7 +507,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -130,7 +130,7 @@ jobs:
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
         run: |
           echo "Updating companion image to ${IMAGE_NAME}..."
-          kubectl -n ai-system set image deployment/companion companion=${IMAGE_NAME}
+          kubectl -n ai-system set image deployment/companion "companion=${IMAGE_NAME}"
 
       - name: Companion Deploy - Wait for deployment
         run: |
@@ -147,8 +147,8 @@ jobs:
               echo "Service is reachable";
               exit 0;
             fi
-            echo "Service not reachable yet, retrying in $INTERVAL_SECONDS seconds...";
-            sleep $INTERVAL_SECONDS;
+            echo "Service not reachable yet, retrying in ${INTERVAL_SECONDS} seconds...";
+            sleep "$INTERVAL_SECONDS";
           done
           echo "Service did not become reachable within $TIMEOUT_SECONDS seconds";
           exit 1
@@ -172,7 +172,7 @@ jobs:
           ./../../scripts/shell/extract-python-version.sh
 
       - name: Evaluation Tests Setup - Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -180,7 +180,7 @@ jobs:
         working-directory: tests/blackbox
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Evaluation Tests Setup - Install dependencies
         working-directory: tests/blackbox
@@ -193,7 +193,7 @@ jobs:
           COMPANION_API_URL: "http://localhost:32000"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > $CONFIG_PATH
+          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH! Running API tests against Companion at $COMPANION_API_URL"
           poetry run pytest src/api_tests/ -v
 
@@ -208,7 +208,7 @@ jobs:
           KC_EVAL_RETRIES: "5"
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > $CONFIG_PATH
+          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH!"
           poetry run python src/run_evaluation.py
 

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.TEST_REF }}
           repository: ${{ inputs.TEST_REPO_FULLNAME }}
@@ -172,7 +172,7 @@ jobs:
           ./../../scripts/shell/extract-python-version.sh
 
       - name: Evaluation Tests Setup - Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -31,14 +31,14 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -5,7 +5,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'no'

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -5,7 +5,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'no'

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       actions: none
     steps:
-      - uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9
+      - uses: amannn/action-semantic-pull-request@ac7e3fc035c47465748bbcb1a822c1583cf79bbc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,24 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "release-**"
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.12

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - name: Check if all checks passed
-        uses: wechuli/allcheckspassed@1d00cf0c34c4b0805db8866d8913f22e7125301e # v2.3.0
+        uses: wechuli/allcheckspassed@2d075c11ec321da095a716c70c07c7327eeb68a3 # v2.3.0
         with:
           delay: "1" # minutes
           retries: "10"

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install jq
         run: sudo apt-get install jq

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -10,7 +10,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch gitleaks ${{ env.GITLEAKS_VERSION }}

--- a/.github/workflows/pull-lint-doc-indexer.yaml
+++ b/.github/workflows/pull-lint-doc-indexer.yaml
@@ -24,14 +24,14 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./doc_indexer

--- a/.github/workflows/pull-lint-doc-indexer.yaml
+++ b/.github/workflows/pull-lint-doc-indexer.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Python version
         id: python-version
@@ -24,7 +24,7 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/pull-lint-tests-blackbox.yaml
+++ b/.github/workflows/pull-lint-tests-blackbox.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Python version
         id: python-version
@@ -24,7 +24,7 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/pull-lint-tests-blackbox.yaml
+++ b/.github/workflows/pull-lint-tests-blackbox.yaml
@@ -24,14 +24,14 @@ jobs:
           echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         working-directory: ./tests/blackbox

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: shmokmt/actions-setup-github-comment@v2.1.1
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Post comment (codeowner)
         if: steps.check-author.outputs.is-codeowner == 'true'

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -38,7 +38,7 @@ jobs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get the latest tag
         id: get_tag
         run: |

--- a/.github/workflows/push-build-image.yaml
+++ b/.github/workflows/push-build-image.yaml
@@ -19,7 +19,7 @@ jobs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get the latest tag
         id: get_tag
         run: |

--- a/.github/workflows/setup-test-cluster.yaml
+++ b/.github/workflows/setup-test-cluster.yaml
@@ -29,30 +29,32 @@ jobs:
           # setup Gardener kubeconfig.
           mkdir -p "${HOME}/.gardener"
           export GARDENER_KUBECONFIG="${HOME}/.gardener/kubeconfig"
-          echo ${GARDENER_KYMATUNAS} | base64 --decode > ${GARDENER_KUBECONFIG}
-          echo "GARDENER_KUBECONFIG=${GARDENER_KUBECONFIG}" >> $GITHUB_ENV
+          echo "${GARDENER_KYMATUNAS}" | base64 --decode > "${GARDENER_KUBECONFIG}"
+          echo "GARDENER_KUBECONFIG=${GARDENER_KUBECONFIG}" >> "$GITHUB_ENV"
 
       - name: Export Github env
         run: |
           # set cluster name and export it to Github env to access it later
           export CLUSTER_NAME="comp-tests-0"
-          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> "$GITHUB_ENV"
 
       - name: Create kubeconfig request
+        id: create-kubeconfig
         env:
           GARDENER_PROJECT_NAME: ${{ vars.GARDENER_PROJECT_NAME }}
         run: |
           # create kubeconfig request, that creates a Kubeconfig, which is valid for one day
           kubectl create --kubeconfig="${GARDENER_KUBECONFIG}" \
              -f <(printf '{"spec":{"expirationSeconds":86400}}') \
-             --raw /apis/core.gardener.cloud/v1beta1/namespaces/garden-${GARDENER_PROJECT_NAME}/shoots/${CLUSTER_NAME}/adminkubeconfig | \
+             --raw "/apis/core.gardener.cloud/v1beta1/namespaces/garden-${GARDENER_PROJECT_NAME}/shoots/${CLUSTER_NAME}/adminkubeconfig" | \
              jq -r ".status.kubeconfig" | \
-             base64 -d > ${CLUSTER_NAME}_kubeconfig.yaml
-          
+             base64 -d > "${CLUSTER_NAME}_kubeconfig.yaml"
+
           # merge with the existing kubeconfig settings
-          mkdir -p ~/.kube
-          KUBECONFIG="~/.kube/config:${CLUSTER_NAME}_kubeconfig.yaml" kubectl config view --flatten --merge > merged_kubeconfig.yaml
-          mv merged_kubeconfig.yaml ~/.kube/config
+          mkdir -p "$HOME/.kube"
+          KUBECONFIG="$HOME/.kube/config:${CLUSTER_NAME}_kubeconfig.yaml" kubectl config view --flatten --merge > merged_kubeconfig.yaml
+          mv merged_kubeconfig.yaml "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_OUTPUT"
 
       - name: Display cluster information
         run: |
@@ -78,7 +80,7 @@ jobs:
         run: |
           mkdir -p bin
           curl -L "https://github.com/kyma-project/cli/releases/download/${KYMA_VERSION}/kyma_$(uname -s)_$(uname -m).tar.gz" | tar -zxvf - -C bin kyma && mv bin/kyma bin/kyma@v2
-          echo "::set-output name=version::$(bin/kyma@v2 version)"
+          echo "version=$(bin/kyma@v2 version)" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Check Kyma CLI version

--- a/.github/workflows/setup-test-cluster.yaml
+++ b/.github/workflows/setup-test-cluster.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Connect to Gardener cluster - setup kubeconfig
         env:

--- a/.github/workflows/tag-build-image.yaml
+++ b/.github/workflows/tag-build-image.yaml
@@ -16,7 +16,7 @@ jobs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get the latest tag
         id: get_tag
         run: |

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -16,11 +16,11 @@ jobs:
       run_tests: ${{ steps.determine.outputs.run_tests }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47.0.5
         with:
           files_ignore: | # do not use quotes
             - docs/**
@@ -56,14 +56,14 @@ jobs:
     if: needs.check-if-test-is-needed.outputs.run_tests == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Python version
         id: python-version
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -39,10 +39,10 @@ jobs:
 
           if [ -z "${{ steps.changed-files.outputs.all_changed_files }}" ]; then
             echo "No relevant files changed. Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
           else
             echo "Relevant files changed. Running tests."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
           fi
 
   ## **IMPORTANT**: If any changes are made to how to run the unit tests. Make sure to update the steps for unit-tests
@@ -63,14 +63,14 @@ jobs:
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,5 @@ test-integration-local = "pytest -n auto -v tests/integration -x --reruns=6 --re
 run = "fastapi run src/main.py --port 8000"
 run-local = "fastapi dev src/main.py --port 8000"
 sort = "poetry sort"
-pre-commit-check = ["sort", "code-fix", "codecheck", "test-local"]
+lint-workflows = "bash scripts/shell/lint-workflows.sh"
+pre-commit-check = ["sort", "code-fix", "codecheck", "test-local", "lint-workflows"]

--- a/scripts/shell/lint-workflows.sh
+++ b/scripts/shell/lint-workflows.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Runs actionlint against all GitHub Actions workflow files.
+
+set -o nounset
+set -o errexit
+set -E
+set -o pipefail
+
+if ! command -v actionlint &>/dev/null; then
+  echo "ERROR: actionlint not found. Install it with: brew install actionlint"
+  exit 1
+fi
+
+actionlint .github/workflows/*.yml .github/workflows/*.yaml


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `.github/workflows/lint-workflows.yml` - runs `rhysd/actionlint` against all workflow files on PRs targeting `main` or `release-**` branches, triggered only when `.github/workflows/**` files change
- Fix all pre-existing `actionlint` issues found when running the linter locally against the full workflow set:
  - SC2086: quote variables to prevent word splitting/globbing (`$GITHUB_PATH`, `$GITHUB_OUTPUT`, `$GITHUB_ENV`, shell vars in scripts)
  - SC2046: quote command substitution in `if` condition (`create-release.yml`)
  - SC2088: replace `~` with `$HOME` in quoted `KUBECONFIG` assignment (`setup-test-cluster.yaml`)
  - Deprecated `::set-output` command replaced with `$GITHUB_OUTPUT` (`setup-test-cluster.yaml`)
  - Missing `id: create-kubeconfig` on the step referenced in the job `outputs` (`setup-test-cluster.yaml`)
- Upgrade all actions to latest versions:
  - `actions/checkout`: v4/v6 mix - unified to `v6`
  - `actions/setup-python`: v4/v5 mix - unified to `v6`
  - `tj-actions/changed-files`: `v46` - `v47.0.5`
  - `amannn/action-semantic-pull-request`: updated to latest SHA
  - `wechuli/allcheckspassed`: updated to latest SHA

**Related issue(s)**