### PR TITLE
fix: add e2e environment to integration test jobs in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -184,6 +184,7 @@ jobs:
     name: Run integration tests
     needs: validate-input-params
     runs-on: ubuntu-latest
+    environment: e2e
     permissions: read-all
     env:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -229,6 +229,7 @@ jobs:
     name: Run indexer integration tests
     needs: validate-input-params
     runs-on: ubuntu-latest
+    environment: e2e
     permissions: read-all
     env:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}


### PR DESCRIPTION
## Summary

- Add `environment: e2e` to `run-integration-tests` in `create-release.yml`
- Add `environment: e2e` to `run-integration-tests-indexer` in `create-release.yml`

Both jobs use secrets that live in the `e2e` environment (`INTEGRATION_TEST_CONFIG` and `DOC_INDEXER_TESTS_CONFIG` respectively) but had no `environment:` declaration, causing the secrets to resolve to empty strings.

Same root cause and fix as #1173, which applied the identical change to the PR workflow.

Closes #1174

**Testing**

Cannot be tested before merge -- `create-release` is `workflow_dispatch` triggered from a release branch. Will verify by triggering a release workflow run after merge and confirming both jobs read their secrets correctly.