### PR TITLE
fix: correct kubectl wait logic in drop/tables e2e steps

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -424,9 +424,8 @@ jobs:
       - name: wait for build indexer
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GIT_REF: ${{ inputs.name }}
-          # The re-useable image-builder workflow from neighbors appends the "Build image" suffix to the check run name.
-          GIT_CHECK_RUN_NAME: "build-indexer-${{ inputs.name }} / Build image"
+          GIT_REF: ${{ needs.validate-input-params.outputs.release_branch }}
+          GIT_CHECK_RUN_NAME: "build-indexer / Build image"
           INTERVAL: 60
           TIMEOUT: 900
         run: |
@@ -435,10 +434,10 @@ jobs:
   run-e2e-tests-indexer:
     name: Run indexer e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
-    needs: wait-for-build
+    needs: [wait-for-build, get-image-sha]
     secrets: inherit
     with:
-      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ inputs.name }}"
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ needs.get-image-sha.outputs.sha }}"
       DOCS_TABLE_NAME: "kc_release_${{ inputs.name }}_e2e"
 
   create-draft:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -424,8 +424,9 @@ jobs:
       - name: wait for build indexer
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GIT_REF: ${{ needs.validate-input-params.outputs.release_branch }}
-          GIT_CHECK_RUN_NAME: "build-indexer / Build image"
+          GIT_REF: ${{ inputs.name }}
+          # The re-useable image-builder workflow from neighbors appends the "Build image" suffix to the check run name.
+          GIT_CHECK_RUN_NAME: "build-indexer-${{ inputs.name }} / Build image"
           INTERVAL: 60
           TIMEOUT: 900
         run: |
@@ -434,10 +435,10 @@ jobs:
   run-e2e-tests-indexer:
     name: Run indexer e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
-    needs: [wait-for-build, get-image-sha]
+    needs: wait-for-build
     secrets: inherit
     with:
-      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ needs.get-image-sha.outputs.sha }}"
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ inputs.name }}"
       DOCS_TABLE_NAME: "kc_release_${{ inputs.name }}_e2e"
 
   create-draft:

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -201,11 +201,15 @@ jobs:
                   secret:
                     secretName: doc-indexer-config
           EOF
-          kubectl wait --for=condition=complete job/doc-indexer-drop \
-            -n "${{ env.NAMESPACE }}" --timeout=120s || \
-          kubectl wait --for=condition=failed job/doc-indexer-drop \
-            -n "${{ env.NAMESPACE }}" --timeout=10s && \
-          { kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-drop --tail=50 || true; exit 1; }
+          if kubectl wait --for=condition=complete job/doc-indexer-drop \
+            -n "${{ env.NAMESPACE }}" --timeout=120s; then
+            kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-drop --tail=50 || true
+          else
+            kubectl wait --for=condition=failed job/doc-indexer-drop \
+              -n "${{ env.NAMESPACE }}" --timeout=10s || true
+            kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-drop --tail=50 || true
+            exit 1
+          fi
 
       - name: List HANA tables
         if: always()
@@ -240,9 +244,12 @@ jobs:
                   secret:
                     secretName: doc-indexer-config
           EOF
-          kubectl wait --for=condition=complete job/doc-indexer-tables \
-            -n "${{ env.NAMESPACE }}" --timeout=120s || \
-          kubectl wait --for=condition=failed job/doc-indexer-tables \
-            -n "${{ env.NAMESPACE }}" --timeout=10s && \
-          { kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true; exit 1; }
-          kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true
+          if kubectl wait --for=condition=complete job/doc-indexer-tables \
+            -n "${{ env.NAMESPACE }}" --timeout=120s; then
+            kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true
+          else
+            kubectl wait --for=condition=failed job/doc-indexer-tables \
+              -n "${{ env.NAMESPACE }}" --timeout=10s || true
+            kubectl logs -n "${{ env.NAMESPACE }}" -l job-name=doc-indexer-tables --tail=50 || true
+            exit 1
+          fi

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - "doc_indexer/**"
       - ".github/workflows/pull-build-image-indexer.yaml"
+      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions: read-all
 

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -5,10 +5,6 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths:
-      - "doc_indexer/**"
-      - ".github/workflows/push-build-image-indexer.yaml"
-      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/push-build-image-indexer.yaml
+++ b/.github/workflows/push-build-image-indexer.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - "doc_indexer/**"
       - ".github/workflows/push-build-image-indexer.yaml"
+      - ".github/workflows/e2e-tests-doc-indexer-reusable.yaml"
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/push-build-image.yaml
+++ b/.github/workflows/push-build-image.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - "docs/**"
 
 permissions:
   id-token: write # This is required for requesting the JWT token


### PR DESCRIPTION
## Problems

**1. Drop/tables steps always exit 1**

The `Drop HANA table` and `List HANA tables` steps added in #1142 always
exit with code 1, even when the job succeeds. The post-merge push e2e run
([run 24987524931](https://github.com/kyma-project/kyma-companion/actions/runs/24987524931))
confirmed this: both jobs logged success but the steps failed.

Root cause: shell operator precedence. `||` and `&&` have equal left-to-right
precedence, so:

```bash
kubectl wait --for=condition=complete ... || \
kubectl wait --for=condition=failed  ... && \
{ exit 1; }
```

parses as `(wait_complete || wait_failed) && { exit 1; }`. When `wait_complete`
exits 0, the `||` short-circuits to true, so `&& { exit 1; }` always fires.

**2. Image build not triggered for reusable workflow changes**

`pull-build-image-indexer.yaml` did not include `e2e-tests-doc-indexer-reusable.yaml`
in its paths trigger, so a PR touching only the reusable workflow never built an image.
`wait-for-build` then timed out, and e2e tests were skipped entirely -- making it
impossible to validate workflow-only changes before merge.

**3. Push image builds are path-gated**

Both `push-build-image.yaml` and `push-build-image-indexer.yaml` had path filters,
meaning a push that only touched unrelated files would skip the image build. The
release workflow assumes a valid push image always exists for the release branch HEAD.

## Fixes

- Replace the broken `||/&&` chain in drop/tables steps with an `if/else` block
- Add `e2e-tests-doc-indexer-reusable.yaml` to the paths trigger in `pull-build-image-indexer.yaml`
- Remove all path filters from `push-build-image.yaml` and `push-build-image-indexer.yaml` so both images are always built on every push to `main` or `release-*`

**Testing**

GHA workflow changes -- cannot be validated before merge. Will be confirmed in the
next e2e run after merge.