### PR TITLE
fix: reject cluster URLs when ALLOWED_K8S_DOMAINS is empty and enable…

### DIFF
--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -82,8 +82,8 @@ class K8sAuthHeaders(BaseModel):
     def is_cluster_url_allowed(self) -> bool:
         """Check if the cluster URL is allowed based on the allowed domains."""
         if len(self.allowed_domains) == 0:
-            logger.warning("ALLOWED_K8S_DOMAINS is empty. Skipping cluster URL validation.")
-            return True
+            logger.error("ALLOWED_K8S_DOMAINS is not configured. Rejecting all cluster URLs.")
+            return False
 
         try:
             # parse the URL to get the domain

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -153,6 +153,9 @@ K8S_RESOURCE_RELATIONS_JSON_FILE = config(
 # set ALLOWED_K8S_DOMAINS to [] if all domains are allowed.
 ALLOWED_K8S_DOMAINS = config("ALLOWED_K8S_DOMAINS", default="[]", cast=json.loads)
 
+# Enable verification of K8s JWT tokens (requires K8s CA certificate).
+K8S_VERIFY_TOKEN_SIGNATURE = config("K8S_VERIFY_TOKEN_SIGNATURE", default=True, cast=bool)
+
 if "pytest" in sys.modules:
     TEST_CLUSTER_URL = config("TEST_CLUSTER_URL", default="")
     TEST_CLUSTER_CA_DATA = config("TEST_CLUSTER_CA_DATA", default="")


### PR DESCRIPTION
… token signature verification by default

- is_cluster_url_allowed returns False (was True) when ALLOWED_K8S_DOMAINS is not configured, preventing an open-allow-all fallback.
- K8S_VERIFY_TOKEN_SIGNATURE now defaults to True so token signatures are verified out of the box without explicit opt-in.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request and why:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `ai-force#4567` or `joule-capability#4321`.
- [ ] All necessary steps are delivered, for example, tests, documentation, merging.
  - [ ] Unit tests
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)
  - [ ] Acceptance Criteria (ACs) mentioned in the issue.


