### PR TITLE
fix: replace nonce replay window with atomic SET NX for strict one-ti…

### DIFF
--- a/src/services/encryption_cache.py
+++ b/src/services/encryption_cache.py
@@ -1,4 +1,3 @@
-import time
 from typing import Annotated, Protocol, cast, runtime_checkable
 from urllib.parse import quote
 
@@ -6,7 +5,7 @@ from fastapi import Depends
 from redis.asyncio import Redis as AsyncRedis
 
 from services.redis import Redis, get_redis
-from utils.settings import NONCE_REPLAY_WINDOW_SECONDS, REDIS_TTL
+from utils.settings import REDIS_TTL
 
 _ENCRYPTION_CACHE_KEY_PREFIX = "encryption:session_id:"
 _NONCE_KEY_PREFIX = "encryption:nonce:"
@@ -64,18 +63,12 @@ class EncryptionCache:
     async def is_nonce_allowed(self, session_id: str, nonce: str) -> bool:
         """Check whether a nonce is allowed for the given session.
 
-        On first use the nonce is stored with its timestamp and REDIS_TTL.
-        Subsequent uses within NONCE_REPLAY_WINDOW_SECONDS are permitted
-        (agents may legitimately resend the same headers). Uses beyond that
-        window are rejected as replay attacks.
+        Uses an atomic SET NX (set-if-not-exists) operation so each nonce is
+        accepted exactly once. Clients must generate a fresh nonce per request.
         """
         key = f"{_NONCE_KEY_PREFIX}{quote(session_id, safe='')}:{quote(nonce, safe='')}"
-        raw = cast(str | None, await self._redis.get_connection().get(key))
-        if raw is None:
-            await self._redis.get_connection().set(key, str(time.time()), ex=REDIS_TTL)
-            return True
-        first_seen = float(raw)
-        return bool((time.time() - first_seen) <= NONCE_REPLAY_WINDOW_SECONDS)
+        was_set = await self._redis.get_connection().set(key, "1", ex=REDIS_TTL, nx=True)
+        return bool(was_set)
 
 
 def get_encryption_cache(


### PR DESCRIPTION
…me use

is_nonce_allowed now uses Redis SET NX so each nonce is accepted exactly once, eliminating the replay window that allowed reuse within NONCE_REPLAY_WINDOW_SECONDS. Clients must generate a fresh nonce per request.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request and why:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `ai-force#4567` or `joule-capability#4321`.
- [ ] All necessary steps are delivered, for example, tests, documentation, merging.
  - [ ] Unit tests
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)
  - [ ] Acceptance Criteria (ACs) mentioned in the issue.


