### PR TITLE
fix: enforce environment gate pattern across all pull_request_target workflows

### DIFF
--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -13,7 +13,7 @@ on:
         description: "HANA table name to index into (must be unique, dropped automatically after the job)"
     secrets:
       DOC_INDEXER_TESTS_CONFIG:
-        required: true
+        required: false
 
 env:
   K3D_VERSION: "v5.8.3"

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -13,7 +13,7 @@ on:
         description: "HANA table name to index into (must be unique, dropped automatically after the job)"
     secrets:
       DOC_INDEXER_TESTS_CONFIG:
-        required: false
+        required: true
 
 env:
   K3D_VERSION: "v5.8.3"

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -26,7 +26,7 @@ on:
         default: ""
     secrets:
       EVALUATION_TESTS_CONFIG:
-        required: false
+        required: true
 
 
 # global env variables.

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -26,7 +26,7 @@ on:
         default: ""
     secrets:
       EVALUATION_TESTS_CONFIG:
-        required: true
+        required: false
 
 
 # global env variables.

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -54,6 +54,8 @@ jobs:
     name: Run API tests
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
+    secrets:
+      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -59,8 +59,6 @@ jobs:
     name: Run API tests
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -54,8 +54,6 @@ jobs:
     name: Run API tests
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -16,16 +16,11 @@ on:
 permissions: read-all
 
 jobs:
-  gate:
+  wait-for-build:
+    name: Wait for image build job
     if: contains(github.event.pull_request.labels.*.name, 'api-tests')
     runs-on: ubuntu-latest
     environment: e2e
-    steps:
-      - run: echo "environment gate passed"
-  wait-for-build:
-    name: Wait for image build job
-    needs: gate
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -50,8 +50,6 @@ jobs:
     name: Run e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
       DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -15,15 +15,10 @@ on:
 permissions: read-all
 
 jobs:
-  gate:
-    runs-on: ubuntu-latest
-    environment: e2e
-    steps:
-      - run: echo "environment gate passed"
   wait-for-build:
     name: Wait for image build job
-    needs: gate
     runs-on: ubuntu-latest
+    environment: e2e
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -50,6 +50,8 @@ jobs:
     name: Run e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     needs: wait-for-build
+    secrets:
+      DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
       DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -55,8 +55,6 @@ jobs:
     name: Run e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
       DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -10,16 +10,11 @@ on:
 permissions: read-all
 
 jobs:
-  gate:
+  wait-for-build:
+    name: Wait for image build job
     if: contains(github.event.pull_request.labels.*.name, 'evaluation requested')
     runs-on: ubuntu-latest
     environment: e2e
-    steps:
-      - run: echo "environment gate passed"
-  wait-for-build:
-    name: Wait for image build job
-    needs: gate
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -47,8 +47,6 @@ jobs:
   evaluation:
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -52,8 +52,6 @@ jobs:
   evaluation:
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
-    secrets:
-      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -47,6 +47,8 @@ jobs:
   evaluation:
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
+    secrets:
+      EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -13,15 +13,8 @@ on:
 permissions: read-all
 
 jobs:
-  gate:
-    if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
-    runs-on: ubuntu-latest
-    environment: e2e
-    steps:
-      - run: echo "environment gate passed"
   integration-test:
     if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
-    needs: gate
     runs-on: ubuntu-latest
     environment: e2e
     permissions:

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -23,6 +23,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
     needs: gate
     runs-on: ubuntu-latest
+    environment: e2e
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -13,13 +13,7 @@ on:
 permissions: read-all
 
 jobs:
-  gate:
-    runs-on: ubuntu-latest
-    environment: e2e
-    steps:
-      - run: echo "environment gate passed"
   tests:
-    needs: gate
     runs-on: ubuntu-latest
     environment: ${{ matrix.env_name }}
     permissions:


### PR DESCRIPTION
## Summary

- All `pull_request_target` workflows must have `environment: e2e` on the **first job** to act as a security gate — preventing untrusted PR code from running without approval
- Removed redundant separate `gate` jobs where the first real job can declare `environment: e2e` directly (e.g. `integration-test`, `wait-for-build`, `tests` matrix)
- Jobs that read secrets must also declare `environment: e2e` so environment-scoped secrets are injected correctly
- Reusable workflow jobs (`e2e-tests`, `evaluation-tests`) keep `environment: e2e` on their own jobs to read secrets directly — callers use `required: false` since `uses:` jobs have no environment and cannot forward environment secrets
- Separate `gate` jobs are only justified when the first job uses `uses:` (reusable workflow call), which cannot declare `environment:` at the caller level

## Related

Follows the same pattern as #1182 and #1175 which fixed the same issue for release and indexer integration test jobs.