### PR TITLE
chore: add modg.yaml and .claude/cve-triage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,6 @@ doc_indexer/data/*
 /tests/.deepeval_telemetry.txt
 tests/blackbox/.deepeval_telemetry.txt
 tmp
+
+modg.yaml
+.claude/cve-triage


### PR DESCRIPTION
## Summary
- Add `modg.yaml` to `.gitignore` (delivery service config file, should not be committed)
- Add `.claude/cve-triage` to `.gitignore` (local CVE triage context, should not be committed)

## Test plan
- [ ] Verify the ignored files no longer appear in `git status`