### PR TITLE
sec: upgrade ECDH to P-521 and SHA-384 for PCI compliance

### DIFF
--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -26,6 +26,7 @@ from utils.logging import get_logger
 from utils.response import prepare_chunk_response
 from utils.settings import MAIN_MODEL_NAME, MAX_TOKEN_LIMIT_INPUT_QUERY
 from utils.utils import (
+    UserIdentifier,
     create_session_id,
     get_user_identifier_from_client_certificate,
     get_user_identifier_from_token,
@@ -227,8 +228,9 @@ async def messages(
         raise HTTPException(status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
     # Authorize the user to access the conversation.
-    message.user_identifier = extract_user_identifier(k8s_auth_headers)
-    await authorize_user(str(conversation_id), message.user_identifier, conversation_service)
+    user_identifier = extract_user_identifier(k8s_auth_headers)
+    message.user_identifier = user_identifier.sha384
+    await authorize_user(str(conversation_id), user_identifier, conversation_service)
 
     # Check rate limitation
     await check_token_usage(x_cluster_url, conversation_service)
@@ -295,37 +297,31 @@ async def check_token_usage(x_cluster_url: str, conversation_service: IService) 
 
 def extract_user_identifier(
     k8s_auth_headers: K8sAuthHeaders,
-) -> str:
+) -> UserIdentifier:
     """Get the user identifier from the K8s auth headers."""
-    user_identifier = ""
     if k8s_auth_headers.x_k8s_authorization is not None:
         try:
-            user_identifier = get_user_identifier_from_token(k8s_auth_headers.x_k8s_authorization)
+            return get_user_identifier_from_token(k8s_auth_headers.x_k8s_authorization)
         except Exception as e:
             logger.error(e)
             raise HTTPException(status_code=401, detail="Invalid token") from e
     elif k8s_auth_headers.x_client_certificate_data is not None:
         try:
-            user_identifier = get_user_identifier_from_client_certificate(
-                k8s_auth_headers.get_decoded_client_certificate_data()
-            )
+            return get_user_identifier_from_client_certificate(k8s_auth_headers.get_decoded_client_certificate_data())
         except Exception as e:
             logger.error(e)
             raise HTTPException(status_code=401, detail="Invalid client certificate") from e
 
-    if user_identifier == "":
-        raise HTTPException(
-            status_code=401,
-            detail="User not authorized to access the conversation. "
-            "Unable to get user identifier from the provided Authorization headers.",
-        )
-
-    return user_identifier
+    raise HTTPException(
+        status_code=401,
+        detail="User not authorized to access the conversation. "
+        "Unable to get user identifier from the provided Authorization headers.",
+    )
 
 
 async def authorize_user(
     conversation_id: str,
-    user_identifier: str,
+    user_identifier: UserIdentifier,
     conversation_service: IService,
 ) -> None:
     """Authorize the user to access the conversation."""

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -28,6 +28,7 @@ from utils.settings import (
     TOKEN_USAGE_RESET_INTERVAL,
 )
 from utils.singleton_meta import SingletonMeta
+from utils.utils import UserIdentifier
 
 logger = get_logger(__name__)
 
@@ -49,7 +50,7 @@ class IService(Protocol):
         """Handle a request for a conversation"""
         ...
 
-    async def authorize_user(self, conversation_id: str, user_identifier: str) -> bool:
+    async def authorize_user(self, conversation_id: str, user_identifier: UserIdentifier) -> bool:
         """Authorize the user to access the conversation."""
         ...
 
@@ -146,15 +147,21 @@ class ConversationService(metaclass=SingletonMeta):
             error_chunk = json.dumps({ERROR: {ERROR: ERROR_RESPONSE}})
             yield error_chunk.encode()
 
-    async def authorize_user(self, conversation_id: str, user_identifier: str) -> bool:
+    async def authorize_user(self, conversation_id: str, user_identifier: UserIdentifier) -> bool:
         """Authorize the user to access the conversation."""
         owner = await self._companion_graph.aget_thread_owner(conversation_id)
-        # If the owner is None, we can update the owner to the current user.
+        # New conversation: claim ownership under the SHA-384 hash.
         if owner is None:
-            await self._companion_graph.aupdate_thread_owner(conversation_id, user_identifier)
+            await self._companion_graph.aupdate_thread_owner(conversation_id, user_identifier.sha384)
             return True
-        # If the owner is the same as the user, we can authorize the user.
-        return owner == user_identifier
+        # Existing conversation owned by the same user (SHA-384 match).
+        if owner == user_identifier.sha384:
+            return True
+        # Legacy conversation owned under the old SHA-256 hash: migrate to SHA-384.
+        if owner == user_identifier.sha256:
+            await self._companion_graph.aupdate_thread_owner(conversation_id, user_identifier.sha384)
+            return True
+        return False
 
     async def is_usage_limit_exceeded(self, cluster_id: str) -> UsageExceedReport | None:
         """Check if the token usage limit is exceeded for the given cluster_id."""

--- a/src/services/encryption.py
+++ b/src/services/encryption.py
@@ -16,12 +16,12 @@ import base64
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from services.encryption_cache import IEncryptionCache
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 
@@ -81,10 +81,10 @@ class Encryption:
         return await self._encryption_cache.get_client_public_key(client_public_key_id)
 
     def _derive_shared_key(self, client_public_key_b64: str) -> bytes:
-        """Perform ECDH and derive a 256-bit symmetric key via HKDF-SHA256.
+        """Perform ECDH and derive a 256-bit symmetric key via HKDF-SHA384.
 
         The client public key must be the raw uncompressed EC point
-        (65 bytes for P-256), base64-encoded.
+        (133 bytes for P-521), base64-encoded.
         """
         client_public_key = ec.EllipticCurvePublicKey.from_encoded_point(
             _ECDH_CURVE,
@@ -92,7 +92,7 @@ class Encryption:
         )
         shared_secret = self._private_key.exchange(ec.ECDH(), client_public_key)
         return HKDF(
-            algorithm=SHA256(),
+            algorithm=SHA384(),
             length=32,
             salt=None,
             info=_HKDF_INFO,

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import jwt
@@ -13,6 +14,18 @@ JWT_TOKEN_SUB = "sub"
 JWT_TOKEN_EMAIL = "email"
 JWT_TOKEN_SERVICE_ACCOUNT = "kubernetes.io/serviceaccount/service-account.name"
 CN_KEYS = ["common_name", "commonName"]
+
+
+@dataclass
+class UserIdentifier:
+    """Holds both hash representations of a user identifier for migration purposes.
+
+    sha384 is the current (compliant) hash; sha256 is the legacy hash used for
+    transparent migration of existing Redis-stored identifiers.
+    """
+
+    sha384: str
+    sha256: str
 
 
 def create_ndjson_str(obj: dict) -> str:
@@ -91,39 +104,47 @@ def parse_k8s_token(token: str) -> Any:
 
 def generate_sha256_hash(data: str) -> str:
     """Generate a SHA256 hash of the input string."""
-    # Create a new sha256 hash object
     sha256_hash = hashlib.sha256()
-    # Update the hash object with the bytes-like object (encoded string)
     sha256_hash.update(data.encode())
-    # Return the hexadecimal digest of the hash
     return sha256_hash.hexdigest()
 
 
-def get_user_identifier_from_token(token: str) -> str:
-    """Get the user identifier from the token. The output is a SHA256 hash of the user identifier."""
+def generate_sha384_hash(data: str) -> str:
+    """Generate a SHA384 hash of the input string."""
+    sha384_hash = hashlib.sha384()
+    sha384_hash.update(data.encode())
+    return sha384_hash.hexdigest()
+
+
+def get_user_identifier_from_token(token: str) -> UserIdentifier:
+    """Get the user identifier from the token. Returns both SHA384 and SHA256 hashes for migration."""
     try:
         payload = parse_k8s_token(token)
         if JWT_TOKEN_SUB in payload and payload[JWT_TOKEN_SUB] != "":
-            return generate_sha256_hash(str(payload[JWT_TOKEN_SUB]))
+            raw = str(payload[JWT_TOKEN_SUB])
         elif JWT_TOKEN_EMAIL in payload and payload[JWT_TOKEN_EMAIL] != "":
-            return generate_sha256_hash(str(payload[JWT_TOKEN_EMAIL]))
+            raw = str(payload[JWT_TOKEN_EMAIL])
         elif JWT_TOKEN_SERVICE_ACCOUNT in payload and payload[JWT_TOKEN_SERVICE_ACCOUNT] != "":
-            return generate_sha256_hash(str(payload[JWT_TOKEN_SERVICE_ACCOUNT]))
-        raise ValueError("Invalid token: User identifier not found in token")
+            raw = str(payload[JWT_TOKEN_SERVICE_ACCOUNT])
+        else:
+            raise ValueError("Invalid token: User identifier not found in token")
+        return UserIdentifier(sha384=generate_sha384_hash(raw), sha256=generate_sha256_hash(raw))
     except Exception as e:
         raise ValueError("Failed to get user identifier from token") from e
 
 
-def get_user_identifier_from_client_certificate(client_certificate_data: bytes) -> str:
-    """Get the user identifier from the client certificate. The output is a SHA256 hash of the user identifier."""
+def get_user_identifier_from_client_certificate(client_certificate_data: bytes) -> UserIdentifier:
+    """Get the user identifier from the client certificate. Returns both SHA384 and SHA256 hashes for migration."""
     try:
         cert = x509.load_pem_x509_certificate(client_certificate_data, default_backend())
         # check if the Common Name (CN) is present in the subject.
         for name in cert.subject:
             if name.oid._name in CN_KEYS and name.value != "":
-                return generate_sha256_hash(str(name.value))
+                raw = str(name.value)
+                return UserIdentifier(sha384=generate_sha384_hash(raw), sha256=generate_sha256_hash(raw))
         if str(cert.serial_number) != "":
-            return generate_sha256_hash(str(cert.serial_number))
+            raw = str(cert.serial_number)
+            return UserIdentifier(sha384=generate_sha384_hash(raw), sha256=generate_sha256_hash(raw))
         raise ValueError("Invalid client certificate: User identifier not found in certificate")
     except Exception as e:
         raise ValueError("Failed to get user identifier from client certificate") from e

--- a/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
+++ b/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
@@ -24,7 +24,7 @@ import requests
 from common.config import Config
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 MIN_ERROR_STATUS_CODE = 400
 TIMEOUT = 120  # seconds
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 
@@ -61,7 +61,7 @@ def _encrypt_cluster_payload(
     )
     shared_secret = client_private_key.exchange(ec.ECDH(), companion_public_key)
     shared_key = HKDF(
-        algorithm=SHA256(),
+        algorithm=SHA384(),
         length=32,
         salt=None,
         info=_HKDF_INFO,

--- a/tests/unit/routers/test_conversations.py
+++ b/tests/unit/routers/test_conversations.py
@@ -23,6 +23,7 @@ from services.conversation import IService
 from services.k8s import IK8sClient, K8sAuthHeaders
 from services.metrics import REQUEST_LATENCY_METRIC_KEY, CustomMetrics
 from services.usage import UsageExceedReport
+from utils.utils import UserIdentifier
 
 SAMPLE_JWT_TOKEN = jwt.encode({"sub": "user123"}, "secret", algorithm="HS256")
 SAMPLE_CLIENT_CERTIFICATE_DATA = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJrakNDQVRlZ0F3SUJBZ0lJTmpJSzErZmhrZUF3Q2dZSUtvWkl6ajBFQXdJd0l6RWhNQjhHQTFVRUF3d1kKYXpOekxXTnNhV1Z1ZEMxallVQXhOelF4TXpReE1qRXlNQjRYRFRJMU1ETXdOekE1TlRNek1sb1hEVEkyTURNdwpOekE1TlRNek1sb3dNREVYTUJVR0ExVUVDaE1PYzNsemRHVnRPbTFoYzNSbGNuTXhGVEFUQmdOVkJBTVRESE41CmMzUmxiVHBoWkcxcGJqQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJFcFcwQlQrQW9DSDF3WnkKc1VjUjYzK2tXQ3FtU0NOVUo5Z1RTWnljajc3bmhSTVpwRHJPQU9XN2prRy9hVG9JOTlVRVdnT0N2VlVFZFk5YQpWZ3NpUGlhalNEQkdNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBakFmCkJnTlZIU01FR0RBV2dCUlBzdVROVW01NHlGZ1ZvbXdkUFFnZXJGS1R5REFLQmdncWhrak9QUVFEQWdOSkFEQkcKQWlFQW5OS21uZzlnSlBncVJNcDdDRUU3TVltNTY1T054RklxaFZWWUVBVVNqNDRDSVFDc2dwTlN4Q2xuTDVlWgp3eTFYM2l1MXpLZzU2Q20wblk3aitTNjBIUHE2c1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlCZHpDQ0FSMmdBd0lCQWdJQkFEQUtCZ2dxaGtqT1BRUURBakFqTVNFd0h3WURWUVFEREJock0zTXRZMnhwClpXNTBMV05oUURFM05ERXpOREV5TVRJd0hoY05NalV3TXpBM01EazFNek15V2hjTk16VXdNekExTURrMU16TXkKV2pBak1TRXdId1lEVlFRRERCaHJNM010WTJ4cFpXNTBMV05oUURFM05ERXpOREV5TVRJd1dUQVRCZ2NxaGtqTwpQUUlCQmdncWhrak9QUU1CQndOQ0FBU0VITTc2bURNTVZJOFZRRnVPL2N1RGNzbjJYbXZoZHRidGdMU2ZFQ2ozCm44VTR1QnNka1B5dVZvdFlpOG5kU1plNzlrRk45a1MwelM4dHV5YzZiWDVabzBJd1FEQU9CZ05WSFE4QkFmOEUKQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVUN0xrelZKdWVNaFlGYUpzSFQwSQpIcXhTazhnd0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFNOVlDNEtmKy8wSyszaGlOQzBlaXlHWmwwZVJxeUZkClZXRXZpYXlMR0tRNUFpQTdya0d6QmlMMkNoU3pSOUdkQzVycVBCMi95T2s4Qml3SDF1VHM0TFJqTEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
@@ -47,8 +48,11 @@ class MockService(IService):
             "Test follow-up question 3",
         ]
 
-    async def authorize_user(self, conversation_id: str, user_identifier: str) -> bool:
-        return user_identifier != "87a5e00b7c0b4287fea96bbeabc05fdfdaacba5346b606366be40fbf3046cc9a"
+    async def authorize_user(self, conversation_id: str, user_identifier: "UserIdentifier") -> bool:
+        return (
+            user_identifier.sha384
+            != "ab5c38a5e39f0d8417bada101eeb648fa5b93a470dad1d7dbb836d102cc47979fcccc7c325c8118199b5c81ec64e7b57"
+        )
 
     async def is_usage_limit_exceeded(self, cluster_id: str) -> UsageExceedReport | None:
         """Check if the token usage limit is exceeded for the given cluster_id."""
@@ -998,14 +1002,17 @@ async def test_check_token_usage(cluster_url, usage_report, expected_exception):
         (
             "user authorized",
             "conversation1",
-            "0a041b9462caa4a31bac3567e0b6e6fd9100787db2ab433d96f6d178cabfce90",
+            UserIdentifier(
+                sha384="c6d73ec37c081fafa129ffdbf7364a3a36a9ba90f15e9612bf59d6edced4386d1a230c315025d6bf86bbc27168ee214d",
+                sha256="0a041b9462caa4a31bac3567e0b6e6fd9100787db2ab433d96f6d178cabfce90",
+            ),
             True,
             None,
         ),
         (
             "user not authorized",
             "conversation2",
-            "user2",
+            UserIdentifier(sha384="deadbeef", sha256="deadbeef"),
             False,
             HTTPException,
         ),
@@ -1019,7 +1026,6 @@ async def test_authorize_user(
     expected_exception,
 ):
     # given
-    # Mock the conversation_service
     mock_conversation_service = Mock()
     mock_conversation_service.authorize_user = AsyncMock(return_value=is_authorized)
 
@@ -1033,14 +1039,14 @@ async def test_authorize_user(
 
 
 @pytest.mark.parametrize(
-    "test_description, conversation_id, token, certificate_data, expected_user_identifier, expected_exception",
+    "test_description, conversation_id, token, certificate_data, expected_sha384, expected_exception",
     [
         (
             "valid token 1",
             "conversation1",
             jwt.encode({"sub": "user1"}, "secret", algorithm="HS256"),
             None,
-            "0a041b9462caa4a31bac3567e0b6e6fd9100787db2ab433d96f6d178cabfce90",
+            "c6d73ec37c081fafa129ffdbf7364a3a36a9ba90f15e9612bf59d6edced4386d1a230c315025d6bf86bbc27168ee214d",
             None,
         ),
         (
@@ -1048,7 +1054,7 @@ async def test_authorize_user(
             "conversation2",
             jwt.encode({"sub": "user2"}, "secret", algorithm="HS256"),
             None,
-            "6025d18fe48abd45168528f18a82e265dd98d421a7084aa09f61b341703901a3",
+            "67fd7ba5f933544fc36eab0d6671ca47729b8e9b42401b700931f6ef529a3d7f43f3cc239678b81bf4f340e01fd16da3",
             None,
         ),
         (
@@ -1064,7 +1070,7 @@ async def test_authorize_user(
             "conversation1",
             None,
             SAMPLE_CLIENT_CERTIFICATE_DATA,
-            "259c31ec6667be354fc6d007a452e2d09002bc396b2b6da976980b0cca0b8ced",
+            "d96b58c3b81c1ebd891bf1c775133cc6820d51370eedc2c46c6b4fa8952f202b0d2eb69f800f834f9a8030e510431a1d",
             None,
         ),
         (
@@ -1082,7 +1088,7 @@ def test_extract_user_identifier(
     conversation_id,
     token,
     certificate_data,
-    expected_user_identifier,
+    expected_sha384,
     expected_exception,
 ):
     # given
@@ -1099,8 +1105,9 @@ def test_extract_user_identifier(
         with pytest.raises(expected_exception):
             extract_user_identifier(k8s_auth_headers)
     else:
-        user_identifier = extract_user_identifier(k8s_auth_headers)
-        assert user_identifier == expected_user_identifier
+        result = extract_user_identifier(k8s_auth_headers)
+        assert isinstance(result, UserIdentifier), test_description
+        assert result.sha384 == expected_sha384, test_description
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_conversation.py
+++ b/tests/unit/services/test_conversation.py
@@ -10,6 +10,7 @@ from agents.common.data import Message
 from services.conversation import TOKEN_LIMIT, ConversationService
 from services.usage import UsageExceedReport
 from utils.settings import MAIN_MODEL_MINI_NAME
+from utils.utils import UserIdentifier
 
 TIME_STAMP = 1.8
 QUESTIONS = ["question1?", "question2?", "question3?"]
@@ -216,22 +217,29 @@ class TestConversation:
             (
                 "owner is None, should update owner and authorize",
                 "conversation1",
-                "user1",
+                UserIdentifier(sha384="sha384-user1", sha256="sha256-user1"),
                 None,
                 True,
             ),
             (
-                "owner is the same as user, should authorize",
+                "owner is the same as user (sha384 match), should authorize",
                 "conversation2",
-                "user2",
-                "user2",
+                UserIdentifier(sha384="sha384-user2", sha256="sha256-user2"),
+                "sha384-user2",
+                True,
+            ),
+            (
+                "owner is legacy sha256 hash, should authorize and migrate",
+                "conversation3",
+                UserIdentifier(sha384="sha384-user3", sha256="sha256-user3"),
+                "sha256-user3",
                 True,
             ),
             (
                 "owner is different from user, should not authorize",
-                "conversation3",
-                "user3",
-                "user4",
+                "conversation4",
+                UserIdentifier(sha384="sha384-user4", sha256="sha256-user4"),
+                "sha384-other",
                 False,
             ),
         ],
@@ -262,7 +270,10 @@ class TestConversation:
         # Then
         assert result == expected_result
         if thread_owner is None:
-            mock_companion_graph.aupdate_thread_owner.assert_called_once_with(conversation_id, user_identifier)
+            mock_companion_graph.aupdate_thread_owner.assert_called_once_with(conversation_id, user_identifier.sha384)
+        elif thread_owner == user_identifier.sha256:
+            # Legacy migration: should update to sha384
+            mock_companion_graph.aupdate_thread_owner.assert_called_once_with(conversation_id, user_identifier.sha384)
         else:
             mock_companion_graph.aupdate_thread_owner.assert_not_called()
 

--- a/tests/unit/services/test_encryption.py
+++ b/tests/unit/services/test_encryption.py
@@ -9,7 +9,7 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives.serialization import (
 from services.encryption import Encryption
 from services.encryption_cache import IEncryptionCache
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 _AES_KEY_SIZE = 32
@@ -46,7 +46,7 @@ def _make_encrypted_payload(
     client_key = ec.generate_private_key(_ECDH_CURVE)
 
     shared_secret = client_key.exchange(ec.ECDH(), server_private_key.public_key())
-    shared_key = HKDF(algorithm=SHA256(), length=32, salt=None, info=_HKDF_INFO).derive(shared_secret)
+    shared_key = HKDF(algorithm=SHA384(), length=32, salt=None, info=_HKDF_INFO).derive(shared_secret)
 
     aes_key = os.urandom(32)
     key_nonce = os.urandom(_AES_GCM_NONCE_SIZE)
@@ -80,7 +80,7 @@ _CORRUPTED_ENCRYPTED_KEY = base64.b64encode(os.urandom(60)).decode()
 # _derive_shared_key and _decrypt_aes_key in isolation.
 _CLIENT_KEY_HELPER = ec.generate_private_key(_ECDH_CURVE)
 _CLIENT_PUBLIC_KEY_HELPER_B64 = _ec_public_key_b64(_CLIENT_KEY_HELPER)
-_EXPECTED_SHARED_KEY = HKDF(algorithm=SHA256(), length=32, salt=None, info=_HKDF_INFO).derive(
+_EXPECTED_SHARED_KEY = HKDF(algorithm=SHA384(), length=32, salt=None, info=_HKDF_INFO).derive(
     _CLIENT_KEY_HELPER.exchange(ec.ECDH(), _SERVER_KEY.public_key())
 )
 
@@ -109,7 +109,7 @@ class TestEncryption:
         "test_case, private_key, expected_error, expected_error_msg",
         [
             pytest.param(
-                "valid EC P-256 private key is accepted",
+                "valid EC P-521 private key is accepted",
                 _SERVER_KEY,
                 None,
                 None,

--- a/tests/unit/services/test_key_store.py
+++ b/tests/unit/services/test_key_store.py
@@ -23,8 +23,8 @@ from services.key_store import (
     _load_private_key_from_file,
 )
 
-_ECDH_CURVE = ec.SECP256R1()
-_UNCOMPRESSED_EC_POINT_LENGTH = 65  # 04 || X(32) || Y(32)
+_ECDH_CURVE = ec.SECP521R1()
+_UNCOMPRESSED_EC_POINT_LENGTH = 133  # 04 || X(66) || Y(66)
 _UNCOMPRESSED_EC_POINT_PREFIX = 0x04
 
 
@@ -363,7 +363,7 @@ class TestKeyStore:
         # Then:
         assert result == _SERVER_PUBLIC_KEY_B64
         raw = base64.b64decode(result)
-        # Uncompressed EC point for P-256: 04 || X(32) || Y(32) = 65 bytes.
+        # Uncompressed EC point for P-521: 04 || X(66) || Y(66) = 133 bytes.
         assert len(raw) == _UNCOMPRESSED_EC_POINT_LENGTH
         assert raw[0] == _UNCOMPRESSED_EC_POINT_PREFIX
 

--- a/tests/unit/utils/test_src_utils.py
+++ b/tests/unit/utils/test_src_utils.py
@@ -21,8 +21,10 @@ from utils.utils import (
     JWT_TOKEN_EMAIL,
     JWT_TOKEN_SERVICE_ACCOUNT,
     JWT_TOKEN_SUB,
+    UserIdentifier,
     create_session_id,
     generate_sha256_hash,
+    generate_sha384_hash,
     get_user_identifier_from_client_certificate,
     get_user_identifier_from_token,
     parse_k8s_token,
@@ -110,24 +112,24 @@ def test_parse_k8s_token(test_description, token, expected_result, expected_exce
 
 
 @pytest.mark.parametrize(
-    "test_description, token_payload, expected_result, expected_exception",
+    "test_description, token_payload, expected_sha384, expected_exception",
     [
         (
             "valid token with sub",
             {JWT_TOKEN_SUB: "user123"},
-            "e606e38b0d8c19b24cf0ee3808183162ea7cd63ff7912dbb22b5e803286b4446",
+            "37d750fce012e1eaa888d87286607db0adcdd0a52e6c298d2d82d37b1df4f3437b3bbd10255f82cb2822dc9442272ee2",
             None,
         ),
         (
             "valid token with email",
             {JWT_TOKEN_EMAIL: "user@example.com"},
-            "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514",
+            "932c1566d0e77a011a6c86ac6b17c54be871c16da8807d5539d6f16be403cae45c3976bd224767da386186e99f56a882",
             None,
         ),
         (
             "valid token with service account name",
             {JWT_TOKEN_SERVICE_ACCOUNT: "service-account"},
-            "eb358b69ae30c7bea54b497b6ab1bcffb613bcf1e82099e6bb082047df8b4965",
+            "990d5b2d187539c050ba3ca12bfcd40e6fd1426fa2bf2b490c18e89f211fcf3930b7746916baf82f663240253b2fce86",
             None,
         ),
         (
@@ -144,14 +146,15 @@ def test_parse_k8s_token(test_description, token, expected_result, expected_exce
         ),
     ],
 )
-def test_get_user_identifier_from_token(test_description, token_payload, expected_result, expected_exception):
+def test_get_user_identifier_from_token(test_description, token_payload, expected_sha384, expected_exception):
     token = jwt.encode(token_payload, "secret", algorithm="HS256")
     if expected_exception:
         with pytest.raises(expected_exception, match="Failed to get user identifier from token"):
             get_user_identifier_from_token(token)
     else:
-        user_identifier = get_user_identifier_from_token(token)
-        assert user_identifier == expected_result, test_description
+        result = get_user_identifier_from_token(token)
+        assert isinstance(result, UserIdentifier), test_description
+        assert result.sha384 == expected_sha384, test_description
 
 
 # Sample PEM certificates for testing
@@ -199,14 +202,14 @@ def generate_pem_cert(common_name: str, serial_number: str) -> bytes:
             "Test case 1 Certificate with Common Name",
             # generated using generate_pem_cert("test_user", "12345")
             b"-----BEGIN CERTIFICATE-----\nMIICsjCCAZqgAwIBAgICMDkwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVz\ndDAeFw0yNTA3MjgxNDQ3NDlaFw0yNjA3MjgxNDQ3NDlaMBQxEjAQBgNVBAMMCXRl\nc3RfdXNlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJX9BZd2A76C\nZy2sBjjZIaIFO2lF59h3bcqw9k0GXt5d8Jo372Kw1MdT6DTHuSv63SEmM2slXy2Z\nDOGSZg9nyoh+yTLEO5XS21f9o53j89XQ/dSAX0QsYvwmTeHvnJAksEuKhRDWQXLy\nD50BcmMyaT8mPrAVg4OMIzcFfpl4wwBSv6ftLcdG0whe7f9e7ke69FNJy2f7VG8i\nt0zDBijxtNVxFkeWYgZDvvIJuTgoJNw1lRoAXEkbbqPa+y4B9ShcpZqhZd/yT8Jx\nenxf3pVWZwKxx2opvwRQJ2tlMqln5+FITX+qKriEA96XGOie+EUGBBFGabf/pLKn\nILHPKP8vaW0CAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsF\nAAOCAQEAX1r2GF8SVY9wey4bQ9Nn/1luSf60DMGUJfE8C/Lcq85MjpiAQ30qV/bb\nPOgNZ7LDISg5e06MP2ZCIqIhUMS6MfW/JX/g8XJo9RGgM3WWLhb43VesFb+SFi7Q\nKQ+LtvFlykaHyVmlLwnvnyG29vIt77cOngL9g5ESWAl7qGRa7pb2+w/YjLR5oOnU\nxqvtn8N2KAh1cwFslOi9IfgGEcwA+hd/rc6tlXDbmd8AZcWZo2pmBCYu+YZGSkGX\nTBIxLnQLRtaxwR8tENbb0x2PgiSK0cLAex86VOYlBNsb8Pt4FpSlupDFhKPtT0Va\nSUcAlZwnnepwKMSTCiTupOqi859+BA==\n-----END CERTIFICATE-----\n",
-            "1160130875fda0812c99c5e3f1a03516471a6370c4f97129b221938eb4763e63",
+            "1b18cc9bc452eade7102f2972972e2a2d0a3a6cb4aaf15a1f4759a78451e6be80641f16f7ee9e43b8ed6d1ba780a040f",
             None,
         ),
         (
             "Test case 2 Certificate without Common Name but with serial number",
             # generated using generate_pem_cert("", "67890")
             b"-----BEGIN CERTIFICATE-----\nMIICnzCCAYegAwIBAgIDAQkyMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNVBAMMBHRl\nc3QwHhcNMjUwNzI4MTQ0NzQ5WhcNMjYwNzI4MTQ0NzQ5WjAAMIIBIjANBgkqhkiG\n9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0KwcFwyPInr7IJfeH/15aSljGQjnSkPLoMun\nPqBv/fX2A7Ms/yoYOL6AwRzjZUhtq+qxQ5topKJPRbnk3US1vwv5CL32wxZIDbne\nDA0NWBqujtSSE3SdoA9TyW2wPj7RJVTuastrGZt9TAX4zuaIY3OeIUA99bHrckgn\nITUk+3mky5Bp6RvBdD/XlgcqtimBec2rETXnvk+hVOSLv1J/hem55cFNN16h6+El\nIRTo1ofVa7G+D3Slpgm0S5UZWoc/D133p0oL+9tqtWiZZcfJms4wlmFuVoYj+4AP\n3RFVsY58aTvTG51FoBQtODdvdF+gnVsc+T1BEavTNopHxERifwIDAQABoxMwETAP\nBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCBGARgbIMGYnBiw1pV\n5AFji0g1L1YmsTJC6W69CAi6GihvtzRtHMyTu8dyMvObVYxonzJ4CSmhEA4z6X0i\n4mKCRmjgSa4XkGBfBFJkbuq2iMDQZECgcE+nSZJgSw/tFcyjuTuhysuBuk66xN4i\niLDiLV4Z5qLYfcYnIoIBis6xkOHT3ynS9GC9Dp5Gu5grVqUQYXsEeITldjHaz79O\n8imuqZe74QX2NmXizpwASGPNrTyCe4D5jZ6b7aDo9Pg9JPuIHOKP+fVZMSzyfbmj\nwKslFuEecN1ORnGNE8PoEv9itGh18bQ2gnewqxLxWTsDzq9N7KsRf2OBiIxgpV1j\naDxa\n-----END CERTIFICATE-----\n",
-            "e2217d3e4e120c6a3372a1890f03e232b35ad659d71f7a62501a4ee204a3e66d",
+            "6988c291a83b05760b93263fc78e8feeca8ca4641b007c6978f644e08851b83efc0411a33a174e37065618585b7ba7d4",
             None,
         ),
         (
@@ -224,7 +227,9 @@ def test_get_user_identifier_from_client_certificate(
         with pytest.raises(ValueError):
             get_user_identifier_from_client_certificate(client_certificate_data)
     else:
-        assert get_user_identifier_from_client_certificate(client_certificate_data) == expected_user_identifier
+        result = get_user_identifier_from_client_certificate(client_certificate_data)
+        assert isinstance(result, UserIdentifier), test_description
+        assert result.sha384 == expected_user_identifier, test_description
 
 
 @pytest.mark.parametrize(
@@ -309,6 +314,34 @@ def test_to_sequence_messages(test_description, input_data, expected_output, exp
 )
 def test_generate_sha256_hash(input_data, expected_hash):
     assert generate_sha256_hash(input_data) == expected_hash
+
+
+@pytest.mark.parametrize(
+    "input_data, expected_hash",
+    [
+        ("hello", "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f"),
+        ("", "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"),
+        ("123456", "0a989ebc4a77b56a6e2bb7b19d995d185ce44090c13e2984b7ecc6d446d4b61ea9991b76a4c2f04b1b4d244841449454"),
+        (
+            "test string",
+            "e213dccb3221e0b8fdd995dcc1d04e218fc649981038bfac81abc98932369bac0efb758b92eccd80321df8eb64efae87",
+        ),
+        (
+            "test@email.com",
+            "9360eed5351c4387a49d7be43753dbd1374193c454afd0d5e1419410b886bf1f1c6528f3d400ce7b842ab56ad58604ee",
+        ),
+        (
+            "Person Name",
+            "009f1748ae83fa1947bc6a5fe29c2dbf39b7286e428dc589939095a2bbfda29fc30ea02ecad2e1b8ea87e1c09cb41925",
+        ),
+        (
+            "UNAUTHORIZED",
+            "ab5c38a5e39f0d8417bada101eeb648fa5b93a470dad1d7dbb836d102cc47979fcccc7c325c8118199b5c81ec64e7b57",
+        ),
+    ],
+)
+def test_generate_sha384_hash(input_data, expected_hash):
+    assert generate_sha384_hash(input_data) == expected_hash
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Replace ECDH P-256 with P-521 in `src/services/encryption.py` and all test helpers
- Replace SHA-256 with SHA-384 in HKDF key derivation
- Add `generate_sha384_hash` to `utils/utils.py`; change `get_user_identifier_from_*` functions to return a `UserIdentifier` dataclass (contains both `sha384` and `sha256` hashes)
- Update `ConversationService.authorize_user` to accept `UserIdentifier` and transparently migrate legacy SHA-256 Redis entries to SHA-384 on first access

## Testing

Updated unit tests:
- `tests/unit/services/test_encryption.py` -- test vectors regenerated for P-521 / HKDF-SHA384
- `tests/unit/services/test_key_store.py` -- updated uncompressed point size from 65 to 133 bytes
- `tests/unit/services/test_conversation.py` -- added migration test case (legacy SHA-256 owner is authorized and upgraded)
- `tests/unit/routers/test_conversations.py` -- expected hashes updated to SHA-384
- `tests/unit/utils/test_src_utils.py` -- added `test_generate_sha384_hash`, updated `test_get_user_identifier_from_*` expected values

A companion PR against joule-capability updates `scripts/python/encrypt_k8s_headers.py` to use P-521 / SHA-384 on the client side.