### PR TITLE
fix: add secrets: inherit to PR reusable workflow callers

### DIFF
--- a/.github/workflows/pull-api-tests.yaml
+++ b/.github/workflows/pull-api-tests.yaml
@@ -54,6 +54,7 @@ jobs:
     name: Run API tests
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
+    secrets: inherit
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pull-e2e-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-e2e-tests-doc-indexer.yaml
@@ -50,6 +50,7 @@ jobs:
     name: Run e2e tests
     uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
     needs: wait-for-build
+    secrets: inherit
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion-indexer:PR-${{ github.event.number }}"
       DOCS_TABLE_NAME: "kc_pr_${{ github.event.number }}_e2e"

--- a/.github/workflows/pull-evaluation-tests.yaml
+++ b/.github/workflows/pull-evaluation-tests.yaml
@@ -47,6 +47,7 @@ jobs:
   evaluation:
     uses: kyma-project/kyma-companion/.github/workflows/evaluation-test-reusable.yaml@main
     needs: wait-for-build
+    secrets: inherit
     with:
       IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/dev/kyma-companion:PR-${{ github.event.number }}"
       TEST_REPO_FULLNAME: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary

Adds `secrets: inherit` to the `uses:` job in three PR-triggered caller workflows.

## Root cause

GitHub Actions requires the **calling** job to pass `secrets: inherit` for environment secrets to flow into a reusable workflow. The reusable workflow jobs have `environment: e2e` configured, but this only controls the deployment gate — it does **not** automatically expose `e2e` environment secrets inside the called workflow unless the caller explicitly forwards them with `secrets: inherit`.

Without this, `${{ secrets.DOC_INDEXER_TESTS_CONFIG }}` and `${{ secrets.EVALUATION_TESTS_CONFIG }}` evaluate to empty strings inside the reusable workflows, causing `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` at runtime.

## Affected workflows

| Caller | Reusable | Secret missing |
|---|---|---|
| `pull-e2e-tests-doc-indexer.yaml` | `e2e-tests-doc-indexer-reusable.yaml` | `DOC_INDEXER_TESTS_CONFIG` |
| `pull-evaluation-tests.yaml` | `evaluation-test-reusable.yaml` | `EVALUATION_TESTS_CONFIG` |
| `pull-api-tests.yaml` | `evaluation-test-reusable.yaml` | `EVALUATION_TESTS_CONFIG` |

The `push-e2e-tests-doc-indexer.yaml` and `run-evaluation-tests.yaml` already had `secrets: inherit` and were not affected.

## Verifiability

This fix **cannot be directly verified in this PR** via CI. The affected workflows are `pull_request_target` workflows that run against the PR's code changes — they only trigger when `doc_indexer/**` or companion source files change, not when only `.github/workflows/` files change. The fix will be validated implicitly when the next PR touching `doc_indexer/` or companion sources is opened after this merges to main.

## Test plan

- [ ] Merge to main
- [ ] Open a follow-up PR touching `doc_indexer/` and verify `DOC_INDEXER_TESTS_CONFIG` is non-empty in the e2e job logs (`DOC_INDEXER_CONFIG_BASE64: ***` masked, not blank)