### PR TITLE
fix: run indexer e2e tests before git tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -312,6 +312,7 @@ jobs:
         run-unit-tests,
         run-integration-tests,
         run-evaluation-tests,
+        run-e2e-tests-indexer,
         run-integration-tests-indexer,
         run-unit-tests-indexer,
       ]
@@ -435,15 +436,15 @@ jobs:
   run-e2e-tests-indexer:
     name: Run indexer e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
-    needs: wait-for-build
+    needs: get-image-sha
     secrets: inherit
     with:
-      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ inputs.name }}"
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ needs.get-image-sha.outputs.sha }}"
       DOCS_TABLE_NAME: "kc_release_${{ inputs.name }}_e2e"
 
   create-draft:
     name: Create draft release
-    needs: [wait-for-build, run-e2e-tests-indexer]
+    needs: [wait-for-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `run-e2e-tests-indexer` job was wired to run after `wait-for-build`, which means it only ran after the git tag was already created. A test failure at that point could not prevent a bad tag from being pushed.

This change moves `run-e2e-tests-indexer` to depend on `get-image-sha` instead, running it against the release branch HEAD SHA before the tag is created -- the same pattern used by `run-evaluation-tests`. The job now gates `bump-sec-scanners-release-branch`, which sits upstream of `create-git-tag`.

Changes proposed in this pull request:
- `run-e2e-tests-indexer` now depends on `get-image-sha` instead of `wait-for-build`
- `IMAGE_NAME` uses the release branch HEAD SHA instead of the release tag name
- `run-e2e-tests-indexer` added to the `needs` list of `bump-sec-scanners-release-branch`
- `run-e2e-tests-indexer` removed from the `needs` list of `create-draft`

**Testing**
GHA workflow change -- cannot be tested before merge. A follow-up test PR will be created immediately after merge to verify the workflow runs correctly.

**Related issue(s)**
Resolves #1067
