### PR TITLE
fix: bumped python-multipart  package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5505,14 +5505,14 @@ dev = ["black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", 
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.29"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
-    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+    {file = "python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69"},
+    {file = "python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904"},
 ]
 
 [[package]]
@@ -8154,4 +8154,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.13.*"
-content-hash = "f814f71a0713ae7e8315318d987be040f76353581d46d85d3e82f04a3895219e"
+content-hash = "3739a85015de61033147f1a76ebe0aa05783aec26d2bc48385854f0705222fb5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pyjwt (>=2.12.1,<3.0.0)",
   "python-decouple (>=3.8,<4.0)",
   "python-json-logger (>=4.1.0,<5.0.0)",
+  "python-multipart (>=0.0.23)",
   "redis (>=7.4.0,<8.0.0)",
   "requests (>=2.33.0,<3.0.0)",
   "sap-ai-sdk-gen[all] (>=6.7.0,<7.0.0)",

--- a/tests/blackbox/poetry.lock
+++ b/tests/blackbox/poetry.lock
@@ -4675,14 +4675,14 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.29"
 description = "A streaming multipart parser for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
-    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+    {file = "python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69"},
+    {file = "python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904"},
 ]
 
 [[package]]
@@ -7080,4 +7080,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.13.*"
-content-hash = "5f60db691f322871fd2f6f6dfcfaf5b34afdd91810085eedd657907713f6e3ab"
+content-hash = "988489276c5cdfe8bca8c5030cf0563698edbc0a3d66ec7c08e7a05719a41814"

--- a/tests/blackbox/pyproject.toml
+++ b/tests/blackbox/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "prometheus-client (>=0.24.1,<0.25.0)",
   "pyjwt (>=2.12.1,<3.0.0)",
   "python-decouple (>=3.8,<4.0)",
+  "python-multipart (>=0.0.23)",
   "redis (>=7.4.0,<8.0.0)",
   "requests (>=2.33.1,<3.0.0)",
   "scrubadub (>=2.0.1,<3.0.0)",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

CVE-2026-40347
python-multipart Vulnerable to Denial-of-Service (DoS) via Large Multipart Preamble or Epilogue Data in Multipart Parsing

Changes proposed in this pull request:

- Updated python-multipart from 0.0.22 to 0.0.29

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
