### PR TITLE
test: add TLS-enabled Redis to evaluation test pipeline

### DIFF
--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -102,17 +102,21 @@ jobs:
           kubectl version
           echo "::endgroup::"
 
-      - name: Redis Setup - Deploy Redis using Helm
+      - name: Redis Setup - Generate TLS certificates
+        run: ./scripts/k8s/create-redis-tls-certs.sh /tmp/redis-tls
+
+      - name: Redis Setup - Deploy Redis with TLS
         run: |
           kubectl create namespace redis
-          helm repo add redis-stack https://redis-stack.github.io/helm-redis-stack/
-          echo "Installing Redis using Helm..."
-          helm install --wait redis-stack redis-stack/redis-stack --set auth.enabled=false -n redis
 
-      - name: Redis Setup - Change NodePort
-        run: |
-          kubectl patch service redis-stack -n redis --type='json' -p='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value": 32100}]'
-          kubectl get svc -n redis redis-stack -o yaml
+          # TLS certs secret for Redis server
+          kubectl create secret generic redis-tls-certs -n redis \
+            --from-file=ca.crt=/tmp/redis-tls/ca.crt \
+            --from-file=redis.crt=/tmp/redis-tls/redis.crt \
+            --from-file=redis.key=/tmp/redis-tls/redis.key
+
+          kubectl apply -f scripts/k8s/redis-tls-manifest.yaml
+          kubectl rollout status deployment/redis -n redis --timeout=120s
 
       - name: Companion Deploy - Create secret
         env:
@@ -130,6 +134,11 @@ jobs:
           COMPANION_ENCRYPTION_KEY_BASE64=$(echo -n "$ENCRYPTION_KEY_PEM" | base64 -w 0)
           export COMPANION_ENCRYPTION_KEY_BASE64
           ./scripts/k8s/create-encryption-cert-secret.sh
+
+      - name: Companion Deploy - Create Redis CA cert secret
+        run: |
+          kubectl create secret generic redis-ca-cert -n ai-system \
+            --from-file=ca.crt=/tmp/redis-tls/ca.crt
 
       - name: Companion Deploy - Apply companion manifests
         run: |
@@ -215,7 +224,7 @@ jobs:
           LOG_LEVEL: "DEBUG"
           TEST_DATA_PATH: "./data"
           COMPANION_API_URL: "http://localhost:32000"
-          REDIS_URL: "redis://localhost:32100"
+          REDIS_URL: "rediss://localhost:32100"
           KC_EVAL_RETRIES: "5"
           EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
         run: |

--- a/scripts/k8s/companion-k3d-manifest.yaml
+++ b/scripts/k8s/companion-k3d-manifest.yaml
@@ -78,12 +78,21 @@ spec:
           value: "INFO"
         - name: CONFIG_PATH
           value: "/etc/secret/companion-config.json"
+        - name: REDIS_HOST
+          value: "redis.redis.svc.cluster.local"
+        - name: REDIS_PORT
+          value: "6380"
+        - name: REDIS_SSL_ENABLED
+          value: "true"
         volumeMounts:
           - name: companion-config
             mountPath: /etc/secret/companion-config.json
             subPath: companion-config.json
           - mountPath: /etc/secret/encryption-cert
             name: encryption-cert
+          - name: redis-ca-cert
+            mountPath: /etc/secret/ca.crt
+            subPath: ca.crt
       volumes:
         - name: companion-config
           secret:
@@ -92,3 +101,6 @@ spec:
           secret:
             defaultMode: 420
             secretName: kyma-companion-encryption-cert
+        - name: redis-ca-cert
+          secret:
+            secretName: redis-ca-cert

--- a/scripts/k8s/create-redis-tls-certs.sh
+++ b/scripts/k8s/create-redis-tls-certs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OUTPUT_DIR="${1:-/tmp/redis-tls}"
+mkdir -p "$OUTPUT_DIR"
+
+# CA key + cert with proper key usage (required by Python 3.13 strict X.509 validation)
+openssl genrsa -out "$OUTPUT_DIR/ca.key" 4096
+openssl req -new -x509 -days 365 \
+  -key "$OUTPUT_DIR/ca.key" \
+  -out "$OUTPUT_DIR/ca.crt" \
+  -subj "/CN=redis-test-ca" \
+  -addext "basicConstraints=critical,CA:true" \
+  -addext "keyUsage=critical,digitalSignature,cRLSign,keyCertSign"
+
+# Server key + cert signed by CA
+openssl genrsa -out "$OUTPUT_DIR/redis.key" 4096
+openssl req -new -key "$OUTPUT_DIR/redis.key" -out "$OUTPUT_DIR/redis.csr" \
+  -subj "/CN=redis.redis.svc.cluster.local"
+openssl x509 -req -days 365 \
+  -in "$OUTPUT_DIR/redis.csr" \
+  -CA "$OUTPUT_DIR/ca.crt" \
+  -CAkey "$OUTPUT_DIR/ca.key" \
+  -CAcreateserial \
+  -extfile <(echo "subjectAltName=DNS:redis.redis.svc.cluster.local,IP:127.0.0.1") \
+  -out "$OUTPUT_DIR/redis.crt"
+
+echo "TLS certificates written to $OUTPUT_DIR"

--- a/scripts/k8s/redis-tls-manifest.yaml
+++ b/scripts/k8s/redis-tls-manifest.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redis
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-tls-config
+  namespace: redis
+data:
+  redis.conf: |
+    tls-port 6380
+    port 0
+    tls-cert-file /tls/redis.crt
+    tls-key-file /tls/redis.key
+    tls-ca-cert-file /tls/ca.crt
+    tls-auth-clients no
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:alpine
+        command: ["redis-server", "/etc/redis/redis.conf"]
+        ports:
+        - containerPort: 6380
+        volumeMounts:
+        - name: config
+          mountPath: /etc/redis
+        - name: tls
+          mountPath: /tls
+      volumes:
+      - name: config
+        configMap:
+          name: redis-tls-config
+      - name: tls
+        secret:
+          secretName: redis-tls-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: redis
+spec:
+  type: NodePort
+  selector:
+    app: redis
+  ports:
+  - port: 6380
+    targetPort: 6380
+    nodePort: 32100


### PR DESCRIPTION
## Summary

- Replace the `redis-stack` Helm chart (RSAL-licensed, no TLS support) with a plain
  `redis:alpine` deployment configured with TLS
- Add `scripts/k8s/create-redis-tls-certs.sh` -- generates a self-signed CA + server
  cert; can be run locally for testing
- Add `scripts/k8s/redis-tls-manifest.yaml` -- Namespace, ConfigMap, Deployment, Service
  using `redis:alpine` with TLS on port 6380
- Mount the Redis CA cert into the companion pod and set `REDIS_SSL_ENABLED=true` in the
  k3d manifest -- exercises the TLS connection path in CI

This is a prerequisite for enforcing TLS 1.3 on the Redis connection. Once this merges,
the enforcement PR will be validated end-to-end in CI before it merges.

## Testing

- `create-redis-tls-certs.sh` tested locally -- generates valid certs accepted by Python 3.13
- Redis TLS deployment tested on k3d (`kyma-companion-test`) -- TLS 1.3 and TLS 1.2 both
  connect successfully from inside the cluster