### PR TITLE
chore: use immutable commit SHA for PR head checkout

### DIFF
--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract Python version

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract Python version


### PR DESCRIPTION
**Description**

Replace mutable branch ref (`head.ref`) with immutable commit SHA (`head.sha`) in `pull_request_target` checkout steps.

- `pull-tests-doc-indexer.yaml`
- `pull-integration-test.yaml`

Using `head.ref` (a branch name) creates a race window: an attacker can push new code after codeowner approval but before the checkout step executes. Using `head.sha` pins the checkout to the exact commit that was reviewed and approved — any new push produces a different SHA, which our `check-codeowner-auth` action will reject as a stale approval.

Fixes code scanning alerts #37, #29, #30, #1 (`actions/untrusted-checkout/critical` and `actions/improper-access-control`).

**Testing**

No functional change for normal use — the checked-out code is identical as long as no new commits are pushed between approval and workflow execution. The change only matters when the branch is modified after approval, which is exactly the attack scenario we are closing.