### PR TITLE
fix: correct e2e indexer check run name

### DIFF
--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GIT_BOT_TOKEN }}
 
-  build:
+  build-indexer:
     needs: authorize
     permissions:
       id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"
+    paths:
+      - "doc_indexer/**"
+      - ".github/workflows/pull-build-image-indexer.yaml"
 
 permissions: read-all
 

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -5,27 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "main"
-    paths-ignore:
-      - ".github/**"
-      - ".reuse/**"
-      - "LICENSES/**"
-      - "config/**"
-      - "data/**"
-      - "docs/**"
-      - "scripts/**"
-      - "tests/**"
-      - "**/*.md"
-      - "src/**"
-      - "doc_indexer/.vscode/**"
-      - "doc_indexer/tests/**"
-      - CODEOWNERS
-      - LICENSE
-      - "sec-scanners-config.yaml"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "renovate.json"
-      - ".gitignore"
-      - external-images.yaml
 
 permissions: read-all
 

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -1,19 +1,63 @@
 name: "E2E Tests for Doc Indexer"
-run-name: "E2E Tests for Doc Indexer"
+run-name: "E2E Tests for Doc Indexer PR #${{ github.event.number }}"
 
 on:
-  workflow_run:
-    workflows: ["Pull Build Image for Indexer"]
-    types: [completed]
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths:
+      - "doc_indexer/**"
+      - ".github/workflows/pull-e2e-tests-doc-indexer.yaml"
+      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions: read-all
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check codeowner authorization
+        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
+        with:
+          github-token: ${{ secrets.GIT_BOT_TOKEN }}
+
+  wait-for-build:
+    name: Wait for image build job
+    needs: authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install requirements
+        run: |
+          pip install -r ./scripts/python/wait-for-commit-check/requirements.txt
+
+      - name: Wait for build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_REF: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY_FULL_NAME: "${{ github.repository }}"
+          GIT_CHECK_RUN_NAME: "build-indexer / Build image"
+          INTERVAL: 60
+          TIMEOUT: 900
+        run: |
+          python ./scripts/python/wait-for-commit-check/run.py
+
   e2e-tests:
     name: Run e2e tests
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
+    needs: wait-for-build
     secrets: inherit
     with:
-      IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.workflow_run.pull_requests[0].number }}"
-      DOCS_TABLE_NAME: "kc_pr_${{ github.event.workflow_run.pull_requests[0].number }}_e2e"
+      IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
+      DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -1,63 +1,19 @@
 name: "E2E Tests for Doc Indexer"
-run-name: "E2E Tests for Doc Indexer PR #${{ github.event.number }}"
+run-name: "E2E Tests for Doc Indexer"
 
 on:
-  pull_request_target:
-    types: [labeled, opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-    paths:
-      - "doc_indexer/**"
-      - ".github/workflows/pull-e2e-tests-doc-indexer.yaml"
-      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
+  workflow_run:
+    workflows: ["Pull Build Image for Indexer"]
+    types: [completed]
 
 permissions: read-all
 
 jobs:
-  authorize:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check codeowner authorization
-        uses: kyma-project/kyma-companion/.github/actions/check-codeowner-auth@main
-        with:
-          github-token: ${{ secrets.GIT_BOT_TOKEN }}
-
-  wait-for-build:
-    name: Wait for image build job
-    needs: authorize
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: Setup python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-          cache: "pip"
-
-      - name: Install requirements
-        run: |
-          pip install -r ./scripts/python/wait-for-commit-check/requirements.txt
-
-      - name: Wait for build
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GIT_REF: ${{ github.event.pull_request.head.sha }}
-          REPOSITORY_FULL_NAME: "${{ github.repository }}"
-          GIT_CHECK_RUN_NAME: "build / Build image"
-          INTERVAL: 60
-          TIMEOUT: 900
-        run: |
-          python ./scripts/python/wait-for-commit-check/run.py
-
   e2e-tests:
     name: Run e2e tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
-    needs: wait-for-build
     secrets: inherit
     with:
-      IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
-      DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"
+      IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.workflow_run.pull_requests[0].number }}"
+      DOCS_TABLE_NAME: "kc_pr_${{ github.event.workflow_run.pull_requests[0].number }}_e2e"

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "doc_indexer/**"
       - ".github/workflows/pull-e2e-tests-doc-indexer.yaml"
+      - ".github/workflows/pull-build-image-indexer.yaml"
       - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions: read-all

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
       - "release-*"
+    paths:
+      - "doc_indexer/**"
+      - ".github/workflows/push-build-image-indexer.yaml"
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -5,27 +5,6 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - ".github/**"
-      - ".reuse/**"
-      - "LICENSES/**"
-      - "config/**"
-      - "data/**"
-      - "docs/**"
-      - "scripts/**"
-      - "tests/**"
-      - "**/*.md"
-      - "src/**"
-      - "doc_indexer/.vscode/**"
-      - "doc_indexer/tests/**"
-      - CODEOWNERS
-      - LICENSE
-      - "sec-scanners-config.yaml"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "renovate.json"
-      - ".gitignore"
-      - external-images.yaml
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -27,7 +27,7 @@ jobs:
             echo "${{ github.ref_name}}"
             echo EOF
           } >> "$GITHUB_OUTPUT"
-  build:
+  build-indexer:
     needs: compute-tags
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/push-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/push-e2e-tests-doc-indexer.yaml
@@ -1,20 +1,68 @@
 name: Push E2E Tests for Indexer
 
 on:
-  workflow_run:
-    workflows: ["Push Build Image for Indexer"]
-    types: [completed]
+  push:
     branches:
       - "main"
       - "release-*"
+    paths-ignore:
+      - ".github/**"
+      - ".reuse/**"
+      - "LICENSES/**"
+      - "config/**"
+      - "data/**"
+      - "docs/**"
+      - "scripts/**"
+      - "tests/**"
+      - "**/*.md"
+      - "src/**"
+      - "doc_indexer/.vscode/**"
+      - "doc_indexer/tests/**"
+      - CODEOWNERS
+      - LICENSE
+      - "sec-scanners-config.yaml"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "renovate.json"
+      - ".gitignore"
+      - external-images.yaml
 
 permissions: read-all
 
 jobs:
+  wait-for-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install requirements
+        run: |
+          pip install -r ./scripts/python/wait-for-commit-check/requirements.txt
+
+      - name: Wait for build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_REF: ${{ github.sha }}
+          REPOSITORY_FULL_NAME: "${{ github.repository }}"
+          GIT_CHECK_RUN_NAME: "build-indexer / Build image"
+          INTERVAL: 60
+          TIMEOUT: 900
+        run: |
+          python ./scripts/python/wait-for-commit-check/run.py
+
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: wait-for-build
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     secrets: inherit
     with:
-      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ github.event.workflow_run.head_branch }}"
-      DOCS_TABLE_NAME: "kc_push_${{ github.event.workflow_run.head_sha }}_e2e"
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ github.ref_name }}"
+      DOCS_TABLE_NAME: "kc_push_${{ github.sha }}_e2e"

--- a/.github/workflows/push-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/push-e2e-tests-doc-indexer.yaml
@@ -5,27 +5,11 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - ".github/**"
-      - ".reuse/**"
-      - "LICENSES/**"
-      - "config/**"
-      - "data/**"
-      - "docs/**"
-      - "scripts/**"
-      - "tests/**"
-      - "**/*.md"
-      - "src/**"
-      - "doc_indexer/.vscode/**"
-      - "doc_indexer/tests/**"
-      - CODEOWNERS
-      - LICENSE
-      - "sec-scanners-config.yaml"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "renovate.json"
-      - ".gitignore"
-      - external-images.yaml
+    paths:
+      - "doc_indexer/**"
+      - ".github/workflows/push-e2e-tests-doc-indexer.yaml"
+      - ".github/workflows/push-build-image-indexer.yaml"
+      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions: read-all
 

--- a/.github/workflows/push-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/push-e2e-tests-doc-indexer.yaml
@@ -1,68 +1,20 @@
 name: Push E2E Tests for Indexer
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Push Build Image for Indexer"]
+    types: [completed]
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - ".github/**"
-      - ".reuse/**"
-      - "LICENSES/**"
-      - "config/**"
-      - "data/**"
-      - "docs/**"
-      - "scripts/**"
-      - "tests/**"
-      - "**/*.md"
-      - "src/**"
-      - "doc_indexer/.vscode/**"
-      - "doc_indexer/tests/**"
-      - CODEOWNERS
-      - LICENSE
-      - "sec-scanners-config.yaml"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "renovate.json"
-      - ".gitignore"
-      - external-images.yaml
 
 permissions: read-all
 
 jobs:
-  wait-for-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: Setup python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-          cache: "pip"
-
-      - name: Install requirements
-        run: |
-          pip install -r ./scripts/python/wait-for-commit-check/requirements.txt
-
-      - name: Wait for build
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GIT_REF: ${{ github.sha }}
-          REPOSITORY_FULL_NAME: "${{ github.repository }}"
-          GIT_CHECK_RUN_NAME: "build / Build image"
-          INTERVAL: 60
-          TIMEOUT: 900
-        run: |
-          python ./scripts/python/wait-for-commit-check/run.py
-
   e2e-tests:
-    needs: wait-for-build
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     secrets: inherit
     with:
-      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ github.ref_name }}"
-      DOCS_TABLE_NAME: "kc_push_${{ github.sha }}_e2e"
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ github.event.workflow_run.head_branch }}"
+      DOCS_TABLE_NAME: "kc_push_${{ github.event.workflow_run.head_sha }}_e2e"

--- a/.github/workflows/push-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/push-e2e-tests-doc-indexer.yaml
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GIT_REF: ${{ github.sha }}
           REPOSITORY_FULL_NAME: "${{ github.repository }}"
-          GIT_CHECK_RUN_NAME: "Push Build Image for Indexer / build"
+          GIT_CHECK_RUN_NAME: "build / Build image"
           INTERVAL: 60
           TIMEOUT: 900
         run: |


### PR DESCRIPTION
## What has been done?

Fix the indexer build and e2e workflows for both push and pull_request_target events.

- Rename the `build` job to `build-indexer` in both indexer build workflows so the check run is registered as `"build-indexer / Build image"`, distinct from the main build.
- Update `GIT_CHECK_RUN_NAME` in `push-e2e-tests-doc-indexer.yaml` and `pull-e2e-tests-doc-indexer.yaml` to `"build-indexer / Build image"`.
- Replace broad `paths-ignore` lists on all four indexer workflows with targeted `paths` filters: each workflow now runs only when `doc_indexer/**` or its own workflow file(s) change. E2e workflows also include the corresponding build workflow file so both trigger together when the build workflow is modified.

Resolves #1130