### PR TITLE
chore: cherry pick eval tests

### DIFF
--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -102,6 +102,16 @@ jobs:
           kubectl version
           echo "::endgroup::"
 
+      - name: KIM CRD Setup - Install Runtime CRD
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kyma-project/kyma-infrastructure-manager/refs/heads/main/config/crd/bases/infrastructuremanager.kyma-project.io_runtimes.yaml
+
+      - name: KIM CRD Setup - Create kcp-system namespace and apply test Runtime CRs
+        run: |
+          kubectl create namespace kcp-system
+          kubectl apply -f tests/blackbox/data/api-test-crd-config/cr-general.yaml
+          kubectl apply -f tests/blackbox/data/api-test-crd-config/cr-eu-only.yaml
+
       - name: Redis Setup - Deploy Redis using Helm
         run: |
           kubectl create namespace redis

--- a/tests/blackbox/data/api-test-crd-config/cr-eu-only.yaml
+++ b/tests/blackbox/data/api-test-crd-config/cr-eu-only.yaml
@@ -1,0 +1,131 @@
+apiVersion: infrastructuremanager.kyma-project.io/v1
+kind: Runtime
+metadata:
+  labels:
+    kyma-project.io/instance-id: 7d4e9c12-a3b5-4f8e-b2c1-6a9d0e3f7b5c
+    kyma-project.io/runtime-id: b2c3d4e5-f6a7-8901-bcde-f23456789012
+    kyma-project.io/broker-plan-id: 8d0b6c4e-3f2a-5b9d-c4e7-0f8a1b3c5d7e
+    kyma-project.io/broker-plan-name: aws
+    kyma-project.io/global-account-id: 5f8e2a1b-c4d7-4e9f-a6b3-8d0c1e2f3a4b
+    kyma-project.io/subaccount-id: 2a4c6e80-b1d3-5f7a-9c0e-2b4d6f8a1c3e
+    kyma-project.io/shoot-name: c-b2c3d4e
+    kyma-project.io/region: eu-west-1
+    kyma-project.io/platform-region: cf-eu11
+    kyma-project.io/provider: aws
+    operator.kyma-project.io/kyma-name: my-kyma-runtime-eu
+  name: b2c3d4e5-f6a7-8901-bcde-f23456789012
+  namespace: kcp-system
+spec:
+  shoot:
+    # spec.shoot.name is required
+    name: c-b2c3d4e
+    # spec.shoot.purpose is required
+    purpose: production
+    # spec.shoot.region is required
+    region: eu-west-1
+    # spec.shoot.platformRegion is required
+    platformRegion: "cf-eu11"
+    # spec.shoot.secretBindingName is required
+    secretBindingName: "my-aws-secret-binding-eu"
+    # spec.shoot.enforceSeedLocation is optional ; it allows to make sure the seed cluster will be located in the same region as the runtime
+    enforceSeedLocation: true
+    # spec.shoot.enableNvidiaOpenshell is optional ; when set to true, enables the shoot-nvidia-openshell Gardener extension for GPU support
+    # enableNvidiaOpenshell: true
+    kubernetes:
+      # spec.shoot.kubernetes.version is optional, when not provided default will be used
+      # Will be modified by the SRE
+      version: "1.28.7"
+      kubeAPIServer:
+        # spec.shoot.kubernetes.kubeAPIServer.oidcConfig is required
+        oidcConfig:
+          clientID: 23456789-bcde-fghi-jklm-234567890123 #gitleaks:allow
+          groupsClaim: groups
+          issuerURL: https://kyma.accounts.ondemand.com
+          signingAlgs:
+            - RS256
+          usernameClaim: sub
+        # spec.shoot.kubernetes.kubeAPIServer.additionalOidcConfig is optional, not implemented in the first KIM release
+        additionalOidcConfig:
+          - clientID: 98765432-edcb-ihgf-mlkj-321098765432 #gitleaks:allow
+            groupsClaim: groups
+            issuerURL: https://additional.auth.mycompany.com
+            signingAlgs:
+              - RS256
+            usernameClaim: sub
+            usernamePrefix: 'mycompany'
+        # spec.shoot.kubernetes.kubeAPIServer.acl is optional, if not provided, no restrictions to API server will be applied
+        acl:
+          allowedCIDRs:
+            - "10.0.0.1/32"
+            - "172.16.0.0/24"
+            - "192.168.1.0/16"
+    provider:
+      # spec.shoot.provider.type is required
+      type: aws
+      # spec.shoot.provider.workers is required
+      workers:
+        - machine:
+            # spec.shoot.workers.machine.type is required
+            type: m6i.large
+            # spec.shoot.workers.machine.image is optional, when not provider default will be used
+            # Will be modified by the SRE
+            image:
+              name: gardenlinux
+              version: 1312.3.0
+          # spec.shoot.workers.volume is required for the first release
+          # Probably can be moved into KIM, as it is hardcoded in KEB, and not dependent on plan
+          volume:
+            type: gp2
+            size: 50Gi
+          # spec.shoot.workers.zones is required
+          zones:
+            - eu-west-1a
+            - eu-west-1b
+            - eu-west-1c
+          # spec.shoot.workers.name is optional, if not provided default will be used
+          name: cpu-worker-0
+          # spec.shoot.workers.minimum is required
+          minimum: 3
+          # spec.shoot.workers.maximum is required
+          maximum: 20
+          # spec.shoot.workers.maxSurge is required in the first release.
+          # It can be optional in the future, as it equals to zone count
+          maxSurge: 3
+          # spec.shoot.workers.maxUnavailable is required in the first release.
+          # It can be optional in the future, as it is always set to 0
+          maxUnavailable: 0
+          # enabling gVisor container runtime for this worker pool
+          cri:
+            name: containerd
+            containerRuntimes:
+            # See configuration options for gVisor container runtime at https://github.com/gardener/gardener-extension-runtime-gvisor
+              - type: gvisor 
+                providerConfig:
+                  apiVersion: gvisor.runtime.extensions.config.gardener.cloud/v1alpha1
+                  kind: GVisorConfiguration
+                  configFlags:
+                    debug: "false"
+                    net-raw: "false"
+                    nvproxy: "false"
+    # spec.shoot.Networking is required
+    networking:
+      pods: 100.64.0.0/12
+      nodes: 10.250.0.0/16
+      services: 100.104.0.0/13
+    # spec.shoot.controlPlane is required
+    controlPlane:
+      highAvailability:
+        failureTolerance:
+          type: zone
+  security:
+    networking:
+      filter:
+        # spec.security.networking.filter.egress.enabled is required
+        egress:
+          enabled: false
+        # spec.security.networking.filter.ingress.enabled is optional (default=false), not implemented in the first KIM release
+        ingress:
+          enabled: true
+    # spec.security.administrators is required
+    administrators:
+      - admin@mycompany.com

--- a/tests/blackbox/data/api-test-crd-config/cr-general.yaml
+++ b/tests/blackbox/data/api-test-crd-config/cr-general.yaml
@@ -1,0 +1,131 @@
+apiVersion: infrastructuremanager.kyma-project.io/v1
+kind: Runtime
+metadata:
+  labels:
+    kyma-project.io/instance-id: 3e8f4a91-b7c2-4d6e-9a1f-2c8b5d7e4f0a
+    kyma-project.io/runtime-id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    kyma-project.io/broker-plan-id: 7c9a4b5d-2e1f-4a8c-b3d6-9e7f0a1b2c3d
+    kyma-project.io/broker-plan-name: aws
+    kyma-project.io/global-account-id: 5f8e2a1b-c4d7-4e9f-a6b3-8d0c1e2f3a4b
+    kyma-project.io/subaccount-id: 9c7b5a3d-1e4f-2d8a-b6c0-4e9f7a2b1d3c
+    kyma-project.io/shoot-name: c-a1b2c3d
+    kyma-project.io/region: eu-central-1
+    kyma-project.io/platform-region: cd-eu11
+    kyma-project.io/provider: aws
+    operator.kyma-project.io/kyma-name: my-kyma-runtime
+  name: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  namespace: kcp-system
+spec:
+  shoot:
+    # spec.shoot.name is required
+    name: c-a1b2c3d
+    # spec.shoot.purpose is required
+    purpose: production
+    # spec.shoot.region is required
+    region: eu-central-1
+    # spec.shoot.platformRegion is required
+    platformRegion: "cd-eu11"
+    # spec.shoot.secretBindingName is required
+    secretBindingName: "my-aws-secret-binding"
+    # spec.shoot.enforceSeedLocation is optional ; it allows to make sure the seed cluster will be located in the same region as the runtime
+    enforceSeedLocation: true
+    # spec.shoot.enableNvidiaOpenshell is optional ; when set to true, enables the shoot-nvidia-openshell Gardener extension for GPU support
+    # enableNvidiaOpenshell: true
+    kubernetes:
+      # spec.shoot.kubernetes.version is optional, when not provided default will be used
+      # Will be modified by the SRE
+      version: "1.28.7"
+      kubeAPIServer:
+        # spec.shoot.kubernetes.kubeAPIServer.oidcConfig is required
+        oidcConfig:
+          clientID: 12345678-abcd-efgh-ijkl-123456789012 #gitleaks:allow
+          groupsClaim: groups
+          issuerURL: https://kyma.accounts.ondemand.com
+          signingAlgs:
+            - RS256
+          usernameClaim: sub
+        # spec.shoot.kubernetes.kubeAPIServer.additionalOidcConfig is optional, not implemented in the first KIM release
+        additionalOidcConfig:
+          - clientID: 87654321-dcba-hgfe-lkji-210987654321 #gitleaks:allow
+            groupsClaim: groups
+            issuerURL: https://additional.auth.mycompany.com
+            signingAlgs:
+              - RS256
+            usernameClaim: sub
+            usernamePrefix: 'mycompany'
+        # spec.shoot.kubernetes.kubeAPIServer.acl is optional, if not provided, no restrictions to API server will be applied
+        acl:
+          allowedCIDRs:
+            - "1.1.1.1/32"
+            - "2.2.2.2/24"
+            - "3.3.3.3/16"
+    provider:
+      # spec.shoot.provider.type is required
+      type: aws
+      # spec.shoot.provider.workers is required
+      workers:
+        - machine:
+            # spec.shoot.workers.machine.type is required
+            type: m6i.large
+            # spec.shoot.workers.machine.image is optional, when not provider default will be used
+            # Will be modified by the SRE
+            image:
+              name: gardenlinux
+              version: 1312.3.0
+          # spec.shoot.workers.volume is required for the first release
+          # Probably can be moved into KIM, as it is hardcoded in KEB, and not dependent on plan
+          volume:
+            type: gp2
+            size: 50Gi
+          # spec.shoot.workers.zones is required
+          zones:
+            - eu-central-1a
+            - eu-central-1b
+            - eu-central-1c
+          # spec.shoot.workers.name is optional, if not provided default will be used
+          name: cpu-worker-0
+          # spec.shoot.workers.minimum is required
+          minimum: 3
+          # spec.shoot.workers.maximum is required
+          maximum: 20
+          # spec.shoot.workers.maxSurge is required in the first release.
+          # It can be optional in the future, as it equals to zone count
+          maxSurge: 3
+          # spec.shoot.workers.maxUnavailable is required in the first release.
+          # It can be optional in the future, as it is always set to 0
+          maxUnavailable: 0
+          # enabling gVisor container runtime for this worker pool
+          cri:
+            name: containerd
+            containerRuntimes:
+            # See configuration options for gVisor container runtime at https://github.com/gardener/gardener-extension-runtime-gvisor
+              - type: gvisor 
+                providerConfig:
+                  apiVersion: gvisor.runtime.extensions.config.gardener.cloud/v1alpha1
+                  kind: GVisorConfiguration
+                  configFlags:
+                    debug: "false"
+                    net-raw: "false"
+                    nvproxy: "false"
+    # spec.shoot.Networking is required
+    networking:
+      pods: 100.64.0.0/12
+      nodes: 10.250.0.0/16
+      services: 100.104.0.0/13
+    # spec.shoot.controlPlane is required
+    controlPlane:
+      highAvailability:
+        failureTolerance:
+          type: zone
+  security:
+    networking:
+      filter:
+        # spec.security.networking.filter.egress.enabled is required
+        egress:
+          enabled: false
+        # spec.security.networking.filter.ingress.enabled is optional (default=false), not implemented in the first KIM release
+        ingress:
+          enabled: true
+    # spec.security.administrators is required
+    administrators:
+      - admin@mycompany.com


### PR DESCRIPTION
# Add KIM CRD Setup Steps and Test Runtime CR Fixtures for Evaluation Tests

### Chore

🔧 Cherry-picked evaluation test improvements by adding KIM (Kyma Infrastructure Manager) CRD setup steps to the reusable evaluation test workflow, along with two test Runtime CR fixture files used during testing.

### Changes

* `.github/workflows/evaluation-test-reusable.yaml`: Added two new workflow steps:
  - **KIM CRD Setup - Install Runtime CRD**: Applies the `infrastructuremanager.kyma-project.io_runtimes.yaml` CRD from the KIM repository.
  - **KIM CRD Setup - Create kcp-system namespace and apply test Runtime CRs**: Creates the `kcp-system` namespace and applies the two new test Runtime CR files.

* `tests/blackbox/data/api-test-crd-config/cr-general.yaml`: New test `Runtime` CR fixture for a general AWS runtime in `eu-central-1` region (`cd-eu11` platform region), used to validate standard CRD configurations.

* `tests/blackbox/data/api-test-crd-config/cr-eu-only.yaml`: New test `Runtime` CR fixture for an EU-only AWS runtime in `eu-west-1` region (`cf-eu11` platform region), including `enforceSeedLocation: true` to ensure the seed cluster stays within the EU region.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- Correlation ID: `746afc9d-09e3-4327-93cc-8e7343f72925`
- Event Trigger: `issue_comment.edited`
</details>
