### PR TITLE
feat: add encryption cert secret for companion deployment

### DIFF
--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -116,8 +116,9 @@ jobs:
 
       - name: Companion Deploy - Create secret
         env:
-          COMPANION_CONFIG_BASE64: ${{ secrets.EVALUATION_TESTS_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
+          export COMPANION_CONFIG_BASE64=$(echo -n "$EVALUATION_TESTS_CONFIG" | base64 -w 0)
           kubectl create namespace ai-system
           ./scripts/k8s/create-secret.sh
 
@@ -198,9 +199,10 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
           COMPANION_API_URL: "http://localhost:32000"
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
+          echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH! Running API tests against Companion at $COMPANION_API_URL"
           poetry run pytest src/api_tests/ -v
 
@@ -213,9 +215,10 @@ jobs:
           COMPANION_API_URL: "http://localhost:32000"
           REDIS_URL: "redis://localhost:32100"
           KC_EVAL_RETRIES: "5"
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.EVALUATION_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
+          echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH!"
           poetry run python src/run_evaluation.py
 

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Companion Deploy - Create secret
         env:
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
         run: |
           COMPANION_CONFIG_BASE64=$(echo -n "$EVALUATION_TESTS_CONFIG" | base64 -w 0)
           export COMPANION_CONFIG_BASE64
@@ -201,7 +201,7 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
           COMPANION_API_URL: "http://localhost:32000"
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
           echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"
@@ -217,7 +217,7 @@ jobs:
           COMPANION_API_URL: "http://localhost:32000"
           REDIS_URL: "redis://localhost:32100"
           KC_EVAL_RETRIES: "5"
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
           echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -121,6 +121,13 @@ jobs:
           kubectl create namespace ai-system
           ./scripts/k8s/create-secret.sh
 
+      - name: Companion Deploy - Create encryption cert secret
+        env:
+          ENCRYPTION_KEY_PEM: ${{ secrets.ENCRYPTION_KEY_PEM }}
+        run: |
+          export COMPANION_ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY_PEM" | base64 -w 0)
+          ./scripts/k8s/create-encryption-cert-secret.sh
+
       - name: Companion Deploy - Apply companion manifests
         run: |
           kubectl apply -f scripts/k8s/companion-k3d-manifest.yaml

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -118,7 +118,8 @@ jobs:
         env:
           EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
-          export COMPANION_CONFIG_BASE64=$(echo -n "$EVALUATION_TESTS_CONFIG" | base64 -w 0)
+          COMPANION_CONFIG_BASE64=$(echo -n "$EVALUATION_TESTS_CONFIG" | base64 -w 0)
+          export COMPANION_CONFIG_BASE64
           kubectl create namespace ai-system
           ./scripts/k8s/create-secret.sh
 
@@ -126,7 +127,8 @@ jobs:
         env:
           ENCRYPTION_KEY_PEM: ${{ secrets.ENCRYPTION_KEY_PEM }}
         run: |
-          export COMPANION_ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY_PEM" | base64 -w 0)
+          COMPANION_ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY_PEM" | base64 -w 0)
+          export COMPANION_ENCRYPTION_KEY_BASE64
           ./scripts/k8s/create-encryption-cert-secret.sh
 
       - name: Companion Deploy - Apply companion manifests

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ venv.bak/
 
 # Configuration
 config/config.json
+config/encryption_key.pem
 config/k8s-clusters.json
 
 # Spyder project settings

--- a/scripts/k8s/companion-k3d-manifest.yaml
+++ b/scripts/k8s/companion-k3d-manifest.yaml
@@ -82,7 +82,13 @@ spec:
           - name: companion-config
             mountPath: /etc/secret/companion-config.json
             subPath: companion-config.json
+          - mountPath: /etc/secret/encryption-cert
+            name: encryption-cert
       volumes:
         - name: companion-config
           secret:
             secretName: companion-config
+        - name: encryption-cert
+          secret:
+            defaultMode: 420
+            secretName: kyma-companion-encryption-cert

--- a/scripts/k8s/create-encryption-cert-secret.sh
+++ b/scripts/k8s/create-encryption-cert-secret.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if the COMPANION_ENCRYPTION_KEY_BASE64 env is set.
+if [ -z "$COMPANION_ENCRYPTION_KEY_BASE64" ]; then
+  echo "Error: COMPANION_ENCRYPTION_KEY_BASE64 is not set."
+  exit 1
+fi
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+data:
+  tls.key: "$COMPANION_ENCRYPTION_KEY_BASE64"
+  tls.crt: ZHVtbXkK
+kind: Secret
+metadata:
+  name: kyma-companion-encryption-cert
+  namespace: ai-system
+type: kubernetes.io/tls
+EOF

--- a/scripts/k8s/create-secret.sh
+++ b/scripts/k8s/create-secret.sh
@@ -3,6 +3,7 @@
 # Check if the COMPANION_CONFIG_BASE64 env is set.
 if [ -z "$COMPANION_CONFIG_BASE64" ]; then
   echo "Error: COMPANION_CONFIG_BASE64 is not set."
+  exit 1
 fi
 
 echo "Creating secret companion-config in ai-system namespace."


### PR DESCRIPTION
## Summary

- Adds `create-encryption-cert-secret.sh` to create the `kyma-companion-encryption-cert` TLS secret in the `ai-system` namespace from a base64-encoded encryption key
- Mounts the secret into the companion pod under `/etc/secret/encryption-cert`
- Wires up a new workflow step in the evaluation test pipeline that base64-encodes `ENCRYPTION_KEY_PEM` and runs the script before applying companion manifests
- Fixes a missing `exit 1` in `create-secret.sh` so the script actually exits on a missing env var
- Adds `config/encryption_key.pem` to `.gitignore`