### PR TITLE
fix: paginate check-run API calls in wait-for-commit-check script

### DIFF
--- a/scripts/python/wait-for-commit-check/run.py
+++ b/scripts/python/wait-for-commit-check/run.py
@@ -86,7 +86,7 @@ def print_inputs(inputs: dict) -> None:
 
 
 def fetch_check_runs(repo: str, git_ref: str, token: str) -> dict:
-    """Fetches the check runs from GitHub."""
+    """Fetches the check runs from GitHub (all pages)."""
     # https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
     url = f"https://api.github.com/repos/{repo}/commits/{git_ref}/check-runs"
     req_headers = {
@@ -96,11 +96,19 @@ def fetch_check_runs(repo: str, git_ref: str, token: str) -> dict:
     }
 
     print(f"Fetching check runs from {url}", flush=True)
-    response = requests.get(url, headers=req_headers)
+    all_check_runs = []
+    next_url = url
+    params = {"per_page": 100}
+    while next_url:
+        response = requests.get(next_url, headers=req_headers, params=params)
+        if response.status_code != HTTP_OK:
+            raise Exception(f"API call failed. Status code: {response.status_code}, {response.text}")
+        data = response.json()
+        all_check_runs.extend(data.get("check_runs", []))
+        next_url = response.links.get("next", {}).get("url")
+        params = {}  # params are already encoded in the next URL
 
-    if response.status_code != HTTP_OK:
-        raise Exception(f"API call failed. Status code: {response.status_code}, {response.text}")
-    return response.json()
+    return {"check_runs": all_check_runs}
 
 
 def get_latest_check_run(check_run_name: str, check_runs: dict) -> dict | None:

--- a/scripts/python/wait-for-commit-check/run.py
+++ b/scripts/python/wait-for-commit-check/run.py
@@ -98,6 +98,9 @@ def fetch_check_runs(repo: str, git_ref: str, token: str) -> dict:
     print(f"Fetching check runs from {url}", flush=True)
     all_check_runs = []
     next_url = url
+    # GitHub's default page size is 30; repos with many parallel jobs can exceed that,
+    # causing the target check run to be silently missed. Fetch 100 per page (API max)
+    # and follow Link headers until all pages are consumed.
     params = {"per_page": 100}
     while next_url:
         response = requests.get(next_url, headers=req_headers, params=params)
@@ -106,7 +109,7 @@ def fetch_check_runs(repo: str, git_ref: str, token: str) -> dict:
         data = response.json()
         all_check_runs.extend(data.get("check_runs", []))
         next_url = response.links.get("next", {}).get("url")
-        params = {}  # params are already encoded in the next URL
+        params = {}  # next URL already contains pagination params
 
     return {"check_runs": all_check_runs}
 


### PR DESCRIPTION
## Problem

`scripts/python/wait-for-commit-check/run.py` fetched only the first page (default 30 items) of check runs from the GitHub API. On PRs with many parallel CI jobs (kyma-companion has 52 check runs per commit), the target check run could appear beyond position 30 and would be missed — causing the `Wait for image build job` step to time out after 900 s.

The API does not guarantee ordering, so this is an intermittent failure depending on whether the target check run happens to land on page 1.

This was discovered via PR #1138 (test PR for #1131): `build-indexer / Build image` completed successfully but the poller timed out because it was on page 2.

**Proof:**
```
gh api "repos/kyma-project/kyma-companion/commits/052364abf4c9db1bae2d681390b7fbfb1b14276d/check-runs" --jq '"page1: \(.check_runs|length) / total: \(.total_count)"'
# page1: 30 / total: 52
```

## Fix

- Add `per_page=100` to the initial API request (GitHub max).
- Follow `Link: rel="next"` pagination headers to accumulate all check runs across pages.

Affects all four workflows that use the script:
- `pull-e2e-tests-doc-indexer.yaml`
- `push-e2e-tests-doc-indexer.yaml`
- `pull-api-tests.yaml`
- `pull-evaluation-tests.yaml`

## Testing

After this fix merges, PR #1138 will be re-run to confirm.

Related: #1130, #1131, #1138