### PR TITLE
chore: added rbac

### DIFF
--- a/scripts/k8s/companion-k3d-manifest.yaml
+++ b/scripts/k8s/companion-k3d-manifest.yaml
@@ -9,6 +9,28 @@ metadata:
   name: companion
   namespace: ai-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: companion-runtime-reader
+rules:
+  - apiGroups: ["infrastructuremanager.kyma-project.io"]
+    resources: ["runtimes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: companion-runtime-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: companion-runtime-reader
+subjects:
+  - kind: ServiceAccount
+    name: companion
+    namespace: ai-system
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
# Add RBAC ClusterRole and ClusterRoleBinding for Runtime Access

### Chore

🔧 Added RBAC configuration to grant the `companion` service account read access to `runtimes` resources managed by `infrastructuremanager.kyma-project.io`.

### Changes

* `scripts/k8s/companion-k3d-manifest.yaml`: Added a `ClusterRole` (`companion-runtime-reader`) with `get` and `list` permissions on `runtimes` resources, and a corresponding `ClusterRoleBinding` to associate it with the `companion` service account in the `ai-system` namespace.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- Correlation ID: `cccb69c5-390d-4957-9600-41b24680fb76`
- Event Trigger: `issue_comment.edited`
</details>
