### PR TITLE
fix: eval test improve subscription tests query

### DIFF
--- a/tests/blackbox/data/test-cases/12_kyma_subscription_invalid_sink/scenario.yml
+++ b/tests/blackbox/data/test-cases/12_kyma_subscription_invalid_sink/scenario.yml
@@ -1,7 +1,7 @@
 id: test-subscription-12 # format: test-<resource_kind>-<test_id>
 description: The Subscription is configured with an invalid sink URL
 queries:
-  - user_query: How do I fix my subscription?
+  - user_query: How do I fix my kyma subscription?
     resource:
       kind: Subscription
       api_version: eventing.kyma-project.io/v1alpha2

--- a/tests/blackbox/data/test-cases/13_kyma_subscription_invalid_source/scenario.yml
+++ b/tests/blackbox/data/test-cases/13_kyma_subscription_invalid_source/scenario.yml
@@ -1,7 +1,7 @@
 id: test-subscription-13 # format: test-<resource_kind>-<test_id>
 description: The Subscription is configured with an invalid source configuration.
 queries:
-  - user_query: How exactly do I fix my subscription?
+  - user_query: How exactly do I fix my kyma subscription?
     resource:
       kind: Subscription
       api_version: eventing.kyma-project.io/v1alpha2


### PR DESCRIPTION
# Fix Eval Test: Improve Subscription Query Specificity

### Bug Fix

🐛 Updated test scenario queries to be more specific by including "kyma" in the subscription-related user queries, ensuring more accurate and targeted test evaluations.

### Changes

* `tests/blackbox/data/test-cases/12_kyma_subscription_invalid_sink/scenario.yml`: Updated `user_query` from `"How do I fix my subscription?"` to `"How do I fix my kyma subscription?"` for better specificity.
* `tests/blackbox/data/test-cases/13_kyma_subscription_invalid_source/scenario.yml`: Updated `user_query` from `"How exactly do I fix my subscription?"` to `"How exactly do I fix my kyma subscription?"` for better specificity.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `68fe51c3-ab18-4ad7-bcc7-06e02bf3619c`
</details>
