### PR TITLE
fix: add input length caps to public key, search query, and top_k par…

### DIFF
--- a/src/routers/common.py
+++ b/src/routers/common.py
@@ -210,6 +210,7 @@ class SearchKymaDocRequest(BaseModel):
 
     query: str = Field(
         ...,
+        max_length=2000,
         description="Search query for Kyma documentation",
         examples=[
             "Help me get started with kyma",
@@ -221,7 +222,7 @@ class SearchKymaDocRequest(BaseModel):
         default=5,
         description="Number of top documents to return",
         ge=1,
-        le=50,
+        le=10,
     )
 
 

--- a/src/routers/public_key.py
+++ b/src/routers/public_key.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 class PublicKeyRequest(BaseModel):
     """Request model for storing a client public key for a session."""
 
-    public_key: str = Field(..., min_length=1, description="Client public key")
+    public_key: str = Field(..., min_length=1, max_length=512, description="Base64-encoded client EC public key")
 
 
 class PublicKeyResponse(BaseModel):


### PR DESCRIPTION
…ameters

- PublicKeyRequest.public_key capped at max_length=512 to prevent oversized key payloads.
- SearchKymaDocRequest.query capped at max_length=2000 to limit search input size.
- SearchKymaDocRequest.top_k upper bound reduced from 50 to 10 to prevent excessive retrieval load.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request and why:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `ai-force#4567` or `joule-capability#4321`.
- [ ] All necessary steps are delivered, for example, tests, documentation, merging.
  - [ ] Unit tests
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)
  - [ ] Acceptance Criteria (ACs) mentioned in the issue.


