### PR TITLE
chore: protect doc-indexer e2e workflow with environment gate

### DIFF
--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -22,6 +22,7 @@ env:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    environment: e2e
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -58,7 +58,8 @@ jobs:
     name: Run e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     needs: wait-for-build
-    secrets: inherit
+    secrets:
+      DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
       DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"


### PR DESCRIPTION
## Summary

Follow-up to #1158 — extends the `environment: e2e` protection gate to the doc-indexer E2E workflow path, which was missed in the original fix.

- Add `environment: e2e` to the `e2e-tests` job in `e2e-tests-doc-indexer-reusable.yaml`, gating execution behind required reviewers before `DOC_INDEXER_TESTS_CONFIG` is exposed (mirrors the fix applied to `evaluation-test-reusable.yaml` in #1158)
- Replace `secrets: inherit` in `pull-e2e-tests-doc-indexer.yaml` with explicit `DOC_INDEXER_TESTS_CONFIG` forwarding (least-privilege principle, consistent with #1158)

## Security context

Part of the remediation for the Poisoned Pipeline Execution (PWN Request) vulnerability (CVSS 10.0) tracked in [security-backlog#114](https://github.tools.sap/kyma/security-backlog/issues/114). The `pull_request_target` trigger runs with base-repo privileges; the environment gate ensures a team member approves before secrets are exposed to a fork PR.

## Test plan

- [ ] Open a fork PR touching `doc_indexer/**` and verify the `e2e-tests` job shows **"Waiting"** for environment approval before starting
- [ ] Confirm `DOC_INDEXER_TESTS_CONFIG` is not visible in job logs prior to approval