### PR TITLE
fix: bumped langfuse images

### DIFF
--- a/Dockerfile.langfuse
+++ b/Dockerfile.langfuse
@@ -1,4 +1,4 @@
-FROM langfuse/langfuse:3.63.0
+FROM langfuse/langfuse:3.174.1
 
 # ---- Override OCI labels (remove emojis) ----
 LABEL org.opencontainers.image.title="langfuse" \

--- a/Dockerfile.langfuse-worker
+++ b/Dockerfile.langfuse-worker
@@ -1,4 +1,4 @@
-FROM langfuse/langfuse-worker:3.63.0
+FROM langfuse/langfuse-worker:3.174.1
 
 # ---- Override OCI labels (remove emojis) ----
 LABEL org.opencontainers.image.title="langfuse-worker" \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
CVE-2025-9799
A security flaw has been discovered in Langfuse up to 3.88.0. Affected by this vulnerability is the function promptChangeEventSourcing of the file web/src/features/prompts/server/routers/promptRouter.ts of the component Webhook Handler. Performing manipulation results in server-side request forgery. The attack may be initiated remotely. A high degree of complexity is needed for the attack. The exploitation appears to be difficult. The exploit has been released to the public and may be exploited.
Changes proposed in this pull request:

Both Dockerfiles updated:

- langfuse/langfuse:3.63.0 → 3.174.1
- langfuse/langfuse-worker:3.63.0 → 3.174.1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
