### PR TITLE
fix: drop HANA table after doc-indexer e2e tests

### DIFF
--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -203,3 +203,40 @@ jobs:
           EOF
           kubectl wait --for=condition=complete job/doc-indexer-drop \
             -n "${{ env.NAMESPACE }}" --timeout=120s
+
+      - name: List HANA tables
+        if: always()
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: doc-indexer-tables
+            namespace: ${{ env.NAMESPACE }}
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: doc-indexer
+                  image: ${{ inputs.IMAGE_NAME }}
+                  imagePullPolicy: Never
+                  command: ["python", "src/main.py", "tables"]
+                  env:
+                  - name: LOG_LEVEL
+                    value: "INFO"
+                  - name: CONFIG_PATH
+                    value: "/etc/config/config.json"
+                  volumeMounts:
+                  - name: config
+                    mountPath: /etc/config/config.json
+                    subPath: config.json
+                volumes:
+                - name: config
+                  secret:
+                    secretName: doc-indexer-config
+          EOF
+          kubectl wait --for=condition=complete job/doc-indexer-tables \
+            -n "${{ env.NAMESPACE }}" --timeout=120s
+          kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -202,7 +202,10 @@ jobs:
                     secretName: doc-indexer-config
           EOF
           kubectl wait --for=condition=complete job/doc-indexer-drop \
-            -n "${{ env.NAMESPACE }}" --timeout=120s
+            -n "${{ env.NAMESPACE }}" --timeout=120s || \
+          kubectl wait --for=condition=failed job/doc-indexer-drop \
+            -n "${{ env.NAMESPACE }}" --timeout=10s && \
+          { kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-drop --tail=50 || true; exit 1; }
 
       - name: List HANA tables
         if: always()
@@ -238,5 +241,8 @@ jobs:
                     secretName: doc-indexer-config
           EOF
           kubectl wait --for=condition=complete job/doc-indexer-tables \
-            -n "${{ env.NAMESPACE }}" --timeout=120s
+            -n "${{ env.NAMESPACE }}" --timeout=120s || \
+          kubectl wait --for=condition=failed job/doc-indexer-tables \
+            -n "${{ env.NAMESPACE }}" --timeout=10s && \
+          { kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true; exit 1; }
           kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -10,7 +10,7 @@ on:
       DOCS_TABLE_NAME:
         required: true
         type: string
-        description: "HANA table name to index into (must be unique, will not be cleaned up automatically)"
+        description: "HANA table name to index into (must be unique, dropped automatically after the job)"
     secrets:
       DOC_INDEXER_TESTS_CONFIG:
         required: true
@@ -165,3 +165,41 @@ jobs:
           echo "=== Pod status ==="
           kubectl get pods -n "${{ env.NAMESPACE }}" -o wide || true
           kubectl describe pods -n "${{ env.NAMESPACE }}" || true
+
+      - name: Drop HANA table
+        if: always()
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: doc-indexer-drop
+            namespace: ${{ env.NAMESPACE }}
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: doc-indexer
+                  image: ${{ inputs.IMAGE_NAME }}
+                  imagePullPolicy: Never
+                  command: ["python", "src/main.py", "drop"]
+                  env:
+                  - name: LOG_LEVEL
+                    value: "INFO"
+                  - name: CONFIG_PATH
+                    value: "/etc/config/config.json"
+                  - name: DOCS_TABLE_NAME
+                    value: "${{ inputs.DOCS_TABLE_NAME }}"
+                  volumeMounts:
+                  - name: config
+                    mountPath: /etc/config/config.json
+                    subPath: config.json
+                volumes:
+                - name: config
+                  secret:
+                    secretName: doc-indexer-config
+          EOF
+          kubectl wait --for=condition=complete job/doc-indexer-drop \
+            -n "${{ env.NAMESPACE }}" --timeout=120s

--- a/doc_indexer/src/main.py
+++ b/doc_indexer/src/main.py
@@ -5,7 +5,7 @@ from fetcher.fetcher import DocumentsFetcher
 from hdbcli import dbapi
 from indexing.adaptive_indexer import AdaptiveSplitMarkdownIndexer
 from langchain_core.embeddings import Embeddings
-from utils.hana import create_hana_connection
+from utils.hana import create_hana_connection, drop_table
 
 from utils.logging import get_logger
 from utils.models import (
@@ -27,6 +27,7 @@ from utils.settings import (
 
 TASK_FETCH = "fetch"
 TASK_INDEX = "index"
+TASK_DROP = "drop"
 logger = get_logger(__name__)
 
 
@@ -76,10 +77,29 @@ def run_indexer(
     indexer.index()
 
 
+def run_drop(
+    hana_conn: dbapi.Connection | None = None,
+    table_name: str = DOCS_TABLE_NAME,
+) -> None:
+    """Entry function to drop the HANA table created by the indexer.
+
+    Args:
+        hana_conn: Hana DB connection to use. If None, created from config.
+        table_name: Name of the table to drop. Defaults to DOCS_TABLE_NAME from config.
+    """
+    if hana_conn is None:
+        hana_conn = create_hana_connection(DATABASE_URL, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD)
+        if not hana_conn:
+            logger.error("Failed to connect to the database. Exiting.")
+            raise RuntimeError("Failed to connect to the database.")
+
+    drop_table(hana_conn, DATABASE_USER, table_name)
+
+
 if __name__ == "__main__":
     # read command line argument.
     parser = argparse.ArgumentParser(description="Kyma Documentation Fetcher and Indexer.")
-    parser.add_argument("task", choices=["index", "fetch"])
+    parser.add_argument("task", choices=["index", "fetch", "drop"])
     args = parser.parse_args()
 
     # run the specified task.
@@ -87,5 +107,7 @@ if __name__ == "__main__":
         run_fetcher()
     elif args.task == TASK_INDEX:
         run_indexer()
+    elif args.task == TASK_DROP:
+        run_drop()
     else:
-        print("Invalid task. Valid tasks are: index, fetch.")
+        print("Invalid task. Valid tasks are: index, fetch, drop.")

--- a/doc_indexer/src/main.py
+++ b/doc_indexer/src/main.py
@@ -5,7 +5,7 @@ from fetcher.fetcher import DocumentsFetcher
 from hdbcli import dbapi
 from indexing.adaptive_indexer import AdaptiveSplitMarkdownIndexer
 from langchain_core.embeddings import Embeddings
-from utils.hana import create_hana_connection, drop_table
+from utils.hana import create_hana_connection, drop_table, list_tables
 
 from utils.logging import get_logger
 from utils.models import (
@@ -28,6 +28,7 @@ from utils.settings import (
 TASK_FETCH = "fetch"
 TASK_INDEX = "index"
 TASK_DROP = "drop"
+TASK_TABLES = "tables"
 logger = get_logger(__name__)
 
 
@@ -96,10 +97,36 @@ def run_drop(
     drop_table(hana_conn, DATABASE_USER, table_name)
 
 
+def run_list_tables(
+    hana_conn: dbapi.Connection | None = None,
+) -> None:
+    """Entry function to list all HANA tables owned by the configured user.
+
+    Args:
+        hana_conn: Hana DB connection to use. If None, created from config.
+    """
+    if hana_conn is None:
+        hana_conn = create_hana_connection(DATABASE_URL, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD)
+        if not hana_conn:
+            logger.error("Failed to connect to the database. Exiting.")
+            raise RuntimeError("Failed to connect to the database.")
+
+    rows = list_tables(hana_conn, DATABASE_USER)
+    if not rows:
+        logger.info(f"No tables found for user {DATABASE_USER}.")
+        return
+    header = f"{'TABLE_NAME':<60} {'ROWS':>10} {'SIZE (bytes)':>14}"
+    separator = "-" * 88
+    logger.info(f"HANA tables for user {DATABASE_USER}:\n{header}\n{separator}")
+    for name, records, size in rows:
+        logger.info(f"{name:<60} {records:>10} {size:>14}")
+    logger.info(f"{len(rows)} table(s) total.")
+
+
 if __name__ == "__main__":
     # read command line argument.
     parser = argparse.ArgumentParser(description="Kyma Documentation Fetcher and Indexer.")
-    parser.add_argument("task", choices=["index", "fetch", "drop"])
+    parser.add_argument("task", choices=["index", "fetch", "drop", "tables"])
     args = parser.parse_args()
 
     # run the specified task.
@@ -109,5 +136,7 @@ if __name__ == "__main__":
         run_indexer()
     elif args.task == TASK_DROP:
         run_drop()
+    elif args.task == TASK_TABLES:
+        run_list_tables()
     else:
-        print("Invalid task. Valid tasks are: index, fetch, drop.")
+        print("Invalid task. Valid tasks are: index, fetch, drop, tables.")

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -26,10 +26,7 @@ def create_hana_connection(url: str, port: int, user: str, password: str) -> dba
 
 def list_tables(connection: dbapi.Connection, db_user: str) -> list[tuple[str, int, int]]:
     """Return all tables owned by db_user as (name, row_count, size_bytes) tuples."""
-    sql = (
-        "SELECT TABLE_NAME, RECORD_COUNT, TABLE_SIZE FROM M_TABLES "
-        "WHERE SCHEMA_NAME = ? ORDER BY TABLE_NAME"
-    )
+    sql = "SELECT TABLE_NAME, RECORD_COUNT, TABLE_SIZE FROM M_TABLES WHERE SCHEMA_NAME = ? ORDER BY TABLE_NAME"
     with connection.cursor() as cursor:
         cursor.execute(sql, (db_user,))
         rows: list[tuple[str, int, int]] = cursor.fetchall()

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -4,6 +4,8 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+_ERR_SQL_INV_TABLE = 259  # HANA error code for invalid/missing table name
+
 
 def create_hana_connection(url: str, port: int, user: str, password: str) -> dbapi.Connection | None:
     """Create a connection to the Hana Cloud DB."""
@@ -35,7 +37,6 @@ def list_tables(connection: dbapi.Connection, db_user: str) -> list[tuple[str, i
 
 def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> None:
     """Drop a table from HANA if it exists. Silently ignores missing tables (error 259)."""
-    ERR_SQL_INV_TABLE = 259
     sql = f'DROP TABLE "{db_user}"."{table_name}"'
     try:
         with connection.cursor() as cursor:
@@ -43,7 +44,7 @@ def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> N
         connection.commit()
         logger.info(f"Dropped table {table_name}.")
     except dbapi.ProgrammingError as e:
-        if e.args and e.args[0] == ERR_SQL_INV_TABLE:
+        if e.args and e.args[0] == _ERR_SQL_INV_TABLE:
             logger.warning(f"Table {table_name} does not exist, nothing to drop.")
             return
         logger.exception(f"Error dropping table {table_name}.")

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -22,6 +22,17 @@ def create_hana_connection(url: str, port: int, user: str, password: str) -> dba
     return None
 
 
+def list_tables(connection: dbapi.Connection, db_user: str) -> list[tuple[str, int, int]]:
+    """Return all tables owned by db_user as (name, row_count, size_bytes) tuples."""
+    sql = (
+        "SELECT TABLE_NAME, RECORD_COUNT, TABLE_SIZE FROM M_TABLES "
+        "WHERE SCHEMA_NAME = ? ORDER BY TABLE_NAME"
+    )
+    with connection.cursor() as cursor:
+        cursor.execute(sql, (db_user,))
+        return cursor.fetchall()
+
+
 def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> None:
     """Drop a table from HANA if it exists. Silently ignores missing tables (error 259)."""
     ERR_SQL_INV_TABLE = 259

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -20,3 +20,23 @@ def create_hana_connection(url: str, port: int, user: str, password: str) -> dba
     except Exception:
         logger.exception("Unknown error occurred.")
     return None
+
+
+def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> None:
+    """Drop a table from HANA if it exists. Silently ignores missing tables (error 259)."""
+    ERR_SQL_INV_TABLE = 259
+    sql = f'DROP TABLE "{db_user}"."{table_name}"'
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+        connection.commit()
+        logger.info(f"Dropped table {table_name}.")
+    except dbapi.ProgrammingError as e:
+        if e.args and e.args[0] == ERR_SQL_INV_TABLE:
+            logger.warning(f"Table {table_name} does not exist, nothing to drop.")
+            return
+        logger.exception(f"Error dropping table {table_name}.")
+        raise
+    except Exception:
+        logger.exception(f"Error dropping table {table_name}.")
+        raise

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -32,7 +32,8 @@ def list_tables(connection: dbapi.Connection, db_user: str) -> list[tuple[str, i
     )
     with connection.cursor() as cursor:
         cursor.execute(sql, (db_user,))
-        return cursor.fetchall()
+        rows: list[tuple[str, int, int]] = cursor.fetchall()
+        return rows
 
 
 def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> None:

--- a/doc_indexer/src/utils/hana.py
+++ b/doc_indexer/src/utils/hana.py
@@ -44,7 +44,7 @@ def drop_table(connection: dbapi.Connection, db_user: str, table_name: str) -> N
         connection.commit()
         logger.info(f"Dropped table {table_name}.")
     except dbapi.ProgrammingError as e:
-        if e.args and e.args[0] == _ERR_SQL_INV_TABLE:
+        if e.errorcode == _ERR_SQL_INV_TABLE:
             logger.warning(f"Table {table_name} does not exist, nothing to drop.")
             return
         logger.exception(f"Error dropping table {table_name}.")

--- a/doc_indexer/tests/unit/test_main.py
+++ b/doc_indexer/tests/unit/test_main.py
@@ -67,3 +67,63 @@ def test_run_indexer_uses_injected_embeddings_and_connection(mock_embeddings, mo
     mock_get_config.assert_not_called()
     mock_create_conn.assert_not_called()
     mock_indexer_cls.assert_called_once()
+
+
+def test_run_drop_calls_drop_table_with_injected_connection(mock_hana_conn):
+    """run_drop calls drop_table with the injected connection and configured table name."""
+    from main import run_drop
+
+    with (
+        patch("main.drop_table") as mock_drop,
+        patch("main.DATABASE_USER", "test_user"),
+        patch("main.DOCS_TABLE_NAME", "test_table"),
+    ):
+        run_drop(hana_conn=mock_hana_conn)
+
+    mock_drop.assert_called_once_with(mock_hana_conn, "test_user", "test_table")
+
+
+def test_run_drop_accepts_explicit_table_name(mock_hana_conn):
+    """run_drop uses the explicitly provided table_name instead of the config default."""
+    from main import run_drop
+
+    with (
+        patch("main.drop_table") as mock_drop,
+        patch("main.DATABASE_USER", "test_user"),
+    ):
+        run_drop(hana_conn=mock_hana_conn, table_name="custom_table")
+
+    mock_drop.assert_called_once_with(mock_hana_conn, "test_user", "custom_table")
+
+
+def test_run_drop_creates_connection_when_not_injected():
+    """run_drop creates a HANA connection from config when none is injected."""
+    from main import run_drop
+
+    mock_conn = Mock()
+    with (
+        patch("main.create_hana_connection", return_value=mock_conn) as mock_create,
+        patch("main.drop_table") as mock_drop,
+        patch("main.DATABASE_URL", "hana.example.com"),
+        patch("main.DATABASE_PORT", 443),
+        patch("main.DATABASE_USER", "test_user"),
+        patch("main.DATABASE_PASSWORD", "secret"),
+    ):
+        run_drop()
+
+    mock_create.assert_called_once_with("hana.example.com", 443, "test_user", "secret")
+    mock_drop.assert_called_once()
+
+
+def test_run_drop_raises_when_connection_fails():
+    """run_drop raises RuntimeError when the HANA connection cannot be established."""
+    from main import run_drop
+
+    with (
+        patch("main.create_hana_connection", return_value=None),
+        patch("main.drop_table") as mock_drop,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to connect to the database"):
+            run_drop()
+
+    mock_drop.assert_not_called()

--- a/doc_indexer/tests/unit/test_main.py
+++ b/doc_indexer/tests/unit/test_main.py
@@ -121,9 +121,9 @@ def test_run_drop_raises_when_connection_fails():
     with (
         patch("main.create_hana_connection", return_value=None),
         patch("main.drop_table") as mock_drop,
+        pytest.raises(RuntimeError, match="Failed to connect to the database"),
     ):
-        with pytest.raises(RuntimeError, match="Failed to connect to the database"):
-            run_drop()
+        run_drop()
 
     mock_drop.assert_not_called()
 
@@ -148,8 +148,8 @@ def test_run_list_tables_raises_when_connection_fails():
     with (
         patch("main.create_hana_connection", return_value=None),
         patch("main.list_tables") as mock_list,
+        pytest.raises(RuntimeError, match="Failed to connect to the database"),
     ):
-        with pytest.raises(RuntimeError, match="Failed to connect to the database"):
-            run_list_tables()
+        run_list_tables()
 
     mock_list.assert_not_called()

--- a/doc_indexer/tests/unit/test_main.py
+++ b/doc_indexer/tests/unit/test_main.py
@@ -76,9 +76,8 @@ def test_run_drop_calls_drop_table_with_injected_connection(mock_hana_conn):
     with (
         patch("main.drop_table") as mock_drop,
         patch("main.DATABASE_USER", "test_user"),
-        patch("main.DOCS_TABLE_NAME", "test_table"),
     ):
-        run_drop(hana_conn=mock_hana_conn)
+        run_drop(hana_conn=mock_hana_conn, table_name="test_table")
 
     mock_drop.assert_called_once_with(mock_hana_conn, "test_user", "test_table")
 
@@ -127,3 +126,30 @@ def test_run_drop_raises_when_connection_fails():
             run_drop()
 
     mock_drop.assert_not_called()
+
+
+def test_run_list_tables_calls_list_tables_with_injected_connection(mock_hana_conn):
+    """run_list_tables calls list_tables with the injected connection and DATABASE_USER."""
+    from main import run_list_tables
+
+    with (
+        patch("main.list_tables", return_value=[]) as mock_list,
+        patch("main.DATABASE_USER", "test_user"),
+    ):
+        run_list_tables(hana_conn=mock_hana_conn)
+
+    mock_list.assert_called_once_with(mock_hana_conn, "test_user")
+
+
+def test_run_list_tables_raises_when_connection_fails():
+    """run_list_tables raises RuntimeError when the HANA connection cannot be established."""
+    from main import run_list_tables
+
+    with (
+        patch("main.create_hana_connection", return_value=None),
+        patch("main.list_tables") as mock_list,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to connect to the database"):
+            run_list_tables()
+
+    mock_list.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `drop` and `tables` subcommands to the `doc_indexer` CLI
- `drop` (`python src/main.py drop`) drops the configured HANA table; silently ignores missing tables
- `tables` (`python src/main.py tables`) lists all tables owned by the configured HANA user with row count and size
- Wires both as `if: always()` steps at the end of the e2e reusable workflow - `Drop HANA table` then `List HANA tables` - so every CI run cleans up after itself and leaves a visible table snapshot in the logs
- Updates the `DOCS_TABLE_NAME` input description from "will not be cleaned up automatically" to "dropped automatically after the job"

Closes #1067

## Testing

Tested hands-on with the image built locally from this branch.

Step 1 - `tables` before:
```
kc_pr_1117_e2e    11    196573
kc_pr_1135_e2e    11    196573
kyma_docs       4979  62967210
3 table(s) total.
```

Step 2 - `fetch` + `index` into `kc_pr_test_drop_subcommand` (11 chunks from `e2e_docs_sources.json`):
```
Successfully indexed 11 markdown files chunks in table kc_pr_test_drop_subcommand.
```

Step 3 - `tables` after index:
```
kc_pr_1117_e2e              11    196573
kc_pr_1135_e2e              11    196573
kc_pr_test_drop_subcommand  11    200528
kyma_docs                 4979  62967210
4 table(s) total.
```

Step 4 - `drop`:
```
Dropped table kc_pr_test_drop_subcommand.
```

Step 5 - `tables` after drop:
```
kc_pr_1117_e2e  11    196573
kc_pr_1135_e2e  11    196573
kyma_docs     4979  62967210
3 table(s) total.
```

The `Drop HANA table` and `List HANA tables` workflow steps cannot be validated before merge (reusable workflow). Will be observed in the next e2e run after merge.