### PR TITLE
chore: enforce TLS 1.3 for Redis egress connections

### DIFF
--- a/src/services/redis.py
+++ b/src/services/redis.py
@@ -87,6 +87,7 @@ def _get_redis_connection() -> AsyncRedis:
         ssl_ca_certs="/etc/secret/ca.crt" if REDIS_SSL_ENABLED else None,
         ssl_include_verify_flags=([ssl.VERIFY_DEFAULT] if REDIS_SSL_ENABLED else None),
         ssl_exclude_verify_flags=([ssl.VERIFY_X509_STRICT] if REDIS_SSL_ENABLED else None),
+        ssl_min_version=ssl.TLSVersion.TLSv1_3 if REDIS_SSL_ENABLED else None,
     )
 
 


### PR DESCRIPTION
## Summary

- Set `ssl_min_version=TLSv1_3` on the Redis TLS context in `_get_redis_connection()`
- Only applies when `REDIS_SSL_ENABLED=True`; plain connections are unchanged

## Background

PCI KSA2 requires that egress TLS connections use only approved cipher suites.
Rather than pinning a cipher list for TLS 1.2, we enforce TLS 1.3 directly --
TLS 1.3 has no non-compliant suites by design, so no explicit cipher list is needed.

Depends on #1213 (TLS-enabled Redis in eval pipeline) merging first -- once that
is in, CI will validate this change end-to-end.

## Testing

Tested using direct redis-py calls (matching the exact `ssl_*` kwargs used in
`_get_redis_connection()`):

**Local Docker Redis (TLS 1.2 only):** connection with `ssl_min_version=TLSv1_3`
correctly rejected with `TLSV1_ALERT_PROTOCOL_VERSION`. Connection with
`ssl_min_version=TLSv1_2` succeeded -- confirming enforcement works.

**KCP dev Memorystore (from inside the running companion pod):** connection with
`ssl_min_version=TLSv1_3` succeeded, negotiating `TLS_AES_256_GCM_SHA384`.

**KCP dev pr-deploy ([management-plane-charts#5350](https://github.tools.sap/kyma/management-plane-charts/pull/5350)):**
full app deployed to `ai-system`, `/healthz` returned `is_redis_healthy: true`.

closes #1192