### PR TITLE
fix: doc indexer tests e2e environment and paths trigger

### DIFF
--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -12,15 +12,11 @@ on:
 permissions: read-all
 
 jobs:
-  tests:
+  unit-test:
+    name: Tests (unit)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [unit, integration]
-    name: Tests (${{ matrix.test-type }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -49,7 +45,6 @@ jobs:
         run: poetry install --with test
 
       - name: Run unit tests
-        if: matrix.test-type == 'unit'
         working-directory: ./doc_indexer
         env:
           LOG_LEVEL: "DEBUG"
@@ -59,8 +54,40 @@ jobs:
         run: |
           poetry run poe test-unit
 
+  integration-test:
+    name: Tests (integration)
+    runs-on: ubuntu-latest
+    environment: e2e
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Extract Python version
+        working-directory: ./doc_indexer
+        run: |
+          ../scripts/shell/extract-python-version.sh
+          echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        working-directory: ./doc_indexer
+        run: poetry install --with test
+
       - name: Run integration tests
-        if: matrix.test-type == 'integration'
         working-directory: ./doc_indexer
         env:
           LOG_LEVEL: "DEBUG"

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -8,6 +8,7 @@ on:
       - "release-**"
     paths:
       - "doc_indexer/**"
+      - ".github/workflows/pull-tests-doc-indexer.yaml"
 
 permissions: read-all
 

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -12,11 +12,19 @@ on:
 permissions: read-all
 
 jobs:
-  unit-test:
-    name: Tests (unit)
+  tests:
     runs-on: ubuntu-latest
+    environment: ${{ matrix.env_name }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-type: unit
+          - test-type: integration
+            env_name: e2e
+    name: Tests (${{ matrix.test-type }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -45,6 +53,7 @@ jobs:
         run: poetry install --with test
 
       - name: Run unit tests
+        if: matrix.test-type == 'unit'
         working-directory: ./doc_indexer
         env:
           LOG_LEVEL: "DEBUG"
@@ -54,40 +63,8 @@ jobs:
         run: |
           poetry run poe test-unit
 
-  integration-test:
-    name: Tests (integration)
-    runs-on: ubuntu-latest
-    environment: e2e
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Extract Python version
-        working-directory: ./doc_indexer
-        run: |
-          ../scripts/shell/extract-python-version.sh
-          echo "Got PYTHON_VERSION=${PYTHON_VERSION}"
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install dependencies
-        working-directory: ./doc_indexer
-        run: poetry install --with test
-
       - name: Run integration tests
+        if: matrix.test-type == 'integration'
         working-directory: ./doc_indexer
         env:
           LOG_LEVEL: "DEBUG"


### PR DESCRIPTION
Closes #1172

## Summary

- Add `.github/workflows/pull-tests-doc-indexer.yaml` to the workflow's `paths` trigger so changes to the workflow file itself trigger the tests (takes effect after merge -- `pull_request_target` always runs the workflow from `main`)
- Use a matrix with `include` to set `environment: e2e` only on the integration leg, leaving unit tests ungated
- Fix `DOC_INDEXER_TESTS_CONFIG` being empty: the secret was moved to the `e2e` environment, but the job had no `environment:` declaration

The matrix approach was chosen over splitting into two jobs because GitHub Actions evaluates
`environment:` after matrix expansion -- a leg with no `env_name` defined resolves to an
empty string, which GitHub treats as no environment. This keeps the workflow compact without
gating unit tests behind environment approval.

## Testing

- `actionlint` clean on the changed workflow file
- `Tests (unit)` ran immediately (no environment gate) on this PR
- Post-merge: `Tests (integration)` waiting behavior needs verification on a PR that touches `doc_indexer/**` or this workflow file