### PR TITLE
fix: prevent path traversal and pin cloned repos to a specific commit…

### DIFF
--- a/doc_indexer/src/fetcher/fetcher.py
+++ b/doc_indexer/src/fetcher/fetcher.py
@@ -43,8 +43,8 @@ class DocumentsFetcher:
 
         if source.source_type == SourceType.GITHUB:
             logger.debug(f"Cloning repository: {source.url}")
-            # clone the git repository.
-            repo_dir = clone_repo(source.url, self.tmp_dir)
+            # clone the git repository, pinned to commit_sha when set.
+            repo_dir = clone_repo(source.url, self.tmp_dir, commit_sha=source.commit_sha)
         else:
             raise ValueError(f"unsupported source_type: {source.source_type}")
 

--- a/doc_indexer/src/fetcher/scroller.py
+++ b/doc_indexer/src/fetcher/scroller.py
@@ -26,6 +26,18 @@ class Scroller:
         """Saves the file to the output directory."""
         source_file_path = os.path.join(self.dir_path, file_dir, file_name)
 
+        # Reject symlinks to prevent traversal outside the cloned repository.
+        if os.path.islink(source_file_path):
+            logger.warning(f"Skipping symlink: {source_file_path}")
+            return
+
+        # Verify the resolved path stays within the cloned repo root.
+        real_path = os.path.realpath(source_file_path)
+        real_base = os.path.realpath(self.dir_path)
+        if not real_path.startswith(real_base + os.sep):
+            logger.warning(f"Skipping out-of-bounds path: {real_path}")
+            return
+
         target_dir = os.path.join(self.output_dir, file_dir)
         os.makedirs(target_dir, exist_ok=True)
 

--- a/doc_indexer/src/fetcher/source.py
+++ b/doc_indexer/src/fetcher/source.py
@@ -23,6 +23,7 @@ class DocumentsSource(BaseModel):
     include_files: list[str] | None = None
     exclude_files: list[str] | None = None
     filter_file_types: list[str] = ["md"]
+    commit_sha: str | None = None
 
 
 def get_documents_sources(path: str) -> list[DocumentsSource]:

--- a/doc_indexer/src/utils/utils.py
+++ b/doc_indexer/src/utils/utils.py
@@ -8,8 +8,13 @@ from utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def clone_repo(repo_url: str, clone_dir: str) -> str:
-    """Clones the git repository and returns the path."""
+def clone_repo(repo_url: str, clone_dir: str, commit_sha: str | None = None) -> str:
+    """Clones the git repository and returns the path.
+
+    If *commit_sha* is provided the repository is checked out at that exact
+    commit after cloning, preventing a compromised upstream default branch from
+    poisoning the indexed documentation.
+    """
     repo_name = repo_url.split("/")[-1].replace(".git", "")
     repo_path = os.path.join(clone_dir, repo_name)
 
@@ -20,6 +25,13 @@ def clone_repo(repo_url: str, clone_dir: str) -> str:
     result = subprocess.run(["git", "clone", repo_url, repo_path])
     if result.returncode != 0:
         raise RuntimeError(f"git clone failed for {repo_url} (exit {result.returncode})")
+
+    if commit_sha:
+        logger.info("Pinning repository to commit", extra={"url": repo_url, "sha": commit_sha})
+        checkout = subprocess.run(["git", "-C", repo_path, "checkout", commit_sha])
+        if checkout.returncode != 0:
+            raise RuntimeError(f"git checkout {commit_sha} failed for {repo_url} (exit {checkout.returncode})")
+
     logger.info("Repository cloned successfully", extra={"url": repo_url, "dest": repo_path})
 
     return repo_path

--- a/doc_indexer/tests/unit/fetcher/test_fetcher.py
+++ b/doc_indexer/tests/unit/fetcher/test_fetcher.py
@@ -109,7 +109,8 @@ class TestDocumentsFetcher:
 
         # then
         # should have cloned the repo.
-        clone_repo_mock.assert_called_once_with(fetcher.sources[0].url, given_tmp_dir)
+        source = fetcher.sources[0]
+        clone_repo_mock.assert_called_once_with(source.url, given_tmp_dir, commit_sha=source.commit_sha)
         # should have created the module directory for output.
         makedirs_mock.assert_called_once_with(os.path.join(given_output_dir, fetcher.sources[0].name), exist_ok=True)
         # should have created the scroller object and called the scroll method.
@@ -201,6 +202,6 @@ class TestDocumentsFetcher:
         ):
             fetcher.fetch_documents(valid_source)
 
-        clone_repo_mock.assert_called_once_with(valid_source.url, given_tmp_dir)
+        clone_repo_mock.assert_called_once_with(valid_source.url, given_tmp_dir, commit_sha=valid_source.commit_sha)
         scroller_mock.assert_called_once()
         scroller_mock.return_value.scroll.assert_called_once()


### PR DESCRIPTION
… in doc_indexer

- Scroller._save_file rejects symlinks and verifies the resolved path remains within dir_path before copying, blocking symlink-based directory traversal.
- DocumentsSource gains an optional commit_sha field; clone_repo accepts and enforces it via git checkout so indexing is always pinned to a known commit instead of a potentially compromised default branch.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request and why:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `ai-force#4567` or `joule-capability#4321`.
- [ ] All necessary steps are delivered, for example, tests, documentation, merging.
  - [ ] Unit tests
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)
  - [ ] Acceptance Criteria (ACs) mentioned in the issue.


