### PR TITLE
chore: upgrade ECDH curve to P-521 and simplify key loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ venv.bak/
 
 # Configuration
 config/config.json
+config/encryption_key.pem
 config/k8s-clusters.json
 
 # Spyder project settings

--- a/scripts/shell/generate-ecdh-keys.sh
+++ b/scripts/shell/generate-ecdh-keys.sh
@@ -1,31 +1,29 @@
 #!/usr/bin/env bash
-# Generate an ECDSA P-256 private key matching the cert-manager Certificate CR
-# (ECDSA, P-256, PKCS8 encoding).
+# Generate an ECDSA P-521 private key for ECDH key exchange
+# (ECDSA, P-521/secp521r1, PKCS8 encoding).
 #
-# cert-manager stores the key as PEM (PKCS8) in the tls.key field of the
-# Kubernetes secret.  This script produces the same format for local
+# This script produces a PEM (PKCS8) encoded EC private key for local
 # development / testing.
 #
 # Output file:
-#   <output_dir>/tls.key  — PEM-encoded PKCS8 EC private key
+#   <output_dir>/encryption_key.pem  — PEM-encoded PKCS8 EC private key
 #
 # Usage:
 #   ./generate-ecdh-keys.sh [output_dir]
-#   output_dir defaults to ./ecdh-keys
+#   output_dir defaults to ./config
 
 set -euo pipefail
 
-OUTPUT_DIR="${1:-./ecdh-keys}"
-mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="${1:-./config}"
 
 TMP_PEM=$(mktemp)
 trap 'rm -f "$TMP_PEM"' EXIT
 
-# Generate EC private key on the P-256 (prime256v1 / secp256r1) curve.
-openssl ecparam -name prime256v1 -genkey -noout -out "$TMP_PEM"
+# Generate EC private key on the P-521 (secp521r1) curve.
+openssl ecparam -name secp521r1 -genkey -noout -out "$TMP_PEM"
 
 # Convert to PKCS8 PEM (matches cert-manager's PKCS8 encoding).
 openssl pkcs8 -topk8 -nocrypt -in "$TMP_PEM" -outform PEM \
-    > "$OUTPUT_DIR/tls.key"
+    > "$OUTPUT_DIR/encryption_key.pem"
 
-echo "Private key written to: $OUTPUT_DIR/tls.key"
+echo "Private key written to: $OUTPUT_DIR/encryption_key.pem"

--- a/src/services/encryption.py
+++ b/src/services/encryption.py
@@ -93,7 +93,7 @@ class Encryption:
         shared_secret = self._private_key.exchange(ec.ECDH(), client_public_key)
         return HKDF(
             algorithm=SHA384(),
-            length=32, # For AES-256-GCM, which requires exactly a 32-byte (256-bit) key.
+            length=32,  # For AES-256-GCM, which requires exactly a 32-byte (256-bit) key.
             salt=None,
             info=_HKDF_INFO,
         ).derive(shared_secret)

--- a/src/services/encryption.py
+++ b/src/services/encryption.py
@@ -16,12 +16,12 @@ import base64
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from services.encryption_cache import IEncryptionCache
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 
@@ -81,10 +81,10 @@ class Encryption:
         return await self._encryption_cache.get_client_public_key(client_public_key_id)
 
     def _derive_shared_key(self, client_public_key_b64: str) -> bytes:
-        """Perform ECDH and derive a 256-bit symmetric key via HKDF-SHA256.
+        """Perform ECDH and derive a 256-bit symmetric key via HKDF-SHA384.
 
         The client public key must be the raw uncompressed EC point
-        (65 bytes for P-256), base64-encoded.
+        (133 bytes for P-521), base64-encoded.
         """
         client_public_key = ec.EllipticCurvePublicKey.from_encoded_point(
             _ECDH_CURVE,
@@ -92,8 +92,8 @@ class Encryption:
         )
         shared_secret = self._private_key.exchange(ec.ECDH(), client_public_key)
         return HKDF(
-            algorithm=SHA256(),
-            length=32,
+            algorithm=SHA384(),
+            length=32, # For AES-256-GCM, which requires exactly a 32-byte (256-bit) key.
             salt=None,
             info=_HKDF_INFO,
         ).derive(shared_secret)

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     PublicFormat,
-    load_der_private_key,
     load_pem_private_key,
 )
 
@@ -35,7 +34,6 @@ def _load_private_key(data: bytes) -> EllipticCurvePrivateKey:
     :raises ValueError: If the data cannot be decoded or parsed as a private key.
     """
 
-    # load Private key in PEM format.
     key = load_pem_private_key(data, password=None)
     if not isinstance(key, EllipticCurvePrivateKey):
         raise TypeError("Key is not an EC private key")

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives.serialization import (
 )
 
 from utils.logging import get_logger
-from utils.settings import ENCRYPTION_PRIVATE_KEY_B64, ENCRYPTION_PRIVATE_KEY_PATH
+from utils.settings import ENCRYPTION_PRIVATE_KEY_PATH
 from utils.singleton_meta import SingletonMeta
 
 logger = get_logger(__name__)
@@ -30,20 +30,13 @@ _RELOAD_INTERVAL_SECONDS = 30 * 60  # 30 minutes
 def _load_private_key(data: bytes) -> EllipticCurvePrivateKey:
     """Decode key data and return a validated EC private key.
 
-    Supports both PEM and raw DER formats (after base64 decoding).
-
-    :param data: Raw private key bytes in PEM or DER format.
+    :param data: Raw private key bytes in PEM format.
     :raises TypeError: If the key is not an EC private key.
     :raises ValueError: If the data cannot be decoded or parsed as a private key.
     """
 
-    # Try PEM first (has header line), fall back to DER.
-    try:
-        key = load_pem_private_key(data, password=None)
-    except (ValueError, TypeError):
-        logger.error("Failed to parse private key as PEM, trying DER format", exc_info=True)
-        key = load_der_private_key(data, password=None)
-
+    # load Private key in PEM format.
+    key = load_pem_private_key(data, password=None)
     if not isinstance(key, EllipticCurvePrivateKey):
         raise TypeError("Key is not an EC private key")
     return key
@@ -51,8 +44,6 @@ def _load_private_key(data: bytes) -> EllipticCurvePrivateKey:
 
 def _load_private_key_from_file(path: Path) -> EllipticCurvePrivateKey:
     """Read the key file and return a validated EC private key.
-
-    Supports both PEM and raw DER formats.
 
     :raises FileNotFoundError: If *path* does not exist.
     :raises TypeError: If the key is not an EC private key.
@@ -155,20 +146,14 @@ class KeyStore(metaclass=SingletonMeta):
     def _load_key(self) -> None:
         """Load (or reload) the private key.
 
-        Reads from the file at ``ENCRYPTION_PRIVATE_KEY_PATH`` when set,
-        otherwise falls back to the ``ENCRYPTION_PRIVATE_KEY_B64`` config value.
+        Reads from the file at ``ENCRYPTION_PRIVATE_KEY_PATH``.
 
         :raises FileNotFoundError: If the key file path is set but does not exist.
         :raises TypeError: If the key is not an EC private key.
         :raises ValueError: If the key data cannot be decoded or parsed.
         """
         if not self._path:
-            logger.warning(
-                "ENCRYPTION_PRIVATE_KEY_PATH is not set, reading from configuration value ENCRYPTION_PRIVATE_KEY_B64"
-            )
-            self._key = _load_private_key(base64.b64decode(str(ENCRYPTION_PRIVATE_KEY_B64)))
-            self._loaded_at = time.monotonic()
-            return
+            raise ValueError("key file path is not set")
         self._key = _load_private_key_from_file(Path(self._path))
         self._loaded_at = time.monotonic()
         logger.info("EC private key loaded from %s", self._path)

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -99,7 +99,7 @@ class KeyStore(metaclass=SingletonMeta):
 
         :raises RuntimeError: If the key cannot be loaded.
         """
-        # Extract the raw uncompressed EC point (65 bytes: 04 || X || Y)
+        # Extract the raw uncompressed EC point.
         raw_point = self.get_public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
 
         # return the Base64-encoded raw point as a string

--- a/src/services/key_store.py
+++ b/src/services/key_store.py
@@ -154,7 +154,7 @@ class KeyStore(metaclass=SingletonMeta):
             raise ValueError("key file path is not set")
         self._key = _load_private_key_from_file(Path(self._path))
         self._loaded_at = time.monotonic()
-        logger.info("EC private key loaded from %s", self._path)
+        logger.info("EC private key loaded successfully from %s", self._path)
 
     # ---- test helpers -----------------------------------------------------
 

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -17,8 +17,8 @@ class LangfuseMaskingModes(StrEnum):
     REDACTED = "REDACTED"  # Everything is redacted.
 
 
-def load_env_from_json() -> None:
-    """Load the configuration from the config.json file."""
+def load_env_from_json() -> Path:
+    """Load the configuration from the config.json file. Returns the path to the config file used."""
     # if running tests with pytest, use config_test.json
     if "pytest" in sys.modules:
         test_config_path = Path(__file__).parent.parent.parent / "config" / "config.test.json"
@@ -47,6 +47,7 @@ def load_env_from_json() -> None:
                     os.environ[key] = json.dumps(value)
                 else:
                     os.environ[key] = str(value)
+        return config_path
     except json.JSONDecodeError as e:
         logging.error(f"Invalid JSON format in config file {config_path}: {e}")
         raise
@@ -62,7 +63,7 @@ def load_env_from_json() -> None:
 
 
 # Load the environment variables from the json file.
-load_env_from_json()
+config_path = load_env_from_json()
 
 # Read the configs.
 # Logging configuration - can be set in config.json or via environment variables
@@ -123,8 +124,8 @@ HANA_HEALTH_CHECK_CACHE_TTL_SECONDS = config(
 )  # Default 5 minutes
 
 # Encryption (Base64 encoded)
-ENCRYPTION_PRIVATE_KEY_PATH = config("ENCRYPTION_PRIVATE_KEY_PATH", default="", cast=str)
-ENCRYPTION_PRIVATE_KEY_B64 = config("ENCRYPTION_PRIVATE_KEY_B64", default="", cast=str)
+default_private_key_path = config_path.parent / "config" / "encryption_key.pem"
+ENCRYPTION_PRIVATE_KEY_PATH = config("ENCRYPTION_PRIVATE_KEY_PATH", default=default_private_key_path, cast=str)
 NONCE_REPLAY_WINDOW_SECONDS = config("NONCE_REPLAY_WINDOW_SECONDS", default=300, cast=int)  # 5 minutes
 
 # Token limits

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -124,7 +124,7 @@ HANA_HEALTH_CHECK_CACHE_TTL_SECONDS = config(
 )  # Default 5 minutes
 
 # Encryption (Base64 encoded)
-default_private_key_path = config_path.parent / "config" / "encryption_key.pem"
+default_private_key_path = config_path.parent / "encryption_key.pem"
 ENCRYPTION_PRIVATE_KEY_PATH = config("ENCRYPTION_PRIVATE_KEY_PATH", default=default_private_key_path, cast=str)
 NONCE_REPLAY_WINDOW_SECONDS = config("NONCE_REPLAY_WINDOW_SECONDS", default=300, cast=int)  # 5 minutes
 

--- a/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
+++ b/tests/blackbox/src/api_tests/test_tools_api_encrypted.py
@@ -24,7 +24,7 @@ import requests
 from common.config import Config
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 MIN_ERROR_STATUS_CODE = 400
 TIMEOUT = 120  # seconds
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 
@@ -61,7 +61,7 @@ def _encrypt_cluster_payload(
     )
     shared_secret = client_private_key.exchange(ec.ECDH(), companion_public_key)
     shared_key = HKDF(
-        algorithm=SHA256(),
+        algorithm=SHA384(),
         length=32,
         salt=None,
         info=_HKDF_INFO,

--- a/tests/unit/services/test_encryption.py
+++ b/tests/unit/services/test_encryption.py
@@ -9,7 +9,7 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA384
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives.serialization import (
 from services.encryption import Encryption
 from services.encryption_cache import IEncryptionCache
 
-_ECDH_CURVE = ec.SECP256R1()
+_ECDH_CURVE = ec.SECP521R1()
 _HKDF_INFO = b"ecdh-key-exchange"
 _AES_GCM_NONCE_SIZE = 12
 _AES_KEY_SIZE = 32
@@ -46,7 +46,7 @@ def _make_encrypted_payload(
     client_key = ec.generate_private_key(_ECDH_CURVE)
 
     shared_secret = client_key.exchange(ec.ECDH(), server_private_key.public_key())
-    shared_key = HKDF(algorithm=SHA256(), length=32, salt=None, info=_HKDF_INFO).derive(shared_secret)
+    shared_key = HKDF(algorithm=SHA384(), length=32, salt=None, info=_HKDF_INFO).derive(shared_secret)
 
     aes_key = os.urandom(32)
     key_nonce = os.urandom(_AES_GCM_NONCE_SIZE)
@@ -80,7 +80,7 @@ _CORRUPTED_ENCRYPTED_KEY = base64.b64encode(os.urandom(60)).decode()
 # _derive_shared_key and _decrypt_aes_key in isolation.
 _CLIENT_KEY_HELPER = ec.generate_private_key(_ECDH_CURVE)
 _CLIENT_PUBLIC_KEY_HELPER_B64 = _ec_public_key_b64(_CLIENT_KEY_HELPER)
-_EXPECTED_SHARED_KEY = HKDF(algorithm=SHA256(), length=32, salt=None, info=_HKDF_INFO).derive(
+_EXPECTED_SHARED_KEY = HKDF(algorithm=SHA384(), length=32, salt=None, info=_HKDF_INFO).derive(
     _CLIENT_KEY_HELPER.exchange(ec.ECDH(), _SERVER_KEY.public_key())
 )
 

--- a/tests/unit/services/test_key_store.py
+++ b/tests/unit/services/test_key_store.py
@@ -488,15 +488,3 @@ class TestKeyStore:
 
         # Then:
         assert result is expected_result, test_case
-
-    # -- fallback to ENCRYPTION_PRIVATE_KEY_B64 -----------------------------
-
-    def test_load_key_falls_back_to_b64_config(self, monkeypatch):
-        """When path is empty, _load_key reads from ENCRYPTION_PRIVATE_KEY_B64."""
-        b64_value = base64.b64encode(_SERVER_KEY_DER).decode()
-        monkeypatch.setattr("services.key_store.ENCRYPTION_PRIVATE_KEY_B64", b64_value)
-        monkeypatch.setattr("services.key_store.ENCRYPTION_PRIVATE_KEY_PATH", "")
-
-        store = KeyStore()
-
-        assert isinstance(store.get_private_key(), EllipticCurvePrivateKey)

--- a/tests/unit/services/test_key_store.py
+++ b/tests/unit/services/test_key_store.py
@@ -38,11 +38,6 @@ def _ec_key_pem_bytes(key: EllipticCurvePrivateKey) -> bytes:
     return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
 
 
-def _ec_key_der_bytes(key: EllipticCurvePrivateKey) -> bytes:
-    """Encode an EC private key as DER/PKCS8 bytes."""
-    return key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
-
-
 def _ec_public_key_b64(key: EllipticCurvePrivateKey) -> str:
     """Encode the uncompressed public point of an EC key as base64."""
     return base64.b64encode(key.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)).decode()
@@ -54,11 +49,10 @@ def _ec_public_key_b64(key: EllipticCurvePrivateKey) -> str:
 
 _SERVER_KEY = ec.generate_private_key(_ECDH_CURVE)
 _SERVER_KEY_PEM = _ec_key_pem_bytes(_SERVER_KEY)
-_SERVER_KEY_DER = _ec_key_der_bytes(_SERVER_KEY)
 _SERVER_PUBLIC_KEY_B64 = _ec_public_key_b64(_SERVER_KEY)
 
 _RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_RSA_KEY_DER = _RSA_KEY.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+_RSA_KEY_PEM = _RSA_KEY.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
 
 
 # ---------------------------------------------------------------------------
@@ -78,15 +72,8 @@ class TestLoadPrivateKey:
                 id="pem_ec_key",
             ),
             pytest.param(
-                "DER-encoded EC key is loaded successfully",
-                _SERVER_KEY_DER,
-                None,
-                None,
-                id="der_ec_key",
-            ),
-            pytest.param(
-                "RSA DER key raises TypeError",
-                _RSA_KEY_DER,
+                "RSA PEM key raises TypeError",
+                _RSA_KEY_PEM,
                 TypeError,
                 "Key is not an EC private key",
                 id="rsa_key",
@@ -140,13 +127,6 @@ class TestLoadPrivateKey:
             None,
             None,
             id="pem_file",
-        ),
-        pytest.param(
-            "DER file is loaded successfully",
-            _SERVER_KEY_DER,
-            None,
-            None,
-            id="der_file",
         ),
         pytest.param(
             "missing file raises FileNotFoundError",
@@ -220,13 +200,6 @@ class TestKeyStore:
                 id="pem_file",
             ),
             pytest.param(
-                "DER key file is loaded successfully",
-                _SERVER_KEY_DER,
-                None,
-                None,
-                id="der_file",
-            ),
-            pytest.param(
                 "missing file raises FileNotFoundError",
                 None,
                 FileNotFoundError,
@@ -241,8 +214,8 @@ class TestKeyStore:
                 id="garbage_file",
             ),
             pytest.param(
-                "RSA key file raises TypeError",
-                _RSA_KEY_DER,
+                "RSA PEM key file raises TypeError",
+                _RSA_KEY_PEM,
                 TypeError,
                 "Key is not an EC private key",
                 id="rsa_key_file",
@@ -305,13 +278,6 @@ class TestKeyStore:
                 None,
                 None,
                 id="valid_pem",
-            ),
-            pytest.param(
-                "returns the EC private key when the file is valid DER",
-                _SERVER_KEY_DER,
-                None,
-                None,
-                id="valid_der",
             ),
         ],
     )

--- a/tests/unit/services/test_key_store.py
+++ b/tests/unit/services/test_key_store.py
@@ -23,8 +23,8 @@ from services.key_store import (
     _load_private_key_from_file,
 )
 
-_ECDH_CURVE = ec.SECP256R1()
-_UNCOMPRESSED_EC_POINT_LENGTH = 65  # 04 || X(32) || Y(32)
+_ECDH_CURVE = ec.SECP521R1()
+_UNCOMPRESSED_EC_POINT_LENGTH = 133  # 04 || X(66) || Y(66)
 _UNCOMPRESSED_EC_POINT_PREFIX = 0x04
 
 
@@ -363,7 +363,7 @@ class TestKeyStore:
         # Then:
         assert result == _SERVER_PUBLIC_KEY_B64
         raw = base64.b64decode(result)
-        # Uncompressed EC point for P-256: 04 || X(32) || Y(32) = 65 bytes.
+        # Uncompressed EC point for P-521: 04 || X(66) || Y(66) = 133 bytes.
         assert len(raw) == _UNCOMPRESSED_EC_POINT_LENGTH
         assert raw[0] == _UNCOMPRESSED_EC_POINT_PREFIX
 


### PR DESCRIPTION
## Summary

- Upgrades the ECDH curve from P-256 (`secp256r1`) to P-521 (`secp521r1`) for stronger key exchange security; updates HKDF hash from SHA-256 to SHA-384 to match.
- Removes the `ENCRYPTION_PRIVATE_KEY_B64` fallback — the private key must now be loaded from a PEM file at `ENCRYPTION_PRIVATE_KEY_PATH` (defaults to `config/encryption_key.pem`). (This was done for backward compatibility for the already released version, but now the latest released version do not need this)
  - Removes raw DER key format support; only PEM is accepted now.
  - Removes raw private key files from the repo and adds them to `.gitignore`.
- Updates the key-generation script to produce a P-521 key written to `config/encryption_key.pem`.