### PR TITLE
sec: pin TLS cipher suites for egress connections

### DIFF
--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -274,6 +274,8 @@ class K8sClient:
             ca_file.write(self.k8s_auth_headers.get_decoded_certificate_authority_data())
         self.ca_temp_filename = ca_file.name
         self.client_ssl_context = ssl.create_default_context(cafile=self.ca_temp_filename)
+        self.client_ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+        self.client_ssl_context.set_ciphers("ECDHE+AESGCM:ECDHE+CHACHA20")
 
         if self.k8s_auth_headers.get_auth_type() == AuthType.CLIENT_CERTIFICATE:
             # Write the client certificate data to a temporary file.

--- a/src/services/redis.py
+++ b/src/services/redis.py
@@ -85,8 +85,8 @@ def _get_redis_connection() -> AsyncRedis:
         password=str(REDIS_PASSWORD),
         ssl=REDIS_SSL_ENABLED,
         ssl_ca_certs="/etc/secret/ca.crt" if REDIS_SSL_ENABLED else None,
-        ssl_include_verify_flags=([ssl.VERIFY_DEFAULT] if REDIS_SSL_ENABLED else None),
-        ssl_exclude_verify_flags=([ssl.VERIFY_X509_STRICT] if REDIS_SSL_ENABLED else None),
+        ssl_min_version=ssl.TLSVersion.TLSv1_2 if REDIS_SSL_ENABLED else None,
+        ssl_ciphers="ECDHE+AESGCM:ECDHE+CHACHA20" if REDIS_SSL_ENABLED else None,
     )
 
 


### PR DESCRIPTION
Closes #1192

## Changes

- `src/services/k8s.py:276`: pin cipher suites and set minimum TLS version
- `src/services/redis.py:86-89`: same

**Testing**

- Verify TLS connections to Kubernetes API server and Redis still work after cipher suite pinning