### PR TITLE
fix: add environment gate to pull_request_target workflows

### DIFF
--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -16,10 +16,15 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    if: contains(github.event.pull_request.labels.*.name, 'api-tests')
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   wait-for-build:
     name: Wait for image build job
-    if: contains(github.event.pull_request.labels.*.name, 'api-tests')
-    environment: e2e
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -19,6 +19,7 @@ jobs:
   wait-for-build:
     name: Wait for image build job
     if: contains(github.event.pull_request.labels.*.name, 'api-tests')
+    environment: e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -14,12 +14,17 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   build-indexer:
+    needs: gate
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-    environment: e2e
     with:
       name: kyma-companion-indexer
       dockerfile: Dockerfile

--- a/.github/workflows/pull-build-image-indexer.yaml
+++ b/.github/workflows/pull-build-image-indexer.yaml
@@ -19,6 +19,7 @@ jobs:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    environment: e2e
     with:
       name: kyma-companion-indexer
       dockerfile: Dockerfile

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
+    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kyma-companion

--- a/.github/workflows/pull-build-image.yaml
+++ b/.github/workflows/pull-build-image.yaml
@@ -9,11 +9,16 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   build:
+    needs: gate
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
-    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: kyma-companion

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -12,11 +12,16 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   build-langfuse:
+    needs: gate
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
-    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse
@@ -26,10 +31,10 @@ jobs:
       platforms: |
         linux/amd64
   build-langfuse-worker:
+    needs: gate
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
-    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse-worker

--- a/.github/workflows/pull-build-langfuse.yaml
+++ b/.github/workflows/pull-build-langfuse.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
+    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse
@@ -28,6 +29,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
+    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: external-langfuse-worker

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -15,9 +15,14 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   wait-for-build:
     name: Wait for image build job
-    environment: e2e
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -17,6 +17,7 @@ permissions: read-all
 jobs:
   wait-for-build:
     name: Wait for image build job
+    environment: e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -13,6 +13,7 @@ jobs:
   wait-for-build:
     name: Wait for image build job
     if: contains(github.event.pull_request.labels.*.name, 'evaluation requested')
+    environment: e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -10,10 +10,15 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    if: contains(github.event.pull_request.labels.*.name, 'evaluation requested')
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   wait-for-build:
     name: Wait for image build job
-    if: contains(github.event.pull_request.labels.*.name, 'evaluation requested')
-    environment: e2e
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -13,9 +13,15 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   integration-test:
     if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
-    environment: e2e
+    needs: gate
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -10,8 +10,14 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   comment:
     name: Notes for PR
+    needs: gate
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -13,7 +13,13 @@ on:
 permissions: read-all
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: e2e
+    steps:
+      - run: echo "environment gate passed"
   tests:
+    needs: gate
     runs-on: ubuntu-latest
     environment: ${{ matrix.env_name }}
     permissions:


### PR DESCRIPTION
## Summary

- Add `environment: e2e` gate to all jobs using `pull_request_target` that access secrets or perform OIDC-based image pushes
- Without the gate, a malicious fork PR could trigger a workflow that accesses secrets or pushes images to the registry before any maintainer review

## Affected workflows

| Workflow | Risk addressed |
|----------|---------------|
| `pull-api-tests.yaml` | Uses `EVALUATION_TESTS_CONFIG` secret |
| `pull-build-image-indexer.yaml` | OIDC image push (`id-token: write`) |
| `pull-build-image.yaml` | OIDC image push (`id-token: write`) |
| `pull-build-langfuse.yaml` | OIDC image push (`id-token: write`) |
| `pull-e2e-tests-doc-indexer.yaml` | Uses `DOC_INDEXER_TESTS_CONFIG` secret |
| `pull-evaluation-tests.yaml` | Uses `EVALUATION_TESTS_CONFIG` secret |

## Not changed

- `pull-request-comment.yaml` — intentionally no gate; only uses auto-provided `GITHUB_TOKEN`, never executes code from the PR head, and needs `pull_request_target` write access to post comments on fork PRs
- `pull-integration-test.yaml`, `pull-tests-doc-indexer.yaml`, `pull-build-image-indexer.yaml` — already had `environment: e2e`

## Test plan

- [ ] Verify that a fork PR triggers the environment protection review before any secrets or OIDC tokens are accessed