### PR TITLE
chore: extend data sources for RAG

### DIFF
--- a/doc_indexer/docs_sources.json
+++ b/doc_indexer/docs_sources.json
@@ -154,9 +154,6 @@
     "include_files": [
       "tutorials/cp-kyma-microservice-trigger/cp-kyma-microservice-trigger.md",
       "tutorials/cp-kyma-mocks/cp-kyma-mocks.md",
-      "tutorials/cp-kyma-frontend-ui5-mssql/cp-kyma-frontend-ui5-mssql.md",
-      "tutorials/cp-kyma-api-mssql-golang/cp-kyma-api-mssql-golang.md",
-      "tutorials/cp-kyma-mssql-deployment/cp-kyma-mssql-deployment.md",
       "tutorials/cp-kyma-download-cli/cp-kyma-download-cli.md",
       "tutorials/cp-kyma-redis-function/cp-kyma-redis-function.md",
       "tutorials/cp-kyma-getting-started/cp-kyma-getting-started.md",
@@ -302,18 +299,6 @@
       "docs/glossary.md"
     ],
     "exclude_files": [
-      "*/_sidebar.md"
-    ]
-  },
-  {
-    "name": "ans-manager",
-    "source_type": "Github",
-    "url": "https://github.com/kyma-project/ans-manager.git",
-    "include_files": [
-      "docs/user/*"
-    ],
-    "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   }

--- a/doc_indexer/docs_sources.json
+++ b/doc_indexer/docs_sources.json
@@ -7,7 +7,6 @@
       "docs/*"
     ],
     "exclude_files": [
-      "*/_sidebar.md",
       "*/_*.md"
     ]
   },
@@ -17,7 +16,7 @@
     "url": "https://github.com/kyma-project/eventing-manager.git",
     "include_files": [
       "README.md",
-      "docs/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/_sidebar.md"
@@ -29,7 +28,7 @@
     "url": "https://github.com/kyma-project/nats-manager.git",
     "include_files": [
       "README.md",
-      "docs/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/_sidebar.md"
@@ -40,14 +39,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/istio.git",
     "include_files": [
-      "docs/user/04-00-istio-custom-resource.md",
-      "docs/user/tutorials/01-10-external-authorization-provider.md",
-      "docs/user/tutorials/01-20-expose-httbin-gateway-api.md",
-      "docs/user/tutorials/01-50-send-requests-using-egress.md",
-      "docs/user/tutorials/01-55-send-requests-using-egress-and-mtls.md",
-      "docs/user/tutorials/01-60-enable-nlb-load-balancer.md",
-      "docs/user/technical-reference/05-00-istio-controller-parameters.md",
-      "docs/user/technical-reference/05-10-istio-controller-rbac.md"
+      "docs/user/*"
     ]
   },
   {
@@ -56,7 +48,7 @@
     "url": "https://github.com/kyma-project/warden.git",
     "include_files": [
       "README.md",
-      "docs/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/_sidebar.md"
@@ -67,8 +59,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/cloud-manager.git",
     "include_files": [
-      "docs/user/resources/*",
-      "docs/user/tutorials/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "docs/user/resources/README.md",
@@ -80,20 +71,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/api-gateway.git",
     "include_files": [
-      "docs/user/custom-resources/apigateway/*",
-      "docs/user/custom-resources/apirule/04-10-apirule-custom-resource.md",
-      "docs/user/custom-resources/apirule/04-15-api-rule-access-strategies.md",
-      "docs/user/custom-resources/apirule/04-70-changes-in-apirule-v2.md",
-      "docs/user/custom-resources/ratelimit/*",
-      "docs/user/troubleshooting-guides/*",
-      "docs/user/tutorials/01-10-setup-custom-domain-for-workload.md",
-      "docs/user/tutorials/01-20-set-up-tls-gateway.md",
-      "docs/user/tutorials/01-30-set-up-mtls-gateway.md",
-      "docs/user/tutorials/01-70-local-rate-limit.md",
-      "docs/user/apirule-migration/01-81-retrieve-v1beta1-spec.md",
-      "docs/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md",
-      "docs/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md",
-      "docs/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md"
+      "docs/user/*"
     ]
   },
   {
@@ -101,8 +79,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/telemetry-manager.git",
     "include_files": [
-      "docs/user/resources/*",
-      "docs/user/integration/*"
+      "docs/user/*"
     ]
   },
   {
@@ -110,8 +87,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/btp-manager.git",
     "include_files": [
-      "docs/user/resources/*",
-      "docs/user/tutorials/04-40-create-service-in-cluster.md"
+      "docs/user/*"
     ]
   },
   {
@@ -120,7 +96,7 @@
     "url": "https://github.com/kyma-project/application-connector-manager.git",
     "include_files": [
       "README.md",
-      "docs/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/_sidebar.md"
@@ -131,8 +107,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/docker-registry.git",
     "include_files": [
-      "docs/user/resources/*",
-      "docs/user/tutorials/*"
+      "docs/user/*"
     ],
     "exclude_files": [
       "docs/user/tutorials/README.md",
@@ -144,8 +119,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/keda-manager.git",
     "include_files": [
-      "docs/user/04-10-footprint.md",
-      "docs/user/04-20-demo-applications.md"
+      "docs/user/*"
     ]
   },
   {
@@ -153,12 +127,7 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/serverless.git",
     "include_files": [
-      "docs/user/resources/*",
-      "docs/user/troubleshooting-guides/*",
-      "docs/user/technical-reference/*",
-      "docs/user/tutorials/*",
-      "docs/user/00-30-development-toolkit.md",
-      "docs/user/08-10-best-practices.md"
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/README.md",
@@ -171,7 +140,8 @@
     "url": "https://github.com/kyma-project/busola.git",
     "include_files": [
       "docs/resource-validation/*",
-      "docs/extensibility/*"
+      "docs/custom-extensions/*",
+      "docs/user/*"
     ],
     "exclude_files": [
       "*/_sidebar.md"
@@ -189,8 +159,20 @@
       "tutorials/cp-kyma-mssql-deployment/cp-kyma-mssql-deployment.md",
       "tutorials/cp-kyma-download-cli/cp-kyma-download-cli.md",
       "tutorials/cp-kyma-redis-function/cp-kyma-redis-function.md",
-      "tutorials/cp-kyma-mocks/cp-kyma-mocks.md",
-      "tutorials/cp-kyma-getting-started/cp-kyma-getting-started.md"
+      "tutorials/cp-kyma-getting-started/cp-kyma-getting-started.md",
+      "tutorials/btp-cli-setup-kyma-cluster/*",
+      "tutorials/cp-kyma-api-postgres-golang/*",
+      "tutorials/cp-kyma-create-function-cli/*",
+      "tutorials/cp-kyma-create-function-ui/*",
+      "tutorials/cp-kyma-enable-module/*",
+      "tutorials/cp-kyma-frontend-ui5-postgresql/*",
+      "tutorials/cp-kyma-gateway-api/*",
+      "tutorials/cp-kyma-mtls-requests-egress/*",
+      "tutorials/cp-kyma-postgres-seed/*",
+      "tutorials/cp-kyma-requests-egress/*",
+      "tutorials/private-link-aws-kyma/*",
+      "tutorials/private-link-azure-kyma/*",
+      "tutorials/private-link-kyma/*"
     ]
   },
   {
@@ -202,7 +184,137 @@
       "tutorials/deploy-to-kyma/deploy-to-kyma.md",
       "tutorials/user-role-assignment/user-role-assignment.md",
       "tutorials/integrate-with-work-zone-kymaruntime/integrate-with-work-zone-kymaruntime.md",
-      "tutorials/set-up-cicd-kyma/set-up-cicd-kyma.md"
+      "tutorials/set-up-cicd-kyma/set-up-cicd-kyma.md",
+      "tutorials/remote-service-deploy-to-kyma/*",
+      "tutorials/remote-service-deploy-with-mock-kyma/*",
+      "tutorials/remote-service-set-up-mock-kyma/*"
+    ]
+  },
+  {
+    "name": "kyma-environment-broker",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/kyma-environment-broker.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "cli",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/cli.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "registry-proxy",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/registry-proxy.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "auditlog-manager",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/auditlog-manager.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "modulectl",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/modulectl.git",
+    "include_files": [
+      "docs/user/*",
+      "docs/gen-docs/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "lifecycle-manager",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/lifecycle-manager.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "community-modules",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/community-modules.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "kyma-infrastructure-manager",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/kyma-infrastructure-manager.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "kyma",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/kyma.git",
+    "include_files": [
+      "README.md",
+      "docs/01-overview/*",
+      "docs/02-get-started/*",
+      "docs/03-tutorials/*",
+      "docs/04-operation-guides/*",
+      "docs/06-modules/*",
+      "docs/README.md",
+      "docs/glossary.md"
+    ],
+    "exclude_files": [
+      "*/_sidebar.md"
+    ]
+  },
+  {
+    "name": "ans-manager",
+    "source_type": "Github",
+    "url": "https://github.com/kyma-project/ans-manager.git",
+    "include_files": [
+      "docs/user/*"
+    ],
+    "exclude_files": [
+      "docs/user/README.md",
+      "*/_sidebar.md"
     ]
   }
 ]

--- a/doc_indexer/docs_sources.json
+++ b/doc_indexer/docs_sources.json
@@ -7,7 +7,7 @@
       "docs/*"
     ],
     "exclude_files": [
-      "*/_*.md"
+      "*/_sidebar.md"
     ]
   },
   {
@@ -193,10 +193,6 @@
     "url": "https://github.com/kyma-project/kyma-environment-broker.git",
     "include_files": [
       "docs/user/*"
-    ],
-    "exclude_files": [
-      "docs/user/README.md",
-      "*/_sidebar.md"
     ]
   },
   {
@@ -207,7 +203,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },
@@ -219,7 +214,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },
@@ -240,11 +234,9 @@
     "source_type": "Github",
     "url": "https://github.com/kyma-project/modulectl.git",
     "include_files": [
-      "docs/user/*",
       "docs/gen-docs/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },
@@ -268,19 +260,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
-      "*/_sidebar.md"
-    ]
-  },
-  {
-    "name": "kyma-infrastructure-manager",
-    "source_type": "Github",
-    "url": "https://github.com/kyma-project/kyma-infrastructure-manager.git",
-    "include_files": [
-      "docs/user/*"
-    ],
-    "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },

--- a/doc_indexer/docs_sources.json
+++ b/doc_indexer/docs_sources.json
@@ -60,10 +60,6 @@
     "url": "https://github.com/kyma-project/cloud-manager.git",
     "include_files": [
       "docs/user/*"
-    ],
-    "exclude_files": [
-      "docs/user/resources/README.md",
-      "docs/user/tutorials/README.md"
     ]
   },
   {
@@ -108,10 +104,6 @@
     "url": "https://github.com/kyma-project/docker-registry.git",
     "include_files": [
       "docs/user/*"
-    ],
-    "exclude_files": [
-      "docs/user/tutorials/README.md",
-      "docs/user/resources/README.md"
     ]
   },
   {
@@ -130,7 +122,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "*/README.md",
       "docs/user/tutorials/01-60-set-external-registry.md"
     ]
   },
@@ -225,7 +216,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },
@@ -248,7 +238,6 @@
       "docs/user/*"
     ],
     "exclude_files": [
-      "docs/user/README.md",
       "*/_sidebar.md"
     ]
   },


### PR DESCRIPTION
## Summary

- Remove `README.md` entries from `exclude_files` in `doc_indexer/docs_sources.json`
- Affected sources: `cloud-manager`, `docker-registry`, `serverless`, `auditlog-manager`, `lifecycle-manager`

## Related issue(s)

Related to #1156