### PR TITLE
fix: harden session ownership binding and cluster rate-limit key deri…

### DIFF
--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from http import HTTPStatus
 from typing import Annotated
+from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path
@@ -27,6 +28,7 @@ from utils.response import prepare_chunk_response
 from utils.settings import MAIN_MODEL_NAME, MAX_TOKEN_LIMIT_INPUT_QUERY
 from utils.utils import (
     create_session_id,
+    generate_sha384_hash,
     get_user_identifier_from_client_certificate,
     get_user_identifier_from_token,
 )
@@ -108,6 +110,13 @@ async def init_conversation(
     # Initialize with the session_id. Create a new session_id if not provided.
     session_id = session_id if session_id else create_session_id()
 
+    # Bind ownership at creation time so no other caller can claim this session.
+    user_identifier = extract_user_identifier(k8s_auth_headers)
+    await authorize_user(session_id, user_identifier, conversation_service)
+
+    # Check rate limitation (after URL is validated by validate_headers above).
+    await check_token_usage(x_cluster_url, conversation_service)
+
     # Initialize k8s client for the request.
     try:
         k8s_client: IK8sClient = K8sClient(
@@ -117,9 +126,6 @@ async def init_conversation(
     except Exception as e:
         logger.exception("Failed to initialize Kubernetes client")
         raise HTTPException(status_code=400, detail=f"failed to connect to the cluster: {str(e)}") from e
-
-    # Check rate limitation
-    await check_token_usage(x_cluster_url, conversation_service)
 
     try:
         # Create initial questions.
@@ -274,7 +280,8 @@ async def messages(
 
 async def check_token_usage(x_cluster_url: str, conversation_service: IService) -> None:
     """Check if the token usage limit is exceeded for the cluster."""
-    cluster_id = x_cluster_url.split(".")[1]
+    parsed = urlparse(x_cluster_url)
+    cluster_id = generate_sha384_hash(parsed.hostname or x_cluster_url)
 
     report = await conversation_service.is_usage_limit_exceeded(cluster_id)
     if report is not None:

--- a/src/routers/conversations.py
+++ b/src/routers/conversations.py
@@ -125,7 +125,8 @@ async def init_conversation(
         )
     except Exception as e:
         logger.exception("Failed to initialize Kubernetes client")
-        raise HTTPException(status_code=400, detail=f"failed to connect to the cluster: {str(e)}") from e
+        logger.exception("Failed to initialize Kubernetes client")
+        raise HTTPException(status_code=400, detail="failed to connect to the cluster") from e
 
     try:
         # Create initial questions.


### PR DESCRIPTION
# Harden Session Ownership Binding and Cluster Rate-Limit Key Derivation

### Bug Fix

🐛 This PR addresses two security and robustness issues in the conversation router:

1. **Session Hijacking Prevention**: `init_conversation` now immediately calls `extract_user_identifier` and `authorize_user` right after the session ID is created, binding ownership before any downstream work is performed. Previously, the ownership check happened later in the flow, leaving a window for session hijacking.

2. **Robust Rate-Limit Key Derivation**: `check_token_usage` now derives the cluster bucket key by parsing the URL with `urlparse` and hashing the hostname using SHA-384, replacing the fragile `.split(".")[1]` index approach that could fail for non-standard URLs.

### Changes

* `src/routers/conversations.py`:
  - Added `urlparse` import from `urllib.parse`.
  - Imported `generate_sha384_hash` utility function.
  - Moved `extract_user_identifier` + `authorize_user` + `check_token_usage` calls to immediately after session ID creation in `init_conversation`, before K8s client initialization.
  - Replaced `x_cluster_url.split(".")[1]` with `urlparse`-based hostname extraction and SHA-384 hashing in `check_token_usage`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.14`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `61d50970-7942-11f1-8986-df93cef3e9a8`
</details>
