### PR TITLE
fix: read DOC_INDEXER_TESTS_CONFIG from e2e environment in reusable workflow

### DIFF
--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -11,9 +11,6 @@ on:
         required: true
         type: string
         description: "HANA table name to index into (must be unique, dropped automatically after the job)"
-    secrets:
-      DOC_INDEXER_TESTS_CONFIG:
-        required: false
 
 env:
   K3D_VERSION: "v5.8.3"

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -24,10 +24,6 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      EVALUATION_TESTS_CONFIG:
-        required: false
-
 
 # global env variables.
 env:


### PR DESCRIPTION
## Summary

- Adds the new `e2e-tests-doc-indexer-reusable.yaml` and `pull-e2e-tests-doc-indexer.yaml` workflows
- Removes the `workflow_call.secrets` block from the reusable workflow so `DOC_INDEXER_TESTS_CONFIG` is read directly from the `e2e` environment gate on the job

## Root cause

Declaring a secret in `workflow_call.secrets` creates an explicit input channel that **must** be passed by the caller via `secrets:`. When the caller omits it, `${{ secrets.DOC_INDEXER_TESTS_CONFIG }}` inside the reusable workflow evaluates to an empty string — even though the secret is configured on the `e2e` environment and the job has `environment: e2e`. The environment context does not fall back to fill undeclared-but-missing `workflow_call.secrets` inputs.

## Fix

Remove the `workflow_call.secrets` block entirely. With no declared secret inputs, GitHub Actions lets the job's own `environment: e2e` gate provide the secret directly via `${{ secrets.DOC_INDEXER_TESTS_CONFIG }}`.

## Test plan

- [ ] Trigger the `pull-e2e-tests-doc-indexer` workflow on a PR and verify the `Create config secret` step receives a non-empty `DOC_INDEXER_TESTS_CONFIG` value