### PR TITLE
fix: extend all-checks timeout to 45 min

### DIFF
--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -29,4 +29,3 @@ jobs:
           delay: "1" # minutes
           retries: "44"
           polling_interval: "1" # minutes
-          ignore_checks: "All Checks Passed"

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -27,5 +27,6 @@ jobs:
         uses: wechuli/allcheckspassed@1d00cf0c34c4b0805db8866d8913f22e7125301e # v2.3.0
         with:
           delay: "1" # minutes
-          retries: "10"
+          retries: "44"
           polling_interval: "1" # minutes
+          ignore_checks: "All Checks Passed"


### PR DESCRIPTION
## Description

The `All Checks Passed` job was timing out before slower checks could finish. The previous max window was ~11 minutes (1 min delay + 10 retries). This extends it to 45 minutes.

**Changes:**
- Increase `retries` from `10` to `44` (1 min delay + 44 × 1 min polling = 45 min total)

## Related issue(s)

none

## Testing

No hands-on testing needed -- the only change is a configuration value passed to the `wechuli/allcheckspassed` action.