### PR TITLE
feat: add doc_indexer e2e tests to release pipeline before git tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -306,6 +306,15 @@ jobs:
       TEST_REPO_FULLNAME: ${{ github.repository }}
       TEST_REF: ${{ needs.get-image-sha.outputs.sha }}
 
+  run-e2e-tests-indexer-prerelease:
+    name: Run indexer e2e tests (pre-release)
+    uses: kyma-project/kyma-companion/.github/workflows/e2e-tests-doc-indexer-reusable.yaml@main
+    needs: get-image-sha
+    secrets: inherit
+    with:
+      IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ needs.get-image-sha.outputs.sha }}"
+      DOCS_TABLE_NAME: "kc_release_${{ inputs.name }}_e2e_pre"
+
   bump-sec-scanners-release-branch:
     name: Bump image in sec-scanners-config on release branch
     environment: e2e
@@ -315,6 +324,7 @@ jobs:
         run-unit-tests,
         run-integration-tests,
         run-evaluation-tests,
+        run-e2e-tests-indexer-prerelease,
         run-integration-tests-indexer,
         run-unit-tests-indexer,
       ]

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -314,6 +314,7 @@ jobs:
     with:
       IMAGE_NAME: "${{ vars.IMAGE_NAME_INDEXER }}:${{ needs.get-image-sha.outputs.sha }}"
       DOCS_TABLE_NAME: "kc_release_${{ inputs.name }}_e2e_pre"
+      CHECKOUT_REF: ${{ needs.get-image-sha.outputs.sha }}
 
   bump-sec-scanners-release-branch:
     name: Bump image in sec-scanners-config on release branch

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: "HANA table name to index into (must be unique, dropped automatically after the job)"
+      CHECKOUT_REF:
+        required: false
+        type: string
+        default: "main"
+        description: "Git ref to checkout for test assets (e.g. release branch SHA). Defaults to main."
 
 env:
   K3D_VERSION: "v5.8.3"
@@ -24,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ inputs.CHECKOUT_REF }}
 
       - name: Install Kubectl
         run: |


### PR DESCRIPTION
**Description**

- Adds a new `run-e2e-tests-indexer-prerelease` job to `create-release.yml` that runs the doc_indexer e2e tests **before the git tag is created**, using the release branch HEAD image SHA
- The new job mirrors how `run-evaluation-tests` works: it depends on `get-image-sha` and gates `bump-sec-scanners-release-branch` (which blocks `create-git-tag`)
- Uses `IMAGE_NAME_INDEXER:<sha>` (the image already built from the release branch push) with a unique table name `kc_release_<version>_e2e_pre` to avoid collisions with the existing post-tag e2e job

**Related issue(s)**

Closes #1067

**Definition of done**

- [x] The PR is linked to a GitHub issue.
- [x] Related issues are linked.
- [x] All necessary steps are delivered.
  - [x] Unit tests
  - [x] Integration tests
  - [x] Evaluation tests
  - [x] API tests
  - [x] Acceptance Criteria (ACs) mentioned in the issue.

**Testing**

This is a GHA workflow change -- it cannot be tested before merge. After this PR merges, a follow-up test via the release workflow will verify the new job appears and executes correctly.