### PR TITLE
fix: added source file name validation

### DIFF
--- a/doc_indexer/src/fetcher/fetcher.py
+++ b/doc_indexer/src/fetcher/fetcher.py
@@ -6,7 +6,7 @@ from fetcher.source import DocumentsSource, SourceType, get_documents_sources
 
 from utils.logging import get_logger
 from utils.utils import clone_repo
-
+import re
 logger = get_logger(__name__)
 
 
@@ -44,6 +44,9 @@ class DocumentsFetcher:
         else:
             raise ValueError(f"unsupported source_type: {source.source_type}")
 
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", source.name):
+            raise ValueError(f"Invalid source name: {source.name}")
+        
         module_output_dir = os.path.join(self.output_dir, source.name)
         logger.debug(f"Creating a temporary directory: {module_output_dir}")
         os.makedirs(module_output_dir, exist_ok=True)

--- a/doc_indexer/src/fetcher/fetcher.py
+++ b/doc_indexer/src/fetcher/fetcher.py
@@ -38,15 +38,15 @@ class DocumentsFetcher:
         """Fetch the documents from the source."""
         logger.info(f"******* Fetching documents for: {source.name}")
 
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", source.name):
+            raise ValueError(f"Invalid source name: {source.name}")
+
         if source.source_type == SourceType.GITHUB:
             logger.debug(f"Cloning repository: {source.url}")
             # clone the git repository.
             repo_dir = clone_repo(source.url, self.tmp_dir)
         else:
             raise ValueError(f"unsupported source_type: {source.source_type}")
-
-        if not re.fullmatch(r"[A-Za-z0-9_-]+", source.name):
-            raise ValueError(f"Invalid source name: {source.name}")
 
         module_output_dir = os.path.join(self.output_dir, source.name)
         logger.debug(f"Creating a temporary directory: {module_output_dir}")

--- a/doc_indexer/src/fetcher/fetcher.py
+++ b/doc_indexer/src/fetcher/fetcher.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 from fetcher.scroller import Scroller
@@ -6,7 +7,7 @@ from fetcher.source import DocumentsSource, SourceType, get_documents_sources
 
 from utils.logging import get_logger
 from utils.utils import clone_repo
-import re
+
 logger = get_logger(__name__)
 
 
@@ -46,7 +47,7 @@ class DocumentsFetcher:
 
         if not re.fullmatch(r"[A-Za-z0-9_-]+", source.name):
             raise ValueError(f"Invalid source name: {source.name}")
-        
+
         module_output_dir = os.path.join(self.output_dir, source.name)
         logger.debug(f"Creating a temporary directory: {module_output_dir}")
         os.makedirs(module_output_dir, exist_ok=True)


### PR DESCRIPTION
# Add Source File Name Validation in DocumentsFetcher

### Bug Fix

🐛 Added validation for source file names in the `DocumentsFetcher` to prevent invalid characters from being used as directory names during document fetching.

### Changes

* `doc_indexer/src/fetcher/fetcher.py`: Imported the `re` module and added a `re.fullmatch` check to validate that `source.name` contains only alphanumeric characters, underscores, or hyphens (`[A-Za-z0-9_-]+`). A `ValueError` is raised if the source name contains invalid characters, preventing potentially unsafe directory names from being created.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.4`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `c957a445-a3cd-489e-887e-1eb8cc8cbf14`
</details>
