### PR TITLE
feat: add synchronous messages endpoint

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash .claude/skills/update-py-deps/update-dep.sh*)",
+      "Bash(poetry show*)",
+      "Bash(poetry run poe pre-commit-check*)",
+      "Bash(git add -A)",
+      "Bash(git commit -m *)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git status*)",
+      "Bash(ls*)",
+      "Bash(find*)"
+    ]
+  }
+}

--- a/.claude/skills/update-py-deps/SKILL.md
+++ b/.claude/skills/update-py-deps/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: update-py-deps
+description: Update all Python dependencies across the kyma-companion Poetry subprojects, one at a time. For each dependency: update to latest (fall back to minor/patch on conflicts), run pre-commit-check, fix issues, commit.
+---
+
+# Update Dependencies Skill
+
+You are performing a systematic dependency update across the kyma-companion Poetry subprojects.
+
+## Zero-interaction execution
+
+**CRITICAL**: This skill must run to completion with zero user interactions. Never pause to ask questions. Never wait for approval. If something fails, fix it and continue.
+
+**Do not do any setup or discovery steps.** Do not check for config files, do not explore the repo structure, do not read pyproject.toml before starting. The subproject layout is known (see below). Start immediately by reading `pyproject.toml` in the root subproject to identify the first dependency to update.
+
+**One dependency = one commit.** Never batch multiple deps into a single commit. The only exception is when updating dep X forces a co-update of dep Y due to conflicts — in that case update both in one `poetry add` call and one commit, and name both in the commit message.
+
+For each dependency update, run the helper script (pre-approved, no prompt):
+
+```bash
+bash .claude/skills/update-py-deps/update-dep.sh <subproject_dir> <pkg>
+# with a group flag:
+bash .claude/skills/update-py-deps/update-dep.sh <subproject_dir> <pkg> --group test
+# with a specific version (conflict fallback):
+bash .claude/skills/update-py-deps/update-dep.sh <subproject_dir> "<pkg>@^1.2"
+```
+
+The script: captures old version, runs `poetry add <pkg>@latest [extra args]`, captures new version, runs `pre-commit-check`, commits with message `deps: update <pkg> from v<old> to v<new>`. Defaults to `@latest`; pass a version suffix to override (e.g. `"pkg@^1.2"`).
+
+If `pre-commit-check` fails due to source code issues, fix the files (Edit tool), then run:
+
+```bash
+bash .claude/skills/update-py-deps/update-dep.sh <subproject_dir> <pkg>
+```
+
+again from scratch (it re-adds and re-checks). If the fix only needs a re-check without re-adding (e.g. the dep is already added but pre-commit-check failed), run `update-dep.sh` anyway — `poetry add` will be a no-op if the version is already correct.
+
+## Subprojects
+
+There are 3 subprojects, each with their own `pyproject.toml` and `poetry.lock`:
+
+- root (`.`)
+- `doc_indexer/`
+- `tests/blackbox/`
+
+Process in this order: **root → doc_indexer → tests/blackbox**
+
+Each subproject has a `poe pre-commit-check` target (sort, lint, typecheck, format, unit tests). Run all `poetry` and `poe` commands via `poetry run poe ...` (poe is not on PATH directly).
+
+## Process — repeat for each dependency
+
+1. **Read `pyproject.toml`** to find the next dependency to update
+2. **Update + check + commit**: run the helper script
+3. **Fix any source issues** with Edit tool if needed, then re-run `update-dep.sh`
+4. **Move to the next dependency**
+
+## Rules
+
+- Update to latest version when possible; fall back to latest minor/patch only on conflicts
+- Auto-fixes from ruff (format/lint) are applied by `pre-commit-check` automatically — `git add -A` picks them up
+- Never skip a failing check — fix it before moving on
+- Use `poetry add` not `poetry update`
+- If `poetry add <pkg>@latest` fails due to conflicts, retry with a pinned version: `bash .claude/skills/update-py-deps/update-dep.sh <subproject_dir> "<pkg>@^X.Y"` (let poetry resolve the latest compatible)
+- Skip a dependency if it's already at latest (poetry reports "No dependencies to install or update" and version unchanged)
+
+## Dependency order within each subproject
+
+`[project.dependencies]` first, then `[tool.poetry.group.test.dependencies]`, then `[tool.poetry.group.dev.dependencies]`.
+
+## Commit message format
+
+`deps: update <package> from v<old> to v<new>`
+
+For forced co-updates: `deps: update <pkg1> from v<old> to v<new>, <pkg2> from v<old> to v<new>`

--- a/.claude/skills/update-py-deps/update-dep.sh
+++ b/.claude/skills/update-py-deps/update-dep.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Usage: update-dep.sh <subproject_dir> <pkg_spec> [extra_poetry_add_args...]
+# pkg_spec: package name optionally with version (e.g. "mypy" or "mypy@latest" or "mypy@^1.2")
+# Defaults to "<pkg>@latest" when no version suffix is given.
+# Extra args (e.g. --group test) are passed through to poetry add.
+set -euo pipefail
+
+SUBPROJECT_DIR="$1"
+PKG_SPEC="$2"
+shift 2
+EXTRA_ARGS=("$@")
+
+# Extract bare package name for poetry show
+PKG="${PKG_SPEC%%@*}"
+
+# Default to @latest if no version suffix provided
+if [[ "$PKG_SPEC" != *@* ]]; then
+  PKG_SPEC="${PKG_SPEC}@latest"
+fi
+
+cd "$SUBPROJECT_DIR"
+
+OLD=$(poetry show "$PKG" --no-ansi 2>/dev/null | grep "^ *version" | awk '{print $NF}')
+poetry add "$PKG_SPEC" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"
+NEW=$(poetry show "$PKG" --no-ansi 2>/dev/null | grep "^ *version" | awk '{print $NF}')
+poetry run poe pre-commit-check
+git add -A
+git commit -m "deps: update ${PKG} from v${OLD} to v${NEW}"

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -7,6 +7,7 @@ on:
       - "main"
     paths:
       - "doc_indexer/**"
+      - ".github/workflows/pull-e2e-tests-doc-indexer.yaml"
       - ".github/workflows/pull-build-image-indexer.yaml"
       - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,9 @@ __pycache__
 *.vsix
 
 
+# Claude Code
+.claude/settings.local.json
+
 # Custom rules
 .secrets
 scripts/k8s/aicore-secret.yaml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,3 +45,6 @@
 
 # All files and subdirectories in /docs
 /docs/ @kyma-project/technical-writers
+
+# Skills and Claude configuration — reviewed by ai-force, not technical writers
+/.claude/ @kyma-project/ai-force

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -232,6 +232,12 @@ class SearchKymaDocResponse(BaseModel):
     query: str = Field(..., description="Original search query")
 
 
+class SyncMessageResponse(BaseModel):
+    """Response model for the synchronous messages endpoint."""
+
+    answer: str = Field(..., description="The complete answer from the pipeline")
+
+
 # ============================================================================
 # Shared Dependencies
 # ============================================================================

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -60,12 +60,6 @@ class FollowUpQuestionsResponse(BaseModel):
     questions: list[str] = []
 
 
-class SyncMessageResponse(BaseModel):
-    """Response body for synchronous messages endpoint"""
-
-    answer: str
-
-
 # ============================================================================
 # Health/Probe Models
 # ============================================================================

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -60,6 +60,12 @@ class FollowUpQuestionsResponse(BaseModel):
     questions: list[str] = []
 
 
+class SyncMessageResponse(BaseModel):
+    """Response body for synchronous messages endpoint"""
+
+    answer: str
+
+
 # ============================================================================
 # Health/Probe Models
 # ============================================================================

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -6,7 +6,8 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path, Query
 from fastapi.encoders import jsonable_encoder
-from starlette.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from langgraph.constants import END
+from starlette.responses import JSONResponse, StreamingResponse
 
 from agents.common.constants import CLUSTER, ERROR_RATE_LIMIT_CODE, UNKNOWN
 from agents.common.data import Message
@@ -17,6 +18,8 @@ from routers.common import (
     FollowUpQuestionsResponse,
     InitConversationBody,
     InitialQuestionsResponse,
+    SyncMessageResponse,
+    init_k8s_client,
 )
 from services.conversation import ConversationService, IService
 from services.data_sanitizer import DataSanitizer, IDataSanitizer
@@ -201,54 +204,24 @@ async def followup_questions(
 async def messages(
     conversation_id: Annotated[UUID, Path(title="The ID of the conversation to continue")],
     message: Annotated[Message, Body(title="The message to send")],
-    x_cluster_url: Annotated[str, Header()],
-    x_cluster_certificate_authority_data: Annotated[str, Header()],
     conversation_service: Annotated[IService, Depends(init_conversation_service)],
-    data_sanitizer: Annotated[IDataSanitizer, Depends(init_data_sanitizer)],
-    x_k8s_authorization: Annotated[str, Header()] = None,  # type: ignore[assignment]
-    x_client_certificate_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
-    x_client_key_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
+    k8s_client: Annotated[IK8sClient, Depends(init_k8s_client)],
     _: Annotated[None, Depends(enforce_query_token_limit)] = None,
     stream: Annotated[
         bool,
-        Query(description="Stream the response as SSE. Set to false to receive the complete answer as plain text."),
+        Query(description="Stream the response as SSE. Set to false to receive the complete answer as JSON."),
     ] = True,
-) -> StreamingResponse | PlainTextResponse:
+) -> StreamingResponse | JSONResponse:
     """Endpoint to send a message to the Kyma companion"""
 
     logger.info(f"Handling conversation: {str(conversation_id)}. Request data: {message.model_dump_json()}")
 
-    # Validate if all the required K8s headers are provided.
-    k8s_auth_headers = K8sAuthHeaders(
-        x_cluster_url=x_cluster_url,
-        x_cluster_certificate_authority_data=x_cluster_certificate_authority_data,
-        x_k8s_authorization=x_k8s_authorization,
-        x_client_certificate_data=x_client_certificate_data,
-        x_client_key_data=x_client_key_data,
-    )
-    try:
-        k8s_auth_headers.validate_headers()
-    except Exception as e:
-        raise HTTPException(status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=str(e)) from e
-
     # Authorize the user to access the conversation.
-    message.user_identifier = extract_user_identifier(k8s_auth_headers)
+    message.user_identifier = extract_user_identifier(k8s_client.k8s_auth_headers)
     await authorize_user(str(conversation_id), message.user_identifier, conversation_service)
 
     # Check rate limitation
-    await check_token_usage(x_cluster_url, conversation_service)
-
-    # Initialize k8s client for the request.
-    try:
-        k8s_client: IK8sClient = K8sClient.new(
-            k8s_auth_headers=k8s_auth_headers,
-            data_sanitizer=data_sanitizer,
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=f"failed to connect to the cluster: {str(e)}",
-        ) from e
+    await check_token_usage(k8s_client.k8s_auth_headers.x_cluster_url, conversation_service)
 
     # Validate the k8s resource context.
     if not message.is_cluster_overview_query():
@@ -285,9 +258,12 @@ async def _collect_answer(
     message: Message,
     k8s_client: IK8sClient,
     conversation_service: IService,
-) -> PlainTextResponse:
-    """Drain the streaming pipeline and return the concatenated answer as plain text."""
-    final_answer = ""
+) -> JSONResponse:
+    """Drain the streaming pipeline and return the final answer as JSON.
+
+    Only the chunk where answer.next == END is the synthesized final response.
+    All other chunks are intermediate agent status updates.
+    """
     async for chunk in conversation_service.handle_request(conversation_id, message, k8s_client):
         chunk_response = prepare_chunk_response(chunk)
         if chunk_response is None:
@@ -295,20 +271,20 @@ async def _collect_answer(
         try:
             data = json.loads(chunk_response)
             chunk_data = data.get("data", {})
+            if not isinstance(chunk_data, dict):
+                continue
             if chunk_data.get("error") is not None:
                 continue
-            content = (chunk_data.get("answer") or {}).get("content", "")
+            answer = chunk_data.get("answer") or {}
+            if answer.get("next") != END:
+                continue
+            content = answer.get("content", "")
             if content:
-                final_answer += content
+                return JSONResponse(content=jsonable_encoder(SyncMessageResponse(answer=content)))
         except json.JSONDecodeError:
             logger.warning(f"Unexpected non-JSON chunk from pipeline: {chunk_response!r}")
-        except AttributeError:
-            logger.warning(f"Unexpected chunk structure from pipeline: {chunk_response!r}")
 
-    if not final_answer:
-        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="No answer was produced.")
-
-    return PlainTextResponse(final_answer)
+    raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="No answer was produced.")
 
 
 async def check_token_usage(x_cluster_url: str, conversation_service: IService) -> None:

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -4,9 +4,9 @@ from http import HTTPStatus
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path, Query
 from fastapi.encoders import jsonable_encoder
-from starlette.responses import JSONResponse, StreamingResponse
+from starlette.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from agents.common.constants import CLUSTER, ERROR_RATE_LIMIT_CODE, UNKNOWN
 from agents.common.data import Message
@@ -17,8 +17,6 @@ from routers.common import (
     FollowUpQuestionsResponse,
     InitConversationBody,
     InitialQuestionsResponse,
-    SyncMessageResponse,
-    init_k8s_client,
 )
 from services.conversation import ConversationService, IService
 from services.data_sanitizer import DataSanitizer, IDataSanitizer
@@ -199,7 +197,7 @@ async def followup_questions(
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e)) from e
 
 
-@router.post("/{conversation_id}/messages")
+@router.post("/{conversation_id}/messages", response_model=None)
 async def messages(
     conversation_id: Annotated[UUID, Path(title="The ID of the conversation to continue")],
     message: Annotated[Message, Body(title="The message to send")],
@@ -211,7 +209,11 @@ async def messages(
     x_client_certificate_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
     x_client_key_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
     _: Annotated[None, Depends(enforce_query_token_limit)] = None,
-) -> StreamingResponse:
+    stream: Annotated[
+        bool,
+        Query(description="Stream the response as SSE. Set to false to receive the complete answer as plain text."),
+    ] = True,
+) -> StreamingResponse | PlainTextResponse:
     """Endpoint to send a message to the Kyma companion"""
 
     logger.info(f"Handling conversation: {str(conversation_id)}. Request data: {message.model_dump_json()}")
@@ -264,6 +266,9 @@ async def messages(
         # mark the message as a cluster overview query
         message.resource_scope = CLUSTER
 
+    if not stream:
+        return await _collect_answer(str(conversation_id), message, k8s_client, conversation_service)
+
     return StreamingResponse(
         (
             chunk_response + b"\n"
@@ -275,43 +280,15 @@ async def messages(
     )
 
 
-@router.post("/{conversation_id}/messages/sync")
-async def messages_sync(
-    conversation_id: Annotated[UUID, Path(title="The ID of the conversation to continue")],
-    message: Annotated[Message, Body(title="The message to send")],
-    conversation_service: Annotated[IService, Depends(init_conversation_service)],
-    k8s_client: Annotated[IK8sClient, Depends(init_k8s_client)],
-    _: Annotated[None, Depends(enforce_query_token_limit)] = None,
-) -> SyncMessageResponse:
-    """Endpoint to send a message to the Kyma companion and receive the complete response synchronously."""
-
-    logger.info(f"Handling sync conversation: {str(conversation_id)}. Request data: {message.model_dump_json()}")
-
-    # Authorize the user to access the conversation.
-    # get_auth_headers() returns the resolved headers (decrypted if encrypted auth was used).
-    message.user_identifier = extract_user_identifier(k8s_client.get_auth_headers())
-    await authorize_user(str(conversation_id), message.user_identifier, conversation_service)
-
-    # Check rate limitation.
-    await check_token_usage(k8s_client.get_api_server(), conversation_service)
-
-    # Validate the k8s resource context.
-    if not message.is_cluster_overview_query():
-        try:
-            resource_kind_details = await K8sResourceDiscovery(k8s_client).get_resource_kind(
-                str(message.resource_api_version), str(message.resource_kind)
-            )
-            message.add_details(resource_kind_details)
-        except Exception as e:
-            logger.warning(f"Invalid resource context info: {str(e)}")
-            message.resource_kind = UNKNOWN
-            message.resource_api_version = UNKNOWN
-    else:
-        message.resource_scope = CLUSTER
-
-    # Collect the full response by draining the stream and concatenating all answer chunks.
+async def _collect_answer(
+    conversation_id: str,
+    message: Message,
+    k8s_client: IK8sClient,
+    conversation_service: IService,
+) -> PlainTextResponse:
+    """Drain the streaming pipeline and return the concatenated answer as plain text."""
     final_answer = ""
-    async for chunk in conversation_service.handle_request(str(conversation_id), message, k8s_client):
+    async for chunk in conversation_service.handle_request(conversation_id, message, k8s_client):
         chunk_response = prepare_chunk_response(chunk)
         if chunk_response is None:
             continue
@@ -331,7 +308,7 @@ async def messages_sync(
     if not final_answer:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="No answer was produced.")
 
-    return SyncMessageResponse(answer=final_answer)
+    return PlainTextResponse(final_answer)
 
 
 async def check_token_usage(x_cluster_url: str, conversation_service: IService) -> None:

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -309,7 +309,7 @@ async def messages_sync(
     else:
         message.resource_scope = CLUSTER
 
-    # Collect the full response by draining the stream and keeping the last non-empty answer.
+    # Collect the full response by draining the stream and concatenating all answer chunks.
     final_answer = ""
     async for chunk in conversation_service.handle_request(str(conversation_id), message, k8s_client):
         chunk_response = prepare_chunk_response(chunk)
@@ -318,11 +318,11 @@ async def messages_sync(
         try:
             data = json.loads(chunk_response)
             chunk_data = data.get("data", {})
-            if chunk_data.get("error"):
+            if chunk_data.get("error") is not None:
                 continue
-            content = chunk_data.get("answer", {}).get("content", "")
+            content = (chunk_data.get("answer") or {}).get("content", "")
             if content:
-                final_answer = content
+                final_answer += content
         except json.JSONDecodeError:
             logger.warning(f"Unexpected non-JSON chunk from pipeline: {chunk_response!r}")
         except AttributeError:

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -275,14 +275,14 @@ async def messages(
     )
 
 
-@router.post("/{conversation_id}/messages/sync", response_model=SyncMessageResponse)
+@router.post("/{conversation_id}/messages/sync")
 async def messages_sync(
     conversation_id: Annotated[UUID, Path(title="The ID of the conversation to continue")],
     message: Annotated[Message, Body(title="The message to send")],
     conversation_service: Annotated[IService, Depends(init_conversation_service)],
     k8s_client: Annotated[IK8sClient, Depends(init_k8s_client)],
     _: Annotated[None, Depends(enforce_query_token_limit)] = None,
-) -> JSONResponse:
+) -> SyncMessageResponse:
     """Endpoint to send a message to the Kyma companion and receive the complete response synchronously."""
 
     logger.info(f"Handling sync conversation: {str(conversation_id)}. Request data: {message.model_dump_json()}")
@@ -317,13 +317,19 @@ async def messages_sync(
             continue
         try:
             data = json.loads(chunk_response)
-            content = data.get("data", {}).get("answer", {}).get("content", "")
+            chunk_data = data.get("data", {})
+            if chunk_data.get("error"):
+                continue
+            content = chunk_data.get("answer", {}).get("content", "")
             if content:
                 final_answer = content
         except (json.JSONDecodeError, AttributeError):
             pass
 
-    return JSONResponse(content=jsonable_encoder(SyncMessageResponse(answer=final_answer)))
+    if not final_answer:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="No answer was produced.")
+
+    return SyncMessageResponse(answer=final_answer)
 
 
 async def check_token_usage(x_cluster_url: str, conversation_service: IService) -> None:

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -323,8 +323,10 @@ async def messages_sync(
             content = chunk_data.get("answer", {}).get("content", "")
             if content:
                 final_answer = content
-        except (json.JSONDecodeError, AttributeError):
-            pass
+        except json.JSONDecodeError:
+            logger.warning(f"Unexpected non-JSON chunk from pipeline: {chunk_response!r}")
+        except AttributeError:
+            logger.warning(f"Unexpected chunk structure from pipeline: {chunk_response!r}")
 
     if not final_answer:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="No answer was produced.")

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -1,3 +1,4 @@
+import json
 from functools import lru_cache
 from http import HTTPStatus
 from typing import Annotated
@@ -16,6 +17,8 @@ from routers.common import (
     FollowUpQuestionsResponse,
     InitConversationBody,
     InitialQuestionsResponse,
+    SyncMessageResponse,
+    init_k8s_client,
 )
 from services.conversation import ConversationService, IService
 from services.data_sanitizer import DataSanitizer, IDataSanitizer
@@ -270,6 +273,57 @@ async def messages(
         ),
         media_type="text/event-stream",
     )
+
+
+@router.post("/{conversation_id}/messages/sync", response_model=SyncMessageResponse)
+async def messages_sync(
+    conversation_id: Annotated[UUID, Path(title="The ID of the conversation to continue")],
+    message: Annotated[Message, Body(title="The message to send")],
+    conversation_service: Annotated[IService, Depends(init_conversation_service)],
+    k8s_client: Annotated[IK8sClient, Depends(init_k8s_client)],
+    _: Annotated[None, Depends(enforce_query_token_limit)] = None,
+) -> JSONResponse:
+    """Endpoint to send a message to the Kyma companion and receive the complete response synchronously."""
+
+    logger.info(f"Handling sync conversation: {str(conversation_id)}. Request data: {message.model_dump_json()}")
+
+    # Authorize the user to access the conversation.
+    # get_auth_headers() returns the resolved headers (decrypted if encrypted auth was used).
+    message.user_identifier = extract_user_identifier(k8s_client.get_auth_headers())
+    await authorize_user(str(conversation_id), message.user_identifier, conversation_service)
+
+    # Check rate limitation.
+    await check_token_usage(k8s_client.get_api_server(), conversation_service)
+
+    # Validate the k8s resource context.
+    if not message.is_cluster_overview_query():
+        try:
+            resource_kind_details = await K8sResourceDiscovery(k8s_client).get_resource_kind(
+                str(message.resource_api_version), str(message.resource_kind)
+            )
+            message.add_details(resource_kind_details)
+        except Exception as e:
+            logger.warning(f"Invalid resource context info: {str(e)}")
+            message.resource_kind = UNKNOWN
+            message.resource_api_version = UNKNOWN
+    else:
+        message.resource_scope = CLUSTER
+
+    # Collect the full response by draining the stream and keeping the last non-empty answer.
+    final_answer = ""
+    async for chunk in conversation_service.handle_request(str(conversation_id), message, k8s_client):
+        chunk_response = prepare_chunk_response(chunk)
+        if chunk_response is None:
+            continue
+        try:
+            data = json.loads(chunk_response)
+            content = data.get("data", {}).get("answer", {}).get("content", "")
+            if content:
+                final_answer = content
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    return JSONResponse(content=jsonable_encoder(SyncMessageResponse(answer=final_answer)))
 
 
 async def check_token_usage(x_cluster_url: str, conversation_service: IService) -> None:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -222,10 +222,6 @@ class IK8sClient(Protocol):
         """Return the data sanitizer instance"""
         ...
 
-    def get_auth_headers(self) -> K8sAuthHeaders:
-        """Return the K8s authentication headers."""
-        ...
-
 
 def get_url_for_paged_request(base_url: str, continue_token: str) -> str:
     """Construct the URL for paginated requests."""
@@ -322,10 +318,6 @@ class K8sClient:
     def get_api_server(self) -> str:
         """Returns the URL of the Kubernetes cluster."""
         return self.k8s_auth_headers.x_cluster_url
-
-    def get_auth_headers(self) -> K8sAuthHeaders:
-        """Return the K8s authentication headers."""
-        return self.k8s_auth_headers
 
     @property
     def dynamic_client(self) -> dynamic.DynamicClient:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -129,6 +129,8 @@ class K8sAuthHeaders(BaseModel):
 class IK8sClient(Protocol):
     """Interface for the K8sClient class."""
 
+    k8s_auth_headers: K8sAuthHeaders
+
     def get_api_server(self) -> str:
         """Returns the URL of the Kubernetes cluster."""
         ...

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -222,6 +222,10 @@ class IK8sClient(Protocol):
         """Return the data sanitizer instance"""
         ...
 
+    def get_auth_headers(self) -> K8sAuthHeaders:
+        """Return the K8s authentication headers."""
+        ...
+
 
 def get_url_for_paged_request(base_url: str, continue_token: str) -> str:
     """Construct the URL for paginated requests."""
@@ -318,6 +322,10 @@ class K8sClient:
     def get_api_server(self) -> str:
         """Returns the URL of the Kubernetes cluster."""
         return self.k8s_auth_headers.x_cluster_url
+
+    def get_auth_headers(self) -> K8sAuthHeaders:
+        """Return the K8s authentication headers."""
+        return self.k8s_auth_headers
 
     @property
     def dynamic_client(self) -> dynamic.DynamicClient:

--- a/tests/blackbox/src/api_tests/test_conversations_sync_api.py
+++ b/tests/blackbox/src/api_tests/test_conversations_sync_api.py
@@ -14,7 +14,7 @@ from common.config import Config
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 300  # seconds; sync endpoint waits for the full response
+TIMEOUT = 300  # seconds; sync endpoint drains the full LLM response before returning
 
 
 @pytest.fixture(scope="module")
@@ -96,7 +96,7 @@ class TestConversationsSyncAPI:
             timeout=TIMEOUT,
         )
 
-        assert response.status_code >= HTTPStatus.BAD_REQUEST
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_sync_with_invalid_conversation_id_returns_422(
         self,

--- a/tests/blackbox/src/api_tests/test_conversations_sync_api.py
+++ b/tests/blackbox/src/api_tests/test_conversations_sync_api.py
@@ -65,7 +65,7 @@ class TestConversationsSyncAPI:
         auth_headers: dict[str, str],
         conversation_id: str,
     ) -> None:
-        """Test that the sync endpoint returns a plain text non-empty answer string."""
+        """Test that the sync endpoint returns a JSON object with a non-empty answer string."""
         logger.info(f"Testing sync messages endpoint for conversation {conversation_id}")
 
         response = requests.post(
@@ -76,10 +76,10 @@ class TestConversationsSyncAPI:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert response.headers["content-type"].startswith("text/plain")
-        assert isinstance(response.text, str)
-        assert len(response.text) > 0
-        logger.info(f"Sync endpoint returned answer of length {len(response.text)}")
+        assert response.headers["content-type"].startswith("application/json")
+        assert isinstance(response.json().get("answer"), str)
+        assert len(response.json()["answer"]) > 0
+        logger.info(f"Sync endpoint returned answer of length {len(response.json()['answer'])}")
 
     def test_sync_without_auth_returns_error(
         self,

--- a/tests/blackbox/src/api_tests/test_conversations_sync_api.py
+++ b/tests/blackbox/src/api_tests/test_conversations_sync_api.py
@@ -1,0 +1,114 @@
+"""
+API tests for the synchronous messages endpoint.
+
+These tests validate the POST /api/conversations/{id}/messages/sync endpoint by
+making actual HTTP requests to a running Kyma Companion server instance.
+"""
+
+import logging
+from http import HTTPStatus
+
+import pytest
+import requests
+from common.config import Config
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 300  # seconds; sync endpoint waits for the full response
+
+
+@pytest.fixture(scope="module")
+def config() -> Config:
+    """Load configuration for tests."""
+    return Config()
+
+
+@pytest.fixture(scope="module")
+def auth_headers(config: Config) -> dict[str, str]:
+    """Get authentication headers for API requests."""
+    return {
+        "Content-Type": "application/json",
+        "x-cluster-url": config.test_cluster_url,
+        "x-cluster-certificate-authority-data": config.test_cluster_ca_data,
+        "x-k8s-authorization": config.test_cluster_auth_token,
+    }
+
+
+@pytest.fixture(scope="module")
+def base_api_url(config: Config) -> str:
+    """Get base API URL."""
+    return config.companion_api_url
+
+
+@pytest.fixture(scope="module")
+def conversation_id(base_api_url: str, auth_headers: dict[str, str]) -> str:
+    """Initialize a conversation and return its ID."""
+    response = requests.post(
+        f"{base_api_url}/api/conversations",
+        json={"resource_kind": "Cluster"},
+        headers=auth_headers,
+        timeout=TIMEOUT,
+    )
+    assert response.status_code == HTTPStatus.OK, (
+        f"Failed to initialize conversation: {response.status_code} {response.text}"
+    )
+    data = response.json()
+    return data["conversation_id"]
+
+
+class TestConversationsSyncAPI:
+    """Test suite for the synchronous messages endpoint."""
+
+    def test_sync_returns_answer_string(
+        self,
+        base_api_url: str,
+        auth_headers: dict[str, str],
+        conversation_id: str,
+    ) -> None:
+        """Test that the sync endpoint returns a JSON object with a non-empty answer string."""
+        logger.info(f"Testing sync messages endpoint for conversation {conversation_id}")
+
+        response = requests.post(
+            f"{base_api_url}/api/conversations/{conversation_id}/messages/sync",
+            json={"query": "What is Kyma?", "resource_kind": "Cluster"},
+            headers=auth_headers,
+            timeout=TIMEOUT,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["content-type"].startswith("application/json")
+        data = response.json()
+        assert "answer" in data
+        assert isinstance(data["answer"], str)
+        assert len(data["answer"]) > 0
+        logger.info(f"Sync endpoint returned answer of length {len(data['answer'])}")
+
+    def test_sync_without_auth_returns_error(
+        self,
+        base_api_url: str,
+        conversation_id: str,
+    ) -> None:
+        """Test that the sync endpoint returns an error when no auth headers are provided."""
+        response = requests.post(
+            f"{base_api_url}/api/conversations/{conversation_id}/messages/sync",
+            json={"query": "What is Kyma?", "resource_kind": "Cluster"},
+            headers={"Content-Type": "application/json"},
+            timeout=TIMEOUT,
+        )
+
+        assert response.status_code >= HTTPStatus.BAD_REQUEST
+
+    def test_sync_with_invalid_conversation_id_returns_422(
+        self,
+        base_api_url: str,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test that an invalid conversation ID returns 422."""
+        response = requests.post(
+            f"{base_api_url}/api/conversations/not-a-uuid/messages/sync",
+            json={"query": "What is Kyma?", "resource_kind": "Cluster"},
+            headers=auth_headers,
+            timeout=TIMEOUT,
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/blackbox/src/api_tests/test_conversations_sync_api.py
+++ b/tests/blackbox/src/api_tests/test_conversations_sync_api.py
@@ -1,7 +1,7 @@
 """
-API tests for the synchronous messages endpoint.
+API tests for the non-streaming messages endpoint (?stream=false).
 
-These tests validate the POST /api/conversations/{id}/messages/sync endpoint by
+These tests validate the POST /api/conversations/{id}/messages?stream=false endpoint by
 making actual HTTP requests to a running Kyma Companion server instance.
 """
 
@@ -65,23 +65,21 @@ class TestConversationsSyncAPI:
         auth_headers: dict[str, str],
         conversation_id: str,
     ) -> None:
-        """Test that the sync endpoint returns a JSON object with a non-empty answer string."""
+        """Test that the sync endpoint returns a plain text non-empty answer string."""
         logger.info(f"Testing sync messages endpoint for conversation {conversation_id}")
 
         response = requests.post(
-            f"{base_api_url}/api/conversations/{conversation_id}/messages/sync",
+            f"{base_api_url}/api/conversations/{conversation_id}/messages?stream=false",
             json={"query": "What is Kyma?", "resource_kind": "Cluster"},
             headers=auth_headers,
             timeout=TIMEOUT,
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert response.headers["content-type"].startswith("application/json")
-        data = response.json()
-        assert "answer" in data
-        assert isinstance(data["answer"], str)
-        assert len(data["answer"]) > 0
-        logger.info(f"Sync endpoint returned answer of length {len(data['answer'])}")
+        assert response.headers["content-type"].startswith("text/plain")
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+        logger.info(f"Sync endpoint returned answer of length {len(response.text)}")
 
     def test_sync_without_auth_returns_error(
         self,
@@ -90,7 +88,7 @@ class TestConversationsSyncAPI:
     ) -> None:
         """Test that the sync endpoint returns an error when no auth headers are provided."""
         response = requests.post(
-            f"{base_api_url}/api/conversations/{conversation_id}/messages/sync",
+            f"{base_api_url}/api/conversations/{conversation_id}/messages?stream=false",
             json={"query": "What is Kyma?", "resource_kind": "Cluster"},
             headers={"Content-Type": "application/json"},
             timeout=TIMEOUT,
@@ -105,7 +103,7 @@ class TestConversationsSyncAPI:
     ) -> None:
         """Test that an invalid conversation ID returns 422."""
         response = requests.post(
-            f"{base_api_url}/api/conversations/not-a-uuid/messages/sync",
+            f"{base_api_url}/api/conversations/not-a-uuid/messages?stream=false",
             json={"query": "What is Kyma?", "resource_kind": "Cluster"},
             headers=auth_headers,
             timeout=TIMEOUT,

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -1370,7 +1370,13 @@ def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_
 
     response = test_client.post(
         f"/api/conversations/{uuid.uuid4()}/messages/sync",
-        json={"query": "test", "resource_kind": "Cluster", "resource_api_version": "", "resource_name": "", "namespace": ""},
+        json={
+            "query": "test",
+            "resource_kind": "Cluster",
+            "resource_api_version": "",
+            "resource_name": "",
+            "namespace": "",
+        },
     )
 
     app.dependency_overrides.clear()

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -12,7 +12,6 @@ from fastapi.testclient import TestClient
 from agents.common.constants import ERROR_RATE_LIMIT_CODE, UNKNOWN
 from agents.common.data import Message
 from main import app
-from routers.common import init_k8s_client
 from routers.conversations import (
     authorize_user,
     check_token_usage,
@@ -92,20 +91,12 @@ class MockService(IService):
 class MockK8sClient:
     """Mock for the K8sClient class."""
 
-    def __init__(self, token: str = SAMPLE_JWT_TOKEN):
+    def __init__(self, token: str = SAMPLE_JWT_TOKEN, api_server: str = "http://api.k8s.example.com"):
         self._token = token
+        self._api_server = api_server
 
     def get_api_server(self) -> str:
-        return "http://api.k8s.example.com"
-
-    def get_auth_headers(self):
-        from services.k8s import K8sAuthHeaders
-
-        return K8sAuthHeaders(
-            x_cluster_url="http://api.k8s.example.com",
-            x_cluster_certificate_authority_data="non-empty-ca-data",
-            x_k8s_authorization=self._token,
-        )
+        return self._api_server
 
     def model_dump(self) -> None:
         return None
@@ -1147,58 +1138,17 @@ def test_enforce_query_token_limit(mock_token_count, should_raise_exception):
             enforce_query_token_limit(message)  # Should not raise
 
 
-@pytest.fixture(scope="function")
-def sync_client_factory():
-    def _create_client(mock_k8s_client=None, expected_error=None, mock_service=None):
-        if mock_service is None:
-            mock_service = MockService(expected_error)
-        if mock_k8s_client is None:
-            mock_k8s_client = MockK8sClient()
-
-        async def get_mock_k8s_client():
-            return mock_k8s_client
-
-        app.dependency_overrides[init_conversation_service] = lambda: mock_service
-        app.dependency_overrides[init_k8s_client] = get_mock_k8s_client
-        return TestClient(app)
-
-    yield _create_client
-
-    app.dependency_overrides.pop(init_conversation_service, None)
-    app.dependency_overrides.pop(init_k8s_client, None)
-
-
-def _make_k8s_client_for_cert() -> MockK8sClient:
-    """Return a MockK8sClient that identifies via client certificate."""
-    from services.k8s import K8sAuthHeaders
-
-    client = MockK8sClient(token=SAMPLE_JWT_TOKEN)
-
-    def get_auth_headers_cert():
-        return K8sAuthHeaders(
-            x_cluster_url="http://api.k8s.example.com",
-            x_cluster_certificate_authority_data="non-empty-ca-data",
-            x_client_certificate_data=SAMPLE_CLIENT_CERTIFICATE_DATA,
-            x_client_key_data="non-empty-client-key-data",
-        )
-
-    client.get_auth_headers = get_auth_headers_cert  # type: ignore[method-assign]
-    return client
-
-
-def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
-    """Return a MockK8sClient whose cluster URL triggers the rate-limit check."""
-    client = MockK8sClient(token=token)
-    client.get_api_server = lambda: "http://api.EXCEEDED.example.com"  # type: ignore[method-assign]
-    return client
-
-
 @pytest.mark.parametrize(
-    "test_description, mock_k8s_client, conversation_id, input_message, expected_output",
+    "test_description, mock_k8s_client, request_headers, conversation_id, input_message, expected_output",
     [
         (
             "should return final answer for a cluster overview query",
             MockK8sClient(token=SAMPLE_JWT_TOKEN),
+            {
+                "x-k8s-authorization": SAMPLE_JWT_TOKEN,
+                "x-cluster-url": "http://api.k8s.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             uuid.uuid4(),
             {
                 "query": "How to expose a Kyma application?",
@@ -1209,14 +1159,20 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
             },
             {
                 "status_code": 200,
-                "content-type": "application/json",
+                "content-type": "text/plain; charset=utf-8",
                 "answer": "To create an API Rule in Kyma to expose a service externally"
                 "To create a kubernetes deployment",
             },
         ),
         (
             "should return final answer when client certificate is provided",
-            _make_k8s_client_for_cert(),
+            MockK8sClient(token=SAMPLE_JWT_TOKEN),
+            {
+                "X-Client-Certificate-Data": SAMPLE_CLIENT_CERTIFICATE_DATA,
+                "X-Client-Key-Data": "non-empty-client-key-data",
+                "x-cluster-url": "http://api.k8s.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             uuid.uuid4(),
             {
                 "query": "How to expose a Kyma application?",
@@ -1227,7 +1183,7 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
             },
             {
                 "status_code": 200,
-                "content-type": "application/json",
+                "content-type": "text/plain; charset=utf-8",
                 "answer": "To create an API Rule in Kyma to expose a service externally"
                 "To create a kubernetes deployment",
             },
@@ -1235,6 +1191,11 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
         (
             "should return 401 when no auth token is provided",
             MockK8sClient(token=""),
+            {
+                "x-k8s-authorization": "",
+                "x-cluster-url": "http://api.k8s.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             uuid.uuid4(),
             {
                 "query": "How to expose a Kyma application?",
@@ -1251,6 +1212,11 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
         (
             "should return 403 when user is not authorized",
             MockK8sClient(token=jwt.encode({"sub": "UNAUTHORIZED"}, "secret", algorithm="HS256")),
+            {
+                "x-k8s-authorization": jwt.encode({"sub": "UNAUTHORIZED"}, "secret", algorithm="HS256"),
+                "x-cluster-url": "http://api.k8s.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             uuid.uuid4(),
             {
                 "query": "How to expose a Kyma application?",
@@ -1266,7 +1232,12 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
         ),
         (
             "should return token usage exceeded error",
-            _make_k8s_client_for_exceeded(SAMPLE_JWT_TOKEN),
+            MockK8sClient(token=SAMPLE_JWT_TOKEN, api_server="http://api.EXCEEDED.example.com"),
+            {
+                "x-k8s-authorization": SAMPLE_JWT_TOKEN,
+                "x-cluster-url": "http://api.EXCEEDED.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             uuid.uuid4(),
             {
                 "query": "Test query",
@@ -1292,6 +1263,11 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
         (
             "should return 422 when conversation_id is not a valid uuid",
             MockK8sClient(token=SAMPLE_JWT_TOKEN),
+            {
+                "x-k8s-authorization": SAMPLE_JWT_TOKEN,
+                "x-cluster-url": "http://api.k8s.example.com",
+                "x-cluster-certificate-authority-data": "non-empty-ca-data",
+            },
             "abcdef",
             {
                 "query": "How to expose a Kyma application?",
@@ -1307,43 +1283,46 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
         ),
     ],
 )
-def test_messages_sync_endpoint(
-    sync_client_factory,
+def test_messages_stream_false(
+    client_factory,
     test_description,
     mock_k8s_client,
+    request_headers,
     conversation_id,
     input_message,
     expected_output,
 ):
-    test_client = sync_client_factory(mock_k8s_client=mock_k8s_client)
+    with patch("services.k8s.K8sClient.new", return_value=mock_k8s_client):
+        test_client = client_factory()
 
-    # save metrics before request.
-    metric_name = f"{REQUEST_LATENCY_METRIC_KEY}_count"
-    metric_labels = {
-        "method": "POST",
-        "status": str(expected_output["status_code"]),
-        "path": "/api/conversations/{conversation_id}/messages/sync",
-    }
-    before_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels) or 0.0
+        metric_name = f"{REQUEST_LATENCY_METRIC_KEY}_count"
+        metric_labels = {
+            "method": "POST",
+            "status": str(expected_output["status_code"]),
+            "path": "/api/conversations/{conversation_id}/messages",
+        }
+        before_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels) or 0.0
 
-    response = test_client.post(
-        f"/api/conversations/{conversation_id}/messages/sync",
-        json=input_message,
-    )
+        response = test_client.post(
+            f"/api/conversations/{conversation_id}/messages?stream=false",
+            json=input_message,
+            headers=request_headers,
+        )
 
-    assert response.status_code == expected_output["status_code"]
-    assert response.headers["content-type"] == expected_output["content-type"]
+        assert response.status_code == expected_output["status_code"]
+        assert response.headers["content-type"] == expected_output["content-type"]
 
-    after_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels)
-    assert after_metric_value > before_metric_value
+        after_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels)
+        assert after_metric_value > before_metric_value
 
-    if expected_output["status_code"] == HTTPStatus.OK:
-        assert json.loads(response.content)["answer"] == expected_output["answer"]
-    elif "body" in expected_output:
-        assert json.loads(response.content) == expected_output["body"]
+        if expected_output["status_code"] == HTTPStatus.OK:
+            assert response.text == expected_output["answer"]
+        elif "body" in expected_output:
+            assert json.loads(response.content) == expected_output["body"]
 
 
-def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_factory):
+@patch("services.k8s.K8sClient.new", return_value=MockK8sClient())
+def test_messages_stream_false_returns_500_when_no_answer_produced(mock_init, client_factory):
     """Endpoint must return 500 when the pipeline emits only error chunks."""
 
     class ErrorOnlyService(IService):
@@ -1362,16 +1341,22 @@ def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_
         async def handle_request(self, conversation_id, message, k8s_client):
             yield b'{"error": {"error": "pipeline failed"}}'
 
-    test_client = sync_client_factory(mock_service=ErrorOnlyService())
+    test_client = client_factory(expected_error=None)
+    app.dependency_overrides[init_conversation_service] = lambda: ErrorOnlyService()
 
     response = test_client.post(
-        f"/api/conversations/{uuid.uuid4()}/messages/sync",
+        f"/api/conversations/{uuid.uuid4()}/messages?stream=false",
         json={
             "query": "test",
             "resource_kind": "Cluster",
             "resource_api_version": "",
             "resource_name": "",
             "namespace": "",
+        },
+        headers={
+            "x-k8s-authorization": SAMPLE_JWT_TOKEN,
+            "x-cluster-url": "http://api.k8s.example.com",
+            "x-cluster-certificate-authority-data": "non-empty-ca-data",
         },
     )
 

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -1149,8 +1149,9 @@ def test_enforce_query_token_limit(mock_token_count, should_raise_exception):
 
 @pytest.fixture(scope="function")
 def sync_client_factory():
-    def _create_client(mock_k8s_client=None, expected_error=None):
-        mock_service = MockService(expected_error)
+    def _create_client(mock_k8s_client=None, expected_error=None, mock_service=None):
+        if mock_service is None:
+            mock_service = MockService(expected_error)
         if mock_k8s_client is None:
             mock_k8s_client = MockK8sClient()
 
@@ -1163,7 +1164,8 @@ def sync_client_factory():
 
     yield _create_client
 
-    app.dependency_overrides.clear()
+    app.dependency_overrides.pop(init_conversation_service, None)
+    app.dependency_overrides.pop(init_k8s_client, None)
 
 
 def _make_k8s_client_for_cert() -> MockK8sClient:
@@ -1208,7 +1210,8 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
             {
                 "status_code": 200,
                 "content-type": "application/json",
-                "answer": "To create a kubernetes deployment",
+                "answer": "To create an API Rule in Kyma to expose a service externally"
+                "To create a kubernetes deployment",
             },
         ),
         (
@@ -1225,7 +1228,8 @@ def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
             {
                 "status_code": 200,
                 "content-type": "application/json",
-                "answer": "To create a kubernetes deployment",
+                "answer": "To create an API Rule in Kyma to expose a service externally"
+                "To create a kubernetes deployment",
             },
         ),
         (
@@ -1358,15 +1362,7 @@ def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_
         async def handle_request(self, conversation_id, message, k8s_client):
             yield b'{"error": {"error": "pipeline failed"}}'
 
-    mock_service = ErrorOnlyService()
-    mock_k8s_client = MockK8sClient()
-
-    async def get_mock_k8s_client():
-        return mock_k8s_client
-
-    app.dependency_overrides[init_conversation_service] = lambda: mock_service
-    app.dependency_overrides[init_k8s_client] = get_mock_k8s_client
-    test_client = TestClient(app)
+    test_client = sync_client_factory(mock_service=ErrorOnlyService())
 
     response = test_client.post(
         f"/api/conversations/{uuid.uuid4()}/messages/sync",
@@ -1378,7 +1374,5 @@ def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_
             "namespace": "",
         },
     )
-
-    app.dependency_overrides.clear()
 
     assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -1337,3 +1337,42 @@ def test_messages_sync_endpoint(
         assert json.loads(response.content)["answer"] == expected_output["answer"]
     elif "body" in expected_output:
         assert json.loads(response.content) == expected_output["body"]
+
+
+def test_messages_sync_endpoint_returns_500_when_no_answer_produced(sync_client_factory):
+    """Endpoint must return 500 when the pipeline emits only error chunks."""
+
+    class ErrorOnlyService(IService):
+        async def new_conversation(self, k8s_client, message):
+            return []
+
+        async def handle_followup_questions(self, conversation_id):
+            return []
+
+        async def authorize_user(self, conversation_id, user_identifier):
+            return True
+
+        async def is_usage_limit_exceeded(self, cluster_id):
+            return None
+
+        async def handle_request(self, conversation_id, message, k8s_client):
+            yield b'{"error": {"error": "pipeline failed"}}'
+
+    mock_service = ErrorOnlyService()
+    mock_k8s_client = MockK8sClient()
+
+    async def get_mock_k8s_client():
+        return mock_k8s_client
+
+    app.dependency_overrides[init_conversation_service] = lambda: mock_service
+    app.dependency_overrides[init_k8s_client] = get_mock_k8s_client
+    test_client = TestClient(app)
+
+    response = test_client.post(
+        f"/api/conversations/{uuid.uuid4()}/messages/sync",
+        json={"query": "test", "resource_kind": "Cluster", "resource_api_version": "", "resource_name": "", "namespace": ""},
+    )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from agents.common.constants import ERROR_RATE_LIMIT_CODE, UNKNOWN
 from agents.common.data import Message
 from main import app
+from routers.common import init_k8s_client
 from routers.conversations import (
     authorize_user,
     check_token_usage,
@@ -86,14 +87,30 @@ class MockService(IService):
             b'"id": null, "example": false, "tool_calls": [], "invalid_tool_calls": [], '
             b'"usage_metadata": null}]}}'
         )
+        yield (
+            b'{"Supervisor": {"messages": [{"content": "Final synthesized answer", '
+            b'"additional_kwargs": {}, "response_metadata": {}, "type": "ai", "name": "Finalizer", '
+            b'"id": null, "example": false, "tool_calls": [], "invalid_tool_calls": [], '
+            b'"usage_metadata": null}], "next": "__end__"}}'
+        )
 
 
 class MockK8sClient:
     """Mock for the K8sClient class."""
 
-    def __init__(self, token: str = SAMPLE_JWT_TOKEN, api_server: str = "http://api.k8s.example.com"):
+    def __init__(
+        self,
+        token: str = SAMPLE_JWT_TOKEN,
+        api_server: str = "http://api.k8s.example.com",
+        k8s_auth_headers: K8sAuthHeaders | None = None,
+    ):
         self._token = token
         self._api_server = api_server
+        self.k8s_auth_headers = k8s_auth_headers or K8sAuthHeaders(
+            x_cluster_url=api_server,
+            x_cluster_certificate_authority_data="dGVzdA==",
+            x_k8s_authorization=token if token else None,
+        )
 
     def get_api_server(self) -> str:
         return self._api_server
@@ -163,13 +180,41 @@ class MockK8sClient:
 
 @pytest.fixture(scope="function")
 def client_factory():
-    def _create_client(expected_error=None):
+    def _create_client(expected_error=None, mock_k8s_client=None):
+        from typing import Annotated
+
+        from fastapi import Header, HTTPException
+
         mock_service = MockService(expected_error)
 
         def get_mock_service():
             return mock_service
 
+        async def get_mock_k8s_client(
+            x_cluster_url: Annotated[str, Header()] = None,  # type: ignore[assignment]
+            x_cluster_certificate_authority_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
+            x_k8s_authorization: Annotated[str, Header()] = None,  # type: ignore[assignment]
+            x_client_certificate_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
+            x_client_key_data: Annotated[str, Header()] = None,  # type: ignore[assignment]
+        ) -> IK8sClient:
+            headers = K8sAuthHeaders(
+                x_cluster_url=x_cluster_url or "",
+                x_cluster_certificate_authority_data=x_cluster_certificate_authority_data or "",
+                x_k8s_authorization=x_k8s_authorization,
+                x_client_certificate_data=x_client_certificate_data if x_client_certificate_data else None,
+                x_client_key_data=x_client_key_data if x_client_key_data else None,
+            )
+            try:
+                headers.validate_headers()
+            except Exception as e:
+                raise HTTPException(status_code=422, detail=str(e)) from e
+            if mock_k8s_client is not None:
+                mock_k8s_client.k8s_auth_headers = headers
+                return mock_k8s_client
+            return MockK8sClient(k8s_auth_headers=headers)
+
         app.dependency_overrides[init_conversation_service] = get_mock_service
+        app.dependency_overrides[init_k8s_client] = get_mock_k8s_client
         test_client = TestClient(app)
 
         return test_client
@@ -180,7 +225,6 @@ def client_factory():
     app.dependency_overrides.clear()
 
 
-@patch("services.k8s.K8sClient.new", return_value=MockK8sClient())
 @pytest.mark.parametrize(
     "request_headers, conversation_id, input_message, expected_output",
     [
@@ -413,7 +457,6 @@ def client_factory():
     ],
 )
 def test_messages_endpoint(
-    mock_init,
     client_factory,
     request_headers,
     conversation_id,
@@ -1159,9 +1202,8 @@ def test_enforce_query_token_limit(mock_token_count, should_raise_exception):
             },
             {
                 "status_code": 200,
-                "content-type": "text/plain; charset=utf-8",
-                "answer": "To create an API Rule in Kyma to expose a service externally"
-                "To create a kubernetes deployment",
+                "content-type": "application/json",
+                "answer": "Final synthesized answer",
             },
         ),
         (
@@ -1183,9 +1225,8 @@ def test_enforce_query_token_limit(mock_token_count, should_raise_exception):
             },
             {
                 "status_code": 200,
-                "content-type": "text/plain; charset=utf-8",
-                "answer": "To create an API Rule in Kyma to expose a service externally"
-                "To create a kubernetes deployment",
+                "content-type": "application/json",
+                "answer": "Final synthesized answer",
             },
         ),
         (
@@ -1292,37 +1333,35 @@ def test_messages_stream_false(
     input_message,
     expected_output,
 ):
-    with patch("services.k8s.K8sClient.new", return_value=mock_k8s_client):
-        test_client = client_factory()
+    test_client = client_factory(mock_k8s_client=mock_k8s_client)
 
-        metric_name = f"{REQUEST_LATENCY_METRIC_KEY}_count"
-        metric_labels = {
-            "method": "POST",
-            "status": str(expected_output["status_code"]),
-            "path": "/api/conversations/{conversation_id}/messages",
-        }
-        before_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels) or 0.0
+    metric_name = f"{REQUEST_LATENCY_METRIC_KEY}_count"
+    metric_labels = {
+        "method": "POST",
+        "status": str(expected_output["status_code"]),
+        "path": "/api/conversations/{conversation_id}/messages",
+    }
+    before_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels) or 0.0
 
-        response = test_client.post(
-            f"/api/conversations/{conversation_id}/messages?stream=false",
-            json=input_message,
-            headers=request_headers,
-        )
+    response = test_client.post(
+        f"/api/conversations/{conversation_id}/messages?stream=false",
+        json=input_message,
+        headers=request_headers,
+    )
 
-        assert response.status_code == expected_output["status_code"]
-        assert response.headers["content-type"] == expected_output["content-type"]
+    assert response.status_code == expected_output["status_code"]
+    assert response.headers["content-type"] == expected_output["content-type"]
 
-        after_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels)
-        assert after_metric_value > before_metric_value
+    after_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels)
+    assert after_metric_value > before_metric_value
 
-        if expected_output["status_code"] == HTTPStatus.OK:
-            assert response.text == expected_output["answer"]
-        elif "body" in expected_output:
-            assert json.loads(response.content) == expected_output["body"]
+    if expected_output["status_code"] == HTTPStatus.OK:
+        assert response.json()["answer"] == expected_output["answer"]
+    elif "body" in expected_output:
+        assert json.loads(response.content) == expected_output["body"]
 
 
-@patch("services.k8s.K8sClient.new", return_value=MockK8sClient())
-def test_messages_stream_false_returns_500_when_no_answer_produced(mock_init, client_factory):
+def test_messages_stream_false_returns_500_when_no_answer_produced(client_factory):
     """Endpoint must return 500 when the pipeline emits only error chunks."""
 
     class ErrorOnlyService(IService):

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from agents.common.constants import ERROR_RATE_LIMIT_CODE, UNKNOWN
 from agents.common.data import Message
 from main import app
+from routers.common import init_k8s_client
 from routers.conversations import (
     authorize_user,
     check_token_usage,
@@ -91,8 +92,20 @@ class MockService(IService):
 class MockK8sClient:
     """Mock for the K8sClient class."""
 
+    def __init__(self, token: str = SAMPLE_JWT_TOKEN):
+        self._token = token
+
     def get_api_server(self) -> str:
-        return "http://localhost:8080"
+        return "http://api.k8s.example.com"
+
+    def get_auth_headers(self):
+        from services.k8s import K8sAuthHeaders
+
+        return K8sAuthHeaders(
+            x_cluster_url="http://api.k8s.example.com",
+            x_cluster_certificate_authority_data="non-empty-ca-data",
+            x_k8s_authorization=self._token,
+        )
 
     def model_dump(self) -> None:
         return None
@@ -1132,3 +1145,195 @@ def test_enforce_query_token_limit(mock_token_count, should_raise_exception):
             assert exc_info.value.detail == "Input Query exceeds the allowed token limit."
         else:
             enforce_query_token_limit(message)  # Should not raise
+
+
+@pytest.fixture(scope="function")
+def sync_client_factory():
+    def _create_client(mock_k8s_client=None, expected_error=None):
+        mock_service = MockService(expected_error)
+        if mock_k8s_client is None:
+            mock_k8s_client = MockK8sClient()
+
+        async def get_mock_k8s_client():
+            return mock_k8s_client
+
+        app.dependency_overrides[init_conversation_service] = lambda: mock_service
+        app.dependency_overrides[init_k8s_client] = get_mock_k8s_client
+        return TestClient(app)
+
+    yield _create_client
+
+    app.dependency_overrides.clear()
+
+
+def _make_k8s_client_for_cert() -> MockK8sClient:
+    """Return a MockK8sClient that identifies via client certificate."""
+    from services.k8s import K8sAuthHeaders
+
+    client = MockK8sClient(token=SAMPLE_JWT_TOKEN)
+
+    def get_auth_headers_cert():
+        return K8sAuthHeaders(
+            x_cluster_url="http://api.k8s.example.com",
+            x_cluster_certificate_authority_data="non-empty-ca-data",
+            x_client_certificate_data=SAMPLE_CLIENT_CERTIFICATE_DATA,
+            x_client_key_data="non-empty-client-key-data",
+        )
+
+    client.get_auth_headers = get_auth_headers_cert  # type: ignore[method-assign]
+    return client
+
+
+def _make_k8s_client_for_exceeded(token: str) -> MockK8sClient:
+    """Return a MockK8sClient whose cluster URL triggers the rate-limit check."""
+    client = MockK8sClient(token=token)
+    client.get_api_server = lambda: "http://api.EXCEEDED.example.com"  # type: ignore[method-assign]
+    return client
+
+
+@pytest.mark.parametrize(
+    "test_description, mock_k8s_client, conversation_id, input_message, expected_output",
+    [
+        (
+            "should return final answer for a cluster overview query",
+            MockK8sClient(token=SAMPLE_JWT_TOKEN),
+            uuid.uuid4(),
+            {
+                "query": "How to expose a Kyma application?",
+                "resource_kind": "Cluster",
+                "resource_api_version": "",
+                "resource_name": "",
+                "namespace": "",
+            },
+            {
+                "status_code": 200,
+                "content-type": "application/json",
+                "answer": "To create a kubernetes deployment",
+            },
+        ),
+        (
+            "should return final answer when client certificate is provided",
+            _make_k8s_client_for_cert(),
+            uuid.uuid4(),
+            {
+                "query": "How to expose a Kyma application?",
+                "resource_kind": "Cluster",
+                "resource_api_version": "",
+                "resource_name": "",
+                "namespace": "",
+            },
+            {
+                "status_code": 200,
+                "content-type": "application/json",
+                "answer": "To create a kubernetes deployment",
+            },
+        ),
+        (
+            "should return 401 when no auth token is provided",
+            MockK8sClient(token=""),
+            uuid.uuid4(),
+            {
+                "query": "How to expose a Kyma application?",
+                "resource_kind": "Pod",
+                "resource_api_version": "v1",
+                "resource_name": "my-pod",
+                "namespace": "default",
+            },
+            {
+                "status_code": 401,
+                "content-type": "application/json",
+            },
+        ),
+        (
+            "should return 403 when user is not authorized",
+            MockK8sClient(token=jwt.encode({"sub": "UNAUTHORIZED"}, "secret", algorithm="HS256")),
+            uuid.uuid4(),
+            {
+                "query": "How to expose a Kyma application?",
+                "resource_kind": "Cluster",
+                "resource_api_version": "",
+                "resource_name": "",
+                "namespace": "",
+            },
+            {
+                "status_code": 403,
+                "content-type": "application/json",
+            },
+        ),
+        (
+            "should return token usage exceeded error",
+            _make_k8s_client_for_exceeded(SAMPLE_JWT_TOKEN),
+            uuid.uuid4(),
+            {
+                "query": "Test query",
+                "resource_kind": "Cluster",
+                "resource_api_version": "",
+                "resource_name": "",
+                "namespace": "",
+            },
+            {
+                "status_code": ERROR_RATE_LIMIT_CODE,
+                "content-type": "application/json",
+                "body": {
+                    "current_usage": 1000,
+                    "error": "Token usage limit exceeded",
+                    "limit": 1000,
+                    "message": "Token usage limit of 1000 exceeded for this cluster. To ensure a "
+                    "fair usage, Joule controls the number of requests a "
+                    "cluster can make within 24 hours.",
+                    "time_remaining_seconds": 60,
+                },
+            },
+        ),
+        (
+            "should return 422 when conversation_id is not a valid uuid",
+            MockK8sClient(token=SAMPLE_JWT_TOKEN),
+            "abcdef",
+            {
+                "query": "How to expose a Kyma application?",
+                "resource_kind": "Cluster",
+                "resource_api_version": "",
+                "resource_name": "",
+                "namespace": "",
+            },
+            {
+                "status_code": 422,
+                "content-type": "application/json",
+            },
+        ),
+    ],
+)
+def test_messages_sync_endpoint(
+    sync_client_factory,
+    test_description,
+    mock_k8s_client,
+    conversation_id,
+    input_message,
+    expected_output,
+):
+    test_client = sync_client_factory(mock_k8s_client=mock_k8s_client)
+
+    # save metrics before request.
+    metric_name = f"{REQUEST_LATENCY_METRIC_KEY}_count"
+    metric_labels = {
+        "method": "POST",
+        "status": str(expected_output["status_code"]),
+        "path": "/api/conversations/{conversation_id}/messages/sync",
+    }
+    before_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels) or 0.0
+
+    response = test_client.post(
+        f"/api/conversations/{conversation_id}/messages/sync",
+        json=input_message,
+    )
+
+    assert response.status_code == expected_output["status_code"]
+    assert response.headers["content-type"] == expected_output["content-type"]
+
+    after_metric_value = CustomMetrics().registry.get_sample_value(metric_name, metric_labels)
+    assert after_metric_value > before_metric_value
+
+    if expected_output["status_code"] == HTTPStatus.OK:
+        assert json.loads(response.content)["answer"] == expected_output["answer"]
+    elif "body" in expected_output:
+        assert json.loads(response.content) == expected_output["body"]


### PR DESCRIPTION
Joule's A2A integration currently lacks metadata support, which means it cannot use the existing SSE-based messages endpoint. A non-streaming variant is needed as a fallback so Joule can call Kyma Companion directly over plain HTTP.

This adds a `?stream=false` query parameter to the existing `POST /api/conversations/{id}/messages` endpoint. When `stream=false`, the handler drains the streaming pipeline internally and returns the complete answer as a single `text/plain` response. All existing middleware applies: token-limit enforcement, cluster authorization, resource validation.

When `stream=true` (the default), the endpoint behaves identically to before.

**Changes proposed in this pull request:**
- add `?stream=false` query param to `POST /api/conversations/{id}/messages` in `src/routers/conversations.py`
- extract `_collect_answer()` helper that drains the pipeline and concatenates all answer chunks
- update unit tests in `tests/unit/routers/test_conversations.py`
- add blackbox API tests in `tests/blackbox/src/api_tests/test_conversations_sync_api.py`

**Testing**

Blackbox API tests added in `tests/blackbox/src/api_tests/test_conversations_sync_api.py`:
- `test_sync_returns_answer_string` - happy path: verifies the endpoint returns `200` with `content-type: text/plain` and a non-empty answer string
- `test_sync_without_auth_returns_error` - verifies that missing auth headers produce a `422` response
- `test_sync_with_invalid_conversation_id_returns_422` - verifies that a malformed conversation ID returns `422`

Manual end-to-end test against the running app with a k3d cluster. Created namespace `test-app` with deployment `broken-nginx` (image `nginx:nonexistent-tag`) to trigger `ErrImagePull`. Created a conversation session, then called the endpoint with `?stream=false`:

```
POST /api/conversations/e5ca13debd634fbb952068d5d84667de/messages?stream=false
The Deployment broken-nginx in the namespace test-app is not functioning correctly because the container image specified is nginx:nonexistent-tag. This tag does not exist for the official nginx image, so Kubernetes cannot pull the image, resulting in all replicas being unavailable.

To fix this issue, update the Deployment definition to use a valid nginx image tag, such as nginx:latest or another official tag...
```

Returns a single plain text response (`Content-Type: text/plain`), not SSE. All middleware (token limits, auth, resource validation) applied correctly.

**Related issue(s)**
Resolves #1106