### PR TITLE
feat: accept raw key bytes in KeyStore, align key generation to cert-manager PEM format

### DIFF
--- a/scripts/shell/generate-ecdh-keys.sh
+++ b/scripts/shell/generate-ecdh-keys.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Generate ECDH P-256 key pairs for the companion encryption service.
+# Generate an ECDSA P-256 private key matching the cert-manager Certificate CR
+# (ECDSA, P-256, PKCS8 encoding).
 #
-# Output files (all values are base64-encoded, no line wrapping):
-#   <output_dir>/server_private_key.b64  — PKCS8 DER private key (used by Encryption class)
-#   <output_dir>/server_public_key.b64   — raw uncompressed EC point (65 bytes: 04 || X || Y)
-#   <output_dir>/client_private_key.b64  — PKCS8 DER private key (for client-side use)
-#   <output_dir>/client_public_key.b64   — raw uncompressed EC point (TEST_CLIENT_PUBLIC_KEY)
+# cert-manager stores the key as PEM (PKCS8) in the tls.key field of the
+# Kubernetes secret.  This script produces the same format for local
+# development / testing.
+#
+# Output file:
+#   <output_dir>/tls.key  — PEM-encoded PKCS8 EC private key
 #
 # Usage:
 #   ./generate-ecdh-keys.sh [output_dir]
@@ -16,35 +18,14 @@ set -euo pipefail
 OUTPUT_DIR="${1:-./ecdh-keys}"
 mkdir -p "$OUTPUT_DIR"
 
-# P-256 SubjectPublicKeyInfo DER is always 91 bytes.
-# The last 65 bytes are the raw uncompressed EC point (04 || X || Y).
-RAW_EC_POINT_BYTES=65
+TMP_PEM=$(mktemp)
+trap 'rm -f "$TMP_PEM"' EXIT
 
-generate_key_pair() {
-    local name="$1"
-    local tmp_pem
-    tmp_pem=$(mktemp)
+# Generate EC private key on the P-256 (prime256v1 / secp256r1) curve.
+openssl ecparam -name prime256v1 -genkey -noout -out "$TMP_PEM"
 
-    # Generate EC private key on the P-256 (prime256v1 / secp256r1) curve.
-    openssl ecparam -name prime256v1 -genkey -noout -out "$tmp_pem"
+# Convert to PKCS8 PEM (matches cert-manager's PKCS8 encoding).
+openssl pkcs8 -topk8 -nocrypt -in "$TMP_PEM" -outform PEM \
+    > "$OUTPUT_DIR/tls.key"
 
-    # Private key: PKCS8 DER → base64 (no line wrapping).
-    openssl pkcs8 -topk8 -nocrypt -in "$tmp_pem" -outform DER \
-        | base64 | tr -d '\n' \
-        > "$OUTPUT_DIR/${name}_private_key.b64"
-
-    # Public key: raw uncompressed EC point (last 65 bytes of SubjectPublicKeyInfo DER) → base64.
-    openssl ec -in "$tmp_pem" -pubout -outform DER 2>/dev/null \
-        | tail -c "$RAW_EC_POINT_BYTES" \
-        | base64 | tr -d '\n' \
-        > "$OUTPUT_DIR/${name}_public_key.b64"
-
-    rm -f "$tmp_pem"
-    echo "Generated ${name} key pair"
-}
-
-generate_key_pair "server"
-generate_key_pair "client"
-
-echo ""
-echo "Keys written to: $OUTPUT_DIR"
+echo "Private key written to: $OUTPUT_DIR/tls.key"

--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -16,10 +16,10 @@ from services.encryption import Encryption
 from services.encryption_cache import EncryptionCache, get_encryption_cache
 from services.k8s import IK8sClient, K8sAuthHeaders, K8sClient
 from services.k8s_models import PodLogs, PodLogsDiagnosticContext
+from services.key_store import KeyStore
 from utils.config import Config, get_config
 from utils.logging import get_logger
 from utils.models.factory import IModel, ModelFactory
-from utils.settings import ENCRYPTION_PRIVATE_KEY_B64
 from utils.singleton_meta import SingletonMeta
 
 logger = get_logger(__name__)
@@ -71,6 +71,7 @@ class ReadinessModel(BaseModel):
     is_redis_initialized: bool
     is_hana_initialized: bool
     are_models_initialized: bool
+    is_key_store_initialized: bool
 
 
 class HealthModel(BaseModel):
@@ -79,6 +80,7 @@ class HealthModel(BaseModel):
     is_redis_healthy: bool
     is_hana_healthy: bool
     is_usage_tracker_healthy: bool
+    is_key_store_healthy: bool
     llms: dict[str, bool]
 
 
@@ -378,12 +380,6 @@ async def get_k8s_auth_headers_from_encrypted_payload(
                                 encrypted with the random AES-256 key.
     """
 
-    if not ENCRYPTION_PRIVATE_KEY_B64:
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail="Encrypted Auth Headers are not enabled in companion",
-        )
-
     if not x_encrypted_key or not x_client_iv or not x_target_cluster_encrypted:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
@@ -391,8 +387,9 @@ async def get_k8s_auth_headers_from_encrypted_payload(
         )
 
     try:
+        private_key = KeyStore().get_private_key()
         # decrypt the payload using the encryption service.
-        encryption = Encryption(ENCRYPTION_PRIVATE_KEY_B64, encryption_cache)
+        encryption = Encryption(private_key, encryption_cache)
         payload = await encryption.decrypt(x_encrypted_key, x_client_iv, x_session_id, x_target_cluster_encrypted)
         # parse the payload as JSON and convert to a K8sAuthHeaders instance
         payload = json.loads(payload)

--- a/src/routers/probes.py
+++ b/src/routers/probes.py
@@ -9,6 +9,7 @@ from starlette.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 from routers.common import HealthModel, ReadinessModel
 from services.hana import get_hana
 from services.k8s_resource_discovery import K8sResourceDiscovery
+from services.key_store import KeyStore
 from services.probes import (
     get_llm_probe,
     get_usage_tracker_probe,
@@ -139,6 +140,7 @@ async def healthz(
         is_hana_healthy=hana.is_connection_operational(),
         is_redis_healthy=await redis.is_connection_operational(),
         is_usage_tracker_healthy=usage_tracker_probe.is_healthy(),
+        is_key_store_healthy=KeyStore().is_healthy(),
         llms=llm_probe.get_llms_states(),
     )
 
@@ -175,6 +177,7 @@ async def readyz(
         is_hana_initialized=hana.has_connection(),
         is_redis_initialized=redis.has_connection(),
         are_models_initialized=llm_probe.has_models(),
+        is_key_store_initialized=KeyStore().is_healthy(),
     )
     status = HTTP_503_SERVICE_UNAVAILABLE
     if all_ready(response):
@@ -197,8 +200,14 @@ def all_ready(response: HealthModel | ReadinessModel) -> bool:
             response.is_redis_healthy
             and response.is_hana_healthy
             and response.is_usage_tracker_healthy
+            and response.is_key_store_healthy
             and bool(response.llms)
             and all(response.llms.values())
         )
     if isinstance(response, ReadinessModel):
-        return response.is_redis_initialized and response.is_hana_initialized and response.are_models_initialized
+        return (
+            response.is_redis_initialized
+            and response.is_hana_initialized
+            and response.are_models_initialized
+            and response.is_key_store_initialized
+        )

--- a/src/routers/public_key.py
+++ b/src/routers/public_key.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 
 from routers.common import API_PREFIX
 from services.encryption_cache import EncryptionCache, get_encryption_cache
+from services.key_store import KeyStore
 from utils.logging import get_logger
-from utils.settings import ENCRYPTION_PUBLIC_KEY_B64
 from utils.utils import create_session_id
 
 logger = get_logger(__name__)
@@ -32,16 +32,6 @@ router = APIRouter(
 )
 
 
-def _get_companion_public_key() -> str:
-    """Return companion public key configured for key exchange."""
-    if not ENCRYPTION_PUBLIC_KEY_B64:
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail="Companion public key is not configured",
-        )
-    return str(ENCRYPTION_PUBLIC_KEY_B64)
-
-
 @router.post("/public-key", response_model=PublicKeyResponse)
 async def init_public_key(
     request: Annotated[PublicKeyRequest, Body()],
@@ -49,7 +39,7 @@ async def init_public_key(
 ) -> PublicKeyResponse:
     """Initialize a key exchange session by storing client public key in Redis."""
 
-    companion_public_key = _get_companion_public_key()
+    companion_public_key = KeyStore().get_public_key_str()
 
     session_id = create_session_id()
 

--- a/src/services/encryption.py
+++ b/src/services/encryption.py
@@ -18,7 +18,6 @@ from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.primitives.serialization import load_der_private_key
 
 from services.encryption_cache import IEncryptionCache
 
@@ -32,18 +31,16 @@ class Encryption:
     Generic ECDH + AES-256-GCM decryption service.
     """
 
-    def __init__(self, private_key_b64: str, encryption_cache: IEncryptionCache) -> None:
+    def __init__(self, private_key: EllipticCurvePrivateKey, encryption_cache: IEncryptionCache) -> None:
         """Load and validate the server EC private key.
 
-        :param private_key_b64: Base64-encoded DER/PKCS8 EC private key.
+        :param private_key: EC private key.
         :raises TypeError: If the key is not an EC private key.
-        :raises ValueError: If the key cannot be decoded or loaded.
         """
-        raw = base64.b64decode(private_key_b64)
-        key = load_der_private_key(raw, password=None)
-        if not isinstance(key, EllipticCurvePrivateKey):
-            raise TypeError("private_key_b64 is not an EC private key")
-        self._private_key: EllipticCurvePrivateKey = key
+        if not isinstance(private_key, EllipticCurvePrivateKey):
+            raise TypeError("private_key is not an EC private key")
+
+        self._private_key: EllipticCurvePrivateKey = private_key
         self._encryption_cache = encryption_cache
 
     # ------------------------------------------------------------------

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -1,0 +1,180 @@
+"""
+Singleton key store that loads an EC private key from a Kubernetes-mounted
+secret file and transparently reloads it when the cached copy is stale.
+"""
+
+import base64
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    EllipticCurvePrivateKey,
+    EllipticCurvePublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+    load_der_private_key,
+    load_pem_private_key,
+)
+
+from utils.logging import get_logger
+from utils.settings import ENCRYPTION_PRIVATE_KEY_B64, ENCRYPTION_PRIVATE_KEY_PATH
+from utils.singleton_meta import SingletonMeta
+
+logger = get_logger(__name__)
+
+_RELOAD_INTERVAL_SECONDS = 30 * 60  # 30 minutes
+
+
+def _load_private_key(data: bytes) -> EllipticCurvePrivateKey:
+    """Decode key data and return a validated EC private key.
+
+    Supports both PEM and raw DER formats (after base64 decoding).
+
+    :param data: Raw private key bytes in PEM or DER format.
+    :raises TypeError: If the key is not an EC private key.
+    :raises ValueError: If the data cannot be decoded or parsed as a private key.
+    """
+
+    # Try PEM first (has header line), fall back to DER.
+    try:
+        key = load_pem_private_key(data, password=None)
+    except (ValueError, TypeError):
+        key = load_der_private_key(data, password=None)
+
+    if not isinstance(key, EllipticCurvePrivateKey):
+        raise TypeError("Key is not an EC private key")
+    return key
+
+
+def _load_private_key_from_file(path: Path) -> EllipticCurvePrivateKey:
+    """Read the key file and return a validated EC private key.
+
+    Supports both PEM and raw DER formats.
+
+    :raises FileNotFoundError: If *path* does not exist.
+    :raises TypeError: If the key is not an EC private key.
+    :raises ValueError: If the file cannot be parsed as a private key.
+    """
+
+    return _load_private_key(path.read_bytes())
+
+
+class KeyStore(metaclass=SingletonMeta):
+    """Singleton store for the ECDH key pair loaded from disk.
+
+    The key file path is taken from the ``ENCRYPTION_PRIVATE_KEY_PATH``
+    setting.  On every call to :py:meth:`get_private_key` or
+    :py:meth:`get_public_key` the store checks whether the cached key is
+    older than 30 minutes and reloads the file automatically — no restart
+    required when Kubernetes rotates the secret.
+
+    Usage::
+
+        store = KeyStore()
+        private = store.get_private_key()
+        public  = store.get_public_key()
+    """
+
+    def __init__(self) -> None:
+        self._path = str(ENCRYPTION_PRIVATE_KEY_PATH)
+        self._key: EllipticCurvePrivateKey | None = None
+        self._loaded_at: float = 0.0
+        self._load_key()
+
+    # ---- public API -------------------------------------------------------
+
+    def get_private_key(self) -> EllipticCurvePrivateKey:
+        """Return the EC private key, reloading from disk if stale.
+
+        :raises RuntimeError: If the key cannot be loaded.
+        """
+        self._reload_if_stale()
+        if self._key is None:
+            raise RuntimeError(f"EC private key is not available (path={self._path})")
+        return self._key
+
+    def get_public_key(self) -> EllipticCurvePublicKey:
+        """Return the EC public key derived from the private key, reloading from disk if stale.
+
+        :raises RuntimeError: If the key cannot be loaded.
+        """
+        return self.get_private_key().public_key()
+
+    def get_public_key_str(self) -> str:
+        """Return the EC public key derived from the private key as a string, reloading from disk if stale.
+
+        :raises RuntimeError: If the key cannot be loaded.
+        """
+        # Extract the raw uncompressed EC point (65 bytes: 04 || X || Y)
+        raw_point = self.get_public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+
+        # return the Base64-encoded raw point as a string
+        return base64.b64encode(raw_point).decode("ascii")
+
+    def is_healthy(self) -> bool:
+        """Return True if the key store is healthy (i.e. has a valid key), False otherwise.
+
+        This is used in the health probe to determine if the key store is operational.
+        If the key cannot be loaded or parsed, this will return False, but it will not raise an exception.
+        The health probe will log any exceptions encountered when trying to load the key.
+
+        :return: bool
+        """
+        try:
+            self.get_public_key_str()
+            return True
+        except Exception:
+            return False
+
+    # ---- internals --------------------------------------------------------
+
+    def _reload_if_stale(self) -> None:
+        """Reload the key file if the cached copy is older than the reload interval.
+
+        If the reload fails (e.g. the file is temporarily missing during a
+        secret rotation), the last-known-good key is preserved and a warning
+        is logged.  ``_loaded_at`` is updated so we don't hammer the
+        filesystem on every subsequent call.
+        """
+        if time.monotonic() - self._loaded_at >= _RELOAD_INTERVAL_SECONDS:
+            logger.info("Cached key is stale (>%ds), reloading %s", _RELOAD_INTERVAL_SECONDS, self._path)
+            try:
+                self._load_key()
+            except Exception:
+                logger.warning(
+                    "Failed to reload private key from %s — keeping previously cached key.",
+                    self._path,
+                    exc_info=True,
+                )
+                # Bump the timestamp so we don't retry on every single call.
+                self._loaded_at = time.monotonic()
+
+    def _load_key(self) -> None:
+        """Load (or reload) the private key.
+
+        Reads from the file at ``ENCRYPTION_PRIVATE_KEY_PATH`` when set,
+        otherwise falls back to the ``ENCRYPTION_PRIVATE_KEY_B64`` config value.
+
+        :raises FileNotFoundError: If the key file path is set but does not exist.
+        :raises TypeError: If the key is not an EC private key.
+        :raises ValueError: If the key data cannot be decoded or parsed.
+        """
+        if not self._path:
+            logger.warning(
+                "ENCRYPTION_PRIVATE_KEY_PATH is not set, reading from configuration value ENCRYPTION_PRIVATE_KEY_B64"
+            )
+            self._key = _load_private_key(base64.b64decode(str(ENCRYPTION_PRIVATE_KEY_B64)))
+            self._loaded_at = time.monotonic()
+            return
+        self._key = _load_private_key_from_file(Path(self._path))
+        self._loaded_at = time.monotonic()
+        logger.info("EC private key loaded from %s", self._path)
+
+    # ---- test helpers -----------------------------------------------------
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        """Remove the singleton instance so it can be re-created in tests."""
+        SingletonMeta.reset_instance(cls)

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -41,6 +41,7 @@ def _load_private_key(data: bytes) -> EllipticCurvePrivateKey:
     try:
         key = load_pem_private_key(data, password=None)
     except (ValueError, TypeError):
+        logger.error("Failed to parse private key as PEM, trying DER format", exc_info=True)
         key = load_der_private_key(data, password=None)
 
     if not isinstance(key, EllipticCurvePrivateKey):

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -123,8 +123,8 @@ HANA_HEALTH_CHECK_CACHE_TTL_SECONDS = config(
 )  # Default 5 minutes
 
 # Encryption (Base64 encoded)
-ENCRYPTION_PUBLIC_KEY_B64 = config("ENCRYPTION_PUBLIC_KEY_B64", default="")
-ENCRYPTION_PRIVATE_KEY_B64 = config("ENCRYPTION_PRIVATE_KEY_B64", default="")
+ENCRYPTION_PRIVATE_KEY_PATH = config("ENCRYPTION_PRIVATE_KEY_PATH", default="", cast=str)
+ENCRYPTION_PRIVATE_KEY_B64 = config("ENCRYPTION_PRIVATE_KEY_B64", default="", cast=str)
 NONCE_REPLAY_WINDOW_SECONDS = config("NONCE_REPLAY_WINDOW_SECONDS", default=300, cast=int)  # 5 minutes
 
 # Token limits

--- a/tests/unit/routers/test_common.py
+++ b/tests/unit/routers/test_common.py
@@ -19,7 +19,7 @@ from services.data_sanitizer import IDataSanitizer
 from services.encryption_cache import IEncryptionCache
 from services.k8s import K8sAuthHeaders
 
-_PRIVATE_KEY_B64 = "fake-private-key-b64"
+_MOCK_PRIVATE_KEY = Mock()
 _VALID_PAYLOAD = {
     "x-cluster-url": "https://api.test-cluster.example.com",
     "x-cluster-certificate-authority-data": "dGVzdC1jYS1kYXRh",
@@ -260,7 +260,7 @@ class TestInitSearchTool:
     [
         pytest.param(
             "valid encrypted payload is decrypted and parsed into K8sAuthHeaders",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "iv",
             "enc-data",
@@ -276,21 +276,21 @@ class TestInitSearchTool:
             id="success",
         ),
         pytest.param(
-            "raises 500 when the server private key is not configured",
-            "",
+            "raises 422 when the server private key is not available",
+            RuntimeError("EC private key is not available"),
             "enc-key",
             "iv",
             "enc-data",
             None,
             None,
-            HTTPStatus.INTERNAL_SERVER_ERROR,
-            "Encrypted Auth Headers are not enabled in companion",
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            "Failed to decrypt cluster authentication headers",
             None,
             id="private_key_not_configured",
         ),
         pytest.param(
             "raises 400 when x_encrypted_key header is missing",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "",
             "iv",
             "enc-data",
@@ -303,7 +303,7 @@ class TestInitSearchTool:
         ),
         pytest.param(
             "raises 400 when x_client_iv header is missing",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "",
             "enc-data",
@@ -316,7 +316,7 @@ class TestInitSearchTool:
         ),
         pytest.param(
             "raises 400 when x_target_cluster_encrypted header is missing",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "iv",
             "",
@@ -329,7 +329,7 @@ class TestInitSearchTool:
         ),
         pytest.param(
             "raises 400 when decryption raises a ValueError",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "iv",
             "enc-data",
@@ -342,7 +342,7 @@ class TestInitSearchTool:
         ),
         pytest.param(
             "raises 422 when decryption raises a generic exception",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "iv",
             "enc-data",
@@ -355,7 +355,7 @@ class TestInitSearchTool:
         ),
         pytest.param(
             "re-raises HTTPException from decryption unchanged",
-            _PRIVATE_KEY_B64,
+            _MOCK_PRIVATE_KEY,
             "enc-key",
             "iv",
             "enc-data",
@@ -371,7 +371,7 @@ class TestInitSearchTool:
 async def test_get_k8s_auth_headers_from_encrypted_payload(
     monkeypatch: pytest.MonkeyPatch,
     description: str,
-    private_key_b64: str,
+    private_key_b64: object,
     x_encrypted_key: str,
     x_client_iv: str,
     x_target_cluster_encrypted: str,
@@ -382,7 +382,12 @@ async def test_get_k8s_auth_headers_from_encrypted_payload(
     expected_fields: dict | None,
 ):
     # Given:
-    monkeypatch.setattr("routers.common.ENCRYPTION_PRIVATE_KEY_B64", private_key_b64)
+    mock_key_store = Mock()
+    if isinstance(private_key_b64, Exception):
+        mock_key_store.get_private_key.side_effect = private_key_b64  # gitleaks:allow
+    else:
+        mock_key_store.get_private_key.return_value = private_key_b64  # gitleaks:allow
+    monkeypatch.setattr("routers.common.KeyStore", Mock(return_value=mock_key_store))
 
     mock_encryption_instance = Mock()
     mock_encryption_instance.decrypt = AsyncMock(side_effect=decrypt_effect, return_value=decrypt_return)

--- a/tests/unit/routers/test_probes.py
+++ b/tests/unit/routers/test_probes.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,15 +12,16 @@ from services.redis import get_redis
 
 
 @pytest.mark.parametrize(
-    "test_case, hana_ready, redis_ready, usage_tracker_ready, llm_states, expected_status",
+    "test_case, hana_ready, redis_ready, usage_tracker_ready, llm_states, key_store_ready, expected_status",
     [
-        ("all ready", True, True, True, {"model1": True, "model2": True}, HTTP_200_OK),
+        ("all ready", True, True, True, {"model1": True, "model2": True}, True, HTTP_200_OK),
         (
             "Hana not ready",
             False,
             True,
             True,
             {"model1": True, "model2": True},
+            True,
             HTTP_503_SERVICE_UNAVAILABLE,
         ),
         (
@@ -29,6 +30,7 @@ from services.redis import get_redis
             False,
             True,
             {"model1": True, "model2": True},
+            True,
             HTTP_503_SERVICE_UNAVAILABLE,
         ),
         (
@@ -37,15 +39,26 @@ from services.redis import get_redis
             True,
             True,
             {"model1": False, "model2": True},
+            True,
             HTTP_503_SERVICE_UNAVAILABLE,
         ),
-        ("no models", True, True, True, {}, HTTP_503_SERVICE_UNAVAILABLE),
+        ("no models", True, True, True, {}, True, HTTP_503_SERVICE_UNAVAILABLE),
         (
             "usage_tracker not ready",
             True,
             True,
             False,
             {"model1": True, "model2": True},
+            True,
+            HTTP_503_SERVICE_UNAVAILABLE,
+        ),
+        (
+            "key_store not ready",
+            True,
+            True,
+            True,
+            {"model1": True, "model2": True},
+            False,
             HTTP_503_SERVICE_UNAVAILABLE,
         ),
     ],
@@ -56,6 +69,7 @@ def test_healthz_probe(
     redis_ready,
     usage_tracker_ready,
     llm_states,
+    key_store_ready,
     expected_status,
 ):
     """
@@ -78,28 +92,33 @@ def test_healthz_probe(
     mock_llm_probe.get_llms_states.return_value = llm_states
     app.dependency_overrides[get_llm_probe] = lambda: mock_llm_probe
 
-    client = TestClient(app)
+    mock_key_store = MagicMock()
+    mock_key_store.is_healthy.return_value = key_store_ready
 
     # When:
-    response = client.get("/healthz")
+    with patch("routers.probes.KeyStore", return_value=mock_key_store):
+        client = TestClient(app)
+        response = client.get("/healthz")
 
     # Then:
     assert response.status_code == expected_status, test_case
+    assert response.json()["is_key_store_healthy"] == key_store_ready, test_case
 
     # Clean up.
     app.dependency_overrides = {}
 
 
 @pytest.mark.parametrize(
-    "test_case, hana_ready, redis_ready, llm_states, expected_status",
+    "test_case, hana_ready, redis_ready, llm_states, key_store_ready, expected_status",
     [
-        ("all ready", True, True, True, HTTP_200_OK),
-        ("no Hana connection", False, True, True, HTTP_503_SERVICE_UNAVAILABLE),
-        ("no Redis connection", True, False, True, HTTP_503_SERVICE_UNAVAILABLE),
-        ("no models", True, True, False, HTTP_503_SERVICE_UNAVAILABLE),
+        ("all ready", True, True, True, True, HTTP_200_OK),
+        ("no Hana connection", False, True, True, True, HTTP_503_SERVICE_UNAVAILABLE),
+        ("no Redis connection", True, False, True, True, HTTP_503_SERVICE_UNAVAILABLE),
+        ("no models", True, True, False, True, HTTP_503_SERVICE_UNAVAILABLE),
+        ("key_store not ready", True, True, True, False, HTTP_503_SERVICE_UNAVAILABLE),
     ],
 )
-def test_ready_probe(test_case, hana_ready, redis_ready, llm_states, expected_status):
+def test_ready_probe(test_case, hana_ready, redis_ready, llm_states, key_store_ready, expected_status):
     """
     Test the readiness probe endpoint. This test ensures that the endpoint returns the correct status code.
     """
@@ -116,13 +135,17 @@ def test_ready_probe(test_case, hana_ready, redis_ready, llm_states, expected_st
     mock_llm_probe.has_models.return_value = llm_states
     app.dependency_overrides[get_llm_probe] = lambda: mock_llm_probe
 
-    client = TestClient(app)
+    mock_key_store = MagicMock()
+    mock_key_store.is_healthy.return_value = key_store_ready
 
     # When:
-    response = client.get("/readyz")
+    with patch("routers.probes.KeyStore", return_value=mock_key_store):
+        client = TestClient(app)
+        response = client.get("/readyz")
 
     # Then:
     assert response.status_code == expected_status, test_case
+    assert response.json()["is_key_store_initialized"] == key_store_ready, test_case
 
     # Clean up.
     app.dependency_overrides = {}

--- a/tests/unit/routers/test_probes_hana.py
+++ b/tests/unit/routers/test_probes_hana.py
@@ -21,6 +21,8 @@ class TestProbesHana:
         """Clean up after each test."""
         app.dependency_overrides = {}
         Hana._reset_for_tests()
+        if hasattr(self, "_key_store_patcher"):
+            self._key_store_patcher.stop()
 
     def _setup_healthy_dependencies(self):
         """Set up all non-Hana dependencies as healthy."""
@@ -35,6 +37,11 @@ class TestProbesHana:
         mock_llm_probe = MagicMock(spec=ILLMProbe)
         mock_llm_probe.get_llms_states.return_value = {"model1": True}
         app.dependency_overrides[get_llm_probe] = lambda: mock_llm_probe
+
+        self._mock_key_store = MagicMock()
+        self._mock_key_store.is_healthy.return_value = True
+        self._key_store_patcher = patch("routers.probes.KeyStore", return_value=self._mock_key_store)
+        self._key_store_patcher.start()
 
     def test_healthz_returns_200_when_query_succeeds(self):
         """Test that the healthz probe returns HTTP 200 when the database is fully operational.

--- a/tests/unit/routers/test_public_key.py
+++ b/tests/unit/routers/test_public_key.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from unittest.mock import Mock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -44,8 +45,8 @@ class MockEncryptionCache:
             id="redis_write_fails",
         ),
         pytest.param(
-            "returns 500 when the companion public key is not configured",
-            "",
+            "returns 500 when the companion public key is not available",
+            RuntimeError("EC private key is not available"),
             False,
             {"public_key": "request-public-key"},
             HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -77,10 +78,16 @@ def test_post_public_key(
 ):
     encryption_cache = MockEncryptionCache(should_fail=should_fail)
     monkeypatch.setitem(app.dependency_overrides, get_encryption_cache, lambda: encryption_cache)
-    monkeypatch.setattr(public_key, "ENCRYPTION_PUBLIC_KEY_B64", companion_key)
     monkeypatch.setattr(public_key, "create_session_id", lambda: "session-123")
 
-    client = TestClient(app)
+    mock_key_store = Mock()
+    if isinstance(companion_key, Exception):
+        mock_key_store.get_public_key_str.side_effect = companion_key
+    else:
+        mock_key_store.get_public_key_str.return_value = companion_key
+    monkeypatch.setattr(public_key, "KeyStore", Mock(return_value=mock_key_store))
+
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.post("/api/public-key", json=request_body)
 
     assert response.status_code == expected_status, description

--- a/tests/unit/services/test_encryption.py
+++ b/tests/unit/services/test_encryption.py
@@ -6,15 +6,13 @@ import re
 from unittest.mock import AsyncMock
 
 import pytest
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
-    NoEncryption,
-    PrivateFormat,
     PublicFormat,
 )
 
@@ -30,11 +28,6 @@ _AES_KEY_SIZE = 32
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _ec_private_key_b64(key: EllipticCurvePrivateKey) -> str:
-    """Encode an EC private key as base64-encoded DER/PKCS8."""
-    return base64.b64encode(key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())).decode()
 
 
 def _ec_public_key_b64(key: EllipticCurvePrivateKey) -> str:
@@ -75,18 +68,11 @@ def _make_encrypted_payload(
 # ---------------------------------------------------------------------------
 
 _SERVER_KEY = ec.generate_private_key(_ECDH_CURVE)
-_SERVER_KEY_B64 = _ec_private_key_b64(_SERVER_KEY)
 
 _PLAINTEXT = b'{"x_cluster_url": "https://test.example.com"}'
 _VALID_ENCRYPTED_KEY, _VALID_IV, _VALID_ENCRYPTED_DATA, _CLIENT_PUBLIC_KEY_B64 = _make_encrypted_payload(
     _SERVER_KEY, _PLAINTEXT
 )
-
-_RSA_KEY_B64 = base64.b64encode(
-    rsa.generate_private_key(public_exponent=65537, key_size=2048).private_bytes(
-        Encoding.DER, PrivateFormat.PKCS8, NoEncryption()
-    )
-).decode()
 
 _CORRUPTED_ENCRYPTED_KEY = base64.b64encode(os.urandom(60)).decode()
 
@@ -120,42 +106,42 @@ _ENCRYPTED_HELPER_DATA_B64 = base64.b64encode(
 
 class TestEncryption:
     @pytest.mark.parametrize(
-        "test_case, private_key_b64, expected_error, expected_error_msg",
+        "test_case, private_key, expected_error, expected_error_msg",
         [
             pytest.param(
-                "valid EC P-256 private key is loaded successfully",
-                _SERVER_KEY_B64,
+                "valid EC P-256 private key is accepted",
+                _SERVER_KEY,
                 None,
                 None,
                 id="valid_ec_key",
             ),
             pytest.param(
-                "RSA private key raises TypeError",
-                _RSA_KEY_B64,
+                "None raises TypeError",
+                None,
                 TypeError,
-                "private_key_b64 is not an EC private key",
-                id="rsa_key",
+                "private_key is not an EC private key",
+                id="none",
             ),
             pytest.param(
-                "invalid base64 string raises an exception",
-                "not-valid-base64!!!",
-                Exception,
-                None,
-                id="invalid_base64",
+                "string raises TypeError",
+                "not-an-ec-key",
+                TypeError,
+                "private_key is not an EC private key",
+                id="string",
             ),
             pytest.param(
-                "valid base64 but not a valid DER key raises an exception",
-                base64.b64encode(b"garbage data").decode(),
-                Exception,
-                None,
-                id="invalid_der",
+                "integer raises TypeError",
+                42,
+                TypeError,
+                "private_key is not an EC private key",
+                id="integer",
             ),
         ],
     )
     def test_init(
         self,
         test_case: str,
-        private_key_b64: str,
+        private_key: object,
         expected_error: type[Exception] | None,
         expected_error_msg: str | None,
     ):
@@ -163,14 +149,14 @@ class TestEncryption:
 
         if expected_error is None:
             # Given / When:
-            enc = Encryption(private_key_b64, mock_cache)
+            enc = Encryption(private_key, mock_cache)
 
             # Then:
             assert isinstance(enc._private_key, EllipticCurvePrivateKey), test_case
         else:
             match = re.escape(expected_error_msg) if expected_error_msg else None
             with pytest.raises(expected_error, match=match):
-                Encryption(private_key_b64, mock_cache)
+                Encryption(private_key, mock_cache)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -255,7 +241,7 @@ class TestEncryption:
         mock_cache.get_client_public_key.return_value = client_public_key
         mock_cache.is_nonce_allowed.return_value = nonce_allowed
 
-        enc = Encryption(_SERVER_KEY_B64, mock_cache)
+        enc = Encryption(_SERVER_KEY, mock_cache)
 
         if expected_error is None:
             # When:
@@ -295,7 +281,7 @@ class TestEncryption:
         # Given:
         mock_cache = AsyncMock(spec=IEncryptionCache)
         mock_cache.get_client_public_key.return_value = cache_return_value
-        enc = Encryption(_SERVER_KEY_B64, mock_cache)
+        enc = Encryption(_SERVER_KEY, mock_cache)
 
         # When:
         result = await enc._get_client_public_key("session-123")
@@ -337,7 +323,7 @@ class TestEncryption:
         expected_result: bytes | None,
         expected_error: type[Exception] | None,
     ):
-        enc = Encryption(_SERVER_KEY_B64, AsyncMock(spec=IEncryptionCache))
+        enc = Encryption(_SERVER_KEY, AsyncMock(spec=IEncryptionCache))
 
         if expected_error is None:
             # When:
@@ -387,7 +373,7 @@ class TestEncryption:
         expected_result: bytes | None,
         expected_error: type[Exception] | None,
     ):
-        enc = Encryption(_SERVER_KEY_B64, AsyncMock(spec=IEncryptionCache))
+        enc = Encryption(_SERVER_KEY, AsyncMock(spec=IEncryptionCache))
 
         if expected_error is None:
             # When:
@@ -454,7 +440,7 @@ class TestEncryption:
         expected_error: type[Exception] | None,
         expected_error_msg: str | None,
     ):
-        enc = Encryption(_SERVER_KEY_B64, AsyncMock(spec=IEncryptionCache))
+        enc = Encryption(_SERVER_KEY, AsyncMock(spec=IEncryptionCache))
 
         if expected_error is None:
             # When:

--- a/tests/unit/services/test_key_store.py
+++ b/tests/unit/services/test_key_store.py
@@ -1,0 +1,502 @@
+"""Unit tests for services/key_store.py."""
+
+import base64
+import re
+import time
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    EllipticCurvePrivateKey,
+    EllipticCurvePublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+from services.key_store import (
+    KeyStore,
+    _load_private_key,
+    _load_private_key_from_file,
+)
+
+_ECDH_CURVE = ec.SECP256R1()
+_UNCOMPRESSED_EC_POINT_LENGTH = 65  # 04 || X(32) || Y(32)
+_UNCOMPRESSED_EC_POINT_PREFIX = 0x04
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ec_key_pem_bytes(key: EllipticCurvePrivateKey) -> bytes:
+    """Encode an EC private key as PEM/PKCS8 bytes."""
+    return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+
+
+def _ec_key_der_bytes(key: EllipticCurvePrivateKey) -> bytes:
+    """Encode an EC private key as DER/PKCS8 bytes."""
+    return key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+
+
+def _ec_public_key_b64(key: EllipticCurvePrivateKey) -> str:
+    """Encode the uncompressed public point of an EC key as base64."""
+    return base64.b64encode(key.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)).decode()
+
+
+# ---------------------------------------------------------------------------
+# Module-level test vectors
+# ---------------------------------------------------------------------------
+
+_SERVER_KEY = ec.generate_private_key(_ECDH_CURVE)
+_SERVER_KEY_PEM = _ec_key_pem_bytes(_SERVER_KEY)
+_SERVER_KEY_DER = _ec_key_der_bytes(_SERVER_KEY)
+_SERVER_PUBLIC_KEY_B64 = _ec_public_key_b64(_SERVER_KEY)
+
+_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_RSA_KEY_DER = _RSA_KEY.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+
+
+# ---------------------------------------------------------------------------
+# Tests — _load_private_key (module-level function)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPrivateKey:
+    @pytest.mark.parametrize(
+        "test_case, data, expected_error, expected_error_msg",
+        [
+            pytest.param(
+                "PEM-encoded EC key is loaded successfully",
+                _SERVER_KEY_PEM,
+                None,
+                None,
+                id="pem_ec_key",
+            ),
+            pytest.param(
+                "DER-encoded EC key is loaded successfully",
+                _SERVER_KEY_DER,
+                None,
+                None,
+                id="der_ec_key",
+            ),
+            pytest.param(
+                "RSA DER key raises TypeError",
+                _RSA_KEY_DER,
+                TypeError,
+                "Key is not an EC private key",
+                id="rsa_key",
+            ),
+            pytest.param(
+                "garbage bytes raise an exception",
+                b"garbage data",
+                Exception,
+                None,
+                id="garbage_data",
+            ),
+            pytest.param(
+                "empty bytes raise an exception",
+                b"",
+                Exception,
+                None,
+                id="empty_data",
+            ),
+        ],
+    )
+    def test_load_private_key(
+        self,
+        test_case: str,
+        data: bytes,
+        expected_error: type[Exception] | None,
+        expected_error_msg: str | None,
+    ):
+        if expected_error is None:
+            # When:
+            key = _load_private_key(data)
+
+            # Then:
+            assert isinstance(key, EllipticCurvePrivateKey), test_case
+        else:
+            match = re.escape(expected_error_msg) if expected_error_msg else None
+            with pytest.raises(expected_error, match=match):
+                _load_private_key(data)
+
+
+# ---------------------------------------------------------------------------
+# Tests — _load_private_key_from_file (module-level function)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case, file_content, expected_error, expected_error_msg",
+    [
+        pytest.param(
+            "PEM file is loaded successfully",
+            _SERVER_KEY_PEM,
+            None,
+            None,
+            id="pem_file",
+        ),
+        pytest.param(
+            "DER file is loaded successfully",
+            _SERVER_KEY_DER,
+            None,
+            None,
+            id="der_file",
+        ),
+        pytest.param(
+            "missing file raises FileNotFoundError",
+            None,
+            FileNotFoundError,
+            None,
+            id="missing_file",
+        ),
+        pytest.param(
+            "garbage file raises an exception",
+            b"not a valid key",
+            Exception,
+            None,
+            id="garbage_file",
+        ),
+    ],
+)
+def test_load_private_key_from_file(
+    tmp_path,
+    test_case: str,
+    file_content: bytes | None,
+    expected_error: type[Exception] | None,
+    expected_error_msg: str | None,
+):
+    key_file = tmp_path / "tls.key"
+    if file_content is not None:
+        key_file.write_bytes(file_content)
+
+    if expected_error is None:
+        # When:
+        key = _load_private_key_from_file(key_file)
+
+        # Then:
+        assert isinstance(key, EllipticCurvePrivateKey), test_case
+    else:
+        match = re.escape(expected_error_msg) if expected_error_msg else None
+        with pytest.raises(expected_error, match=match):
+            _load_private_key_from_file(key_file)
+
+
+# ---------------------------------------------------------------------------
+# Tests — KeyStore class
+# ---------------------------------------------------------------------------
+
+
+class TestKeyStore:
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self):
+        """Reset the KeyStore singleton before and after each test."""
+        KeyStore._reset_for_tests()
+        yield
+        KeyStore._reset_for_tests()
+
+    @pytest.fixture()
+    def key_file(self, tmp_path, monkeypatch):
+        """Create a temp key file and point ENCRYPTION_PRIVATE_KEY_PATH at it."""
+        path = tmp_path / "tls.key"
+        monkeypatch.setattr("services.key_store.ENCRYPTION_PRIVATE_KEY_PATH", str(path))
+        return path
+
+    # -- __init__ / _load_key -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        "test_case, file_content, expected_error, expected_error_msg",
+        [
+            pytest.param(
+                "PEM key file is loaded successfully",
+                _SERVER_KEY_PEM,
+                None,
+                None,
+                id="pem_file",
+            ),
+            pytest.param(
+                "DER key file is loaded successfully",
+                _SERVER_KEY_DER,
+                None,
+                None,
+                id="der_file",
+            ),
+            pytest.param(
+                "missing file raises FileNotFoundError",
+                None,
+                FileNotFoundError,
+                None,
+                id="missing_file",
+            ),
+            pytest.param(
+                "garbage file raises ValueError",
+                b"not a valid key",
+                ValueError,
+                None,
+                id="garbage_file",
+            ),
+            pytest.param(
+                "RSA key file raises TypeError",
+                _RSA_KEY_DER,
+                TypeError,
+                "Key is not an EC private key",
+                id="rsa_key_file",
+            ),
+        ],
+    )
+    def test_init(
+        self,
+        key_file,
+        test_case: str,
+        file_content: bytes | None,
+        expected_error: type[Exception] | None,
+        expected_error_msg: str | None,
+    ):
+        if file_content is not None:
+            key_file.write_bytes(file_content)
+
+        if expected_error is None:
+            store = KeyStore()
+            assert isinstance(store._key, EllipticCurvePrivateKey), test_case
+        else:
+            match = re.escape(expected_error_msg) if expected_error_msg else None
+            with pytest.raises(expected_error, match=match):
+                KeyStore()
+
+    # -- singleton behaviour ------------------------------------------------
+
+    def test_singleton_returns_same_instance(self, key_file):
+        """Successive KeyStore() calls return the same singleton instance."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+
+        store1 = KeyStore()
+        store2 = KeyStore()
+
+        assert store1 is store2
+
+    def test_reset_for_tests_clears_singleton(self, key_file):
+        """_reset_for_tests allows a fresh instance to be created."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+
+        store1 = KeyStore()
+        KeyStore._reset_for_tests()
+
+        # Generate a different key so we can distinguish the instances.
+        other_key = ec.generate_private_key(_ECDH_CURVE)
+        key_file.write_bytes(_ec_key_pem_bytes(other_key))
+
+        store2 = KeyStore()
+
+        assert store1 is not store2
+
+    # -- get_private_key ----------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "test_case, file_content, expected_error, expected_error_msg",
+        [
+            pytest.param(
+                "returns the EC private key when the file is valid PEM",
+                _SERVER_KEY_PEM,
+                None,
+                None,
+                id="valid_pem",
+            ),
+            pytest.param(
+                "returns the EC private key when the file is valid DER",
+                _SERVER_KEY_DER,
+                None,
+                None,
+                id="valid_der",
+            ),
+        ],
+    )
+    def test_get_private_key(
+        self,
+        key_file,
+        test_case: str,
+        file_content: bytes,
+        expected_error: type[Exception] | None,
+        expected_error_msg: str | None,
+    ):
+        key_file.write_bytes(file_content)
+        store = KeyStore()
+
+        if expected_error is None:
+            # When:
+            result = store.get_private_key()
+
+            # Then:
+            assert isinstance(result, EllipticCurvePrivateKey), test_case
+        else:
+            match = re.escape(expected_error_msg) if expected_error_msg else None
+            with pytest.raises(expected_error, match=match):
+                store.get_private_key()
+
+    # -- get_public_key -----------------------------------------------------
+
+    def test_get_public_key(self, key_file):
+        """get_public_key returns an EllipticCurvePublicKey derived from the private key."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        # When:
+        result = store.get_public_key()
+
+        # Then:
+        assert isinstance(result, EllipticCurvePublicKey)
+
+    # -- get_public_key_str -------------------------------------------------
+
+    def test_get_public_key_str(self, key_file):
+        """get_public_key_str returns a base64-encoded uncompressed EC point."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        # When:
+        result = store.get_public_key_str()
+
+        # Then:
+        assert result == _SERVER_PUBLIC_KEY_B64
+        raw = base64.b64decode(result)
+        # Uncompressed EC point for P-256: 04 || X(32) || Y(32) = 65 bytes.
+        assert len(raw) == _UNCOMPRESSED_EC_POINT_LENGTH
+        assert raw[0] == _UNCOMPRESSED_EC_POINT_PREFIX
+
+    # -- staleness / reload -------------------------------------------------
+
+    def test_reload_if_stale_reloads_after_interval(self, key_file, monkeypatch):
+        """The key is reloaded from disk when the cached copy exceeds the reload interval."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        original_key = store.get_private_key()
+
+        # Write a new key to the same file.
+        new_key = ec.generate_private_key(_ECDH_CURVE)
+        key_file.write_bytes(_ec_key_pem_bytes(new_key))
+
+        # Simulate time passing beyond the reload interval.
+        monkeypatch.setattr(time, "monotonic", lambda: store._loaded_at + 30 * 60 + 1)
+
+        # When:
+        reloaded_key = store.get_private_key()
+
+        # Then: the key should have changed (different serialization).
+        original_bytes = original_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        reloaded_bytes = reloaded_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        assert original_bytes != reloaded_bytes
+
+    def test_no_reload_when_not_stale(self, key_file, monkeypatch):
+        """The key is NOT reloaded when the cached copy is still fresh."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        original_key = store.get_private_key()
+
+        # Write a different key to disk.
+        new_key = ec.generate_private_key(_ECDH_CURVE)
+        key_file.write_bytes(_ec_key_pem_bytes(new_key))
+
+        # Simulate time NOT exceeding the reload interval.
+        monkeypatch.setattr(time, "monotonic", lambda: store._loaded_at + 30 * 60 - 1)
+
+        # When:
+        cached_key = store.get_private_key()
+
+        # Then: should still return the original cached key.
+        original_bytes = original_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        cached_bytes = cached_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        assert original_bytes == cached_bytes
+
+    def test_reload_failure_preserves_cached_key(self, key_file, monkeypatch):
+        """When reload fails, the last-known-good key is preserved and returned."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        original_key = store.get_private_key()
+
+        # Remove the key file to simulate a transient failure during secret rotation.
+        key_file.unlink()
+
+        # Simulate time passing beyond the reload interval.
+        monkeypatch.setattr(time, "monotonic", lambda: store._loaded_at + 30 * 60 + 1)
+
+        # When: get_private_key should NOT raise — it should return the cached key.
+        result = store.get_private_key()
+
+        # Then: the original key is still served.
+        original_bytes = original_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        result_bytes = result.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        assert original_bytes == result_bytes
+
+    def test_reload_failure_bumps_loaded_at(self, key_file, monkeypatch):
+        """After a failed reload, _loaded_at is updated to avoid retrying on every call."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        # Remove the file and trigger a stale reload.
+        key_file.unlink()
+        stale_time = store._loaded_at + 30 * 60 + 1
+        monkeypatch.setattr(time, "monotonic", lambda: stale_time)
+        store.get_private_key()
+
+        # _loaded_at should have been bumped to stale_time.
+        assert store._loaded_at == stale_time
+
+    # -- is_healthy ---------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "test_case, setup_fn, expected_result",
+        [
+            pytest.param(
+                "returns True when a valid key is loaded",
+                lambda store, key_file, monkeypatch: None,  # No special setup needed
+                True,
+                id="valid_key",
+            ),
+            pytest.param(
+                "returns False when the key is None",
+                lambda store, key_file, monkeypatch: setattr(store, "_key", None),
+                False,
+                id="key_none",
+            ),
+            pytest.param(
+                "returns False when get_public_key_str raises an exception",
+                lambda store, key_file, monkeypatch: monkeypatch.setattr(
+                    store, "get_public_key_str", lambda: (_ for _ in ()).throw(RuntimeError("Key unavailable"))
+                ),
+                False,
+                id="exception_raised",
+            ),
+        ],
+    )
+    def test_is_healthy(self, key_file, monkeypatch, test_case, setup_fn, expected_result):
+        """is_healthy returns True for a valid key, False otherwise."""
+        key_file.write_bytes(_SERVER_KEY_PEM)
+        store = KeyStore()
+
+        # Apply test-specific setup
+        setup_fn(store, key_file, monkeypatch)
+
+        # When:
+        result = store.is_healthy()
+
+        # Then:
+        assert result is expected_result, test_case
+
+    # -- fallback to ENCRYPTION_PRIVATE_KEY_B64 -----------------------------
+
+    def test_load_key_falls_back_to_b64_config(self, monkeypatch):
+        """When path is empty, _load_key reads from ENCRYPTION_PRIVATE_KEY_B64."""
+        b64_value = base64.b64encode(_SERVER_KEY_DER).decode()
+        monkeypatch.setattr("services.key_store.ENCRYPTION_PRIVATE_KEY_B64", b64_value)
+        monkeypatch.setattr("services.key_store.ENCRYPTION_PRIVATE_KEY_PATH", "")
+
+        store = KeyStore()
+
+        assert isinstance(store.get_private_key(), EllipticCurvePrivateKey)


### PR DESCRIPTION
Closes #1143

## Summary

- `_load_private_key` now accepts `bytes` (PEM or DER) directly instead of a base64-encoded string; callers handle the base64 decode themselves
- `_load_private_key_from_file` uses `read_bytes()` so binary DER files are supported alongside PEM files
- `generate-ecdh-keys.sh` simplified to produce a single `tls.key` (PEM/PKCS8), matching the format that cert-manager writes into Kubernetes secrets
- `Encryption.__init__` now receives an `EllipticCurvePrivateKey` directly (key decoding moved to `KeyStore`); tests and mocks updated accordingly
- `ENCRYPTION_PRIVATE_KEY_PATH` / `ENCRYPTION_PRIVATE_KEY_B64` settings now have explicit `cast=str`
- Adds `tests/unit/services/test_key_store.py` covering `_load_private_key`, `_load_private_key_from_file`, singleton behaviour, key reload interval, and the B64 config fallback path

## Test plan

- [ ] `pytest tests/unit/services/test_key_store.py` — new key store unit tests pass
- [ ] `pytest tests/unit/services/test_encryption.py` — updated encryption tests pass
- [ ] `pytest tests/unit/routers/test_common.py tests/unit/routers/test_public_key.py` — router tests pass
- [ ] Run `./scripts/shell/generate-ecdh-keys.sh` and verify `tls.key` is produced as a valid PEM/PKCS8 file