### PR TITLE
fix: enforce non-empty ALLOWED_K8S_DOMAINS for cluster URL validation

### DIFF
--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -30,10 +30,10 @@ from services.k8s_models import (
 from utils import logging
 from utils.exceptions import K8sClientError, NoLogsAvailableError, parse_k8s_error_response
 from utils.settings import (
-    ALLOWED_K8S_DOMAINS,
     K8S_API_PAGINATION_LIMIT,
     K8S_API_PAGINATION_MAX_PAGE,
 )
+import utils.settings as _settings
 
 logger = logging.get_logger(__name__)
 
@@ -61,7 +61,7 @@ class K8sAuthHeaders(BaseModel):
     x_k8s_authorization: str | None = Field(default=None, validation_alias="x-k8s-authorization")
     x_client_certificate_data: str | None = Field(default=None, validation_alias="x-client-certificate-data")
     x_client_key_data: str | None = Field(default=None, validation_alias="x-client-key-data")
-    allowed_domains: list[str] = ALLOWED_K8S_DOMAINS
+    allowed_domains: list[str] = Field(default_factory=lambda: _settings.ALLOWED_K8S_DOMAINS)
 
     def validate_headers(self) -> None:
         """Validate the Kubernetes API authentication headers."""
@@ -82,8 +82,10 @@ class K8sAuthHeaders(BaseModel):
     def is_cluster_url_allowed(self) -> bool:
         """Check if the cluster URL is allowed based on the allowed domains."""
         if len(self.allowed_domains) == 0:
-            logger.warning("ALLOWED_K8S_DOMAINS is empty. Skipping cluster URL validation.")
-            return True
+            raise ValueError(
+                "ALLOWED_K8S_DOMAINS is not configured. "
+                "Set ALLOWED_K8S_DOMAINS to a non-empty list of allowed domains to enable cluster URL validation."
+            )
 
         try:
             # parse the URL to get the domain

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -13,6 +13,7 @@ import aiohttp
 from kubernetes import client, dynamic
 from pydantic import BaseModel, ConfigDict, Field
 
+import utils.settings as _settings
 from services.data_sanitizer import IDataSanitizer
 from services.k8s_constants import (
     ContainerStateType,
@@ -33,7 +34,6 @@ from utils.settings import (
     K8S_API_PAGINATION_LIMIT,
     K8S_API_PAGINATION_MAX_PAGE,
 )
-import utils.settings as _settings
 
 logger = logging.get_logger(__name__)
 

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -150,7 +150,9 @@ K8S_RESOURCE_RELATIONS_JSON_FILE = config(
     default=f"{Path(__file__).parent.parent.parent}/config/resource_relations.json",
 )
 
-# set ALLOWED_K8S_DOMAINS to [] if all domains are allowed.
+# ALLOWED_K8S_DOMAINS must be set to a non-empty JSON list of allowed domain suffixes.
+# Leaving it empty disables all cluster URL access (fail-closed).
+# Example: ALLOWED_K8S_DOMAINS='["my-company.internal", "k8s.example.com"]'
 ALLOWED_K8S_DOMAINS = config("ALLOWED_K8S_DOMAINS", default="[]", cast=json.loads)
 
 if "pytest" in sys.modules:

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+import utils.settings
 from main import app
 from routers.common import init_models_dict
 from routers.k8s_tools_api import init_k8s_client as init_k8s_client_k8s
@@ -25,6 +26,13 @@ from utils.exceptions import K8sClientError, NoLogsAvailableError
 SAMPLE_BEARER_TOKEN = "test-token-123"
 SAMPLE_CLUSTER_URL = "https://api.test-cluster.example.com"
 SAMPLE_CA_DATA = "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCg=="
+
+
+@pytest.fixture(autouse=True)
+def allowed_k8s_domains():
+    """Patch ALLOWED_K8S_DOMAINS so cluster URL validation passes for test domains."""
+    with patch.object(utils.settings, "ALLOWED_K8S_DOMAINS", ["example.com"]):
+        yield
 
 
 def get_sample_headers() -> dict[str, str]:

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -192,6 +192,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization="abc",
                     x_client_certificate_data="abc",
                     x_client_key_data="abc",
+                    allowed_domains=["example.com"],
                 ),
                 None,
             ),
@@ -203,6 +204,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization="abc",
                     x_client_certificate_data=None,
                     x_client_key_data=None,
+                    allowed_domains=["example.com"],
                 ),
                 None,
             ),
@@ -214,6 +216,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization=None,
                     x_client_certificate_data="abc",
                     x_client_key_data="abc",
+                    allowed_domains=["example.com"],
                 ),
                 None,
             ),
@@ -225,6 +228,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization="abc",
                     x_client_certificate_data="abc",
                     x_client_key_data="abc",
+                    allowed_domains=["example.com"],
                 ),
                 "x-cluster-url header is required.",
             ),
@@ -236,6 +240,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization="abc",
                     x_client_certificate_data="abc",
                     x_client_key_data="abc",
+                    allowed_domains=["example.com"],
                 ),
                 "x-cluster-certificate-authority-data header is required.",
             ),
@@ -247,6 +252,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization=None,
                     x_client_certificate_data=None,
                     x_client_key_data=None,
+                    allowed_domains=["example.com"],
                 ),
                 "Either x-k8s-authorization header or "
                 + "x-client-certificate-data and x-client-key-data headers are required.",
@@ -259,6 +265,7 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization=None,
                     x_client_certificate_data=None,
                     x_client_key_data="abc",
+                    allowed_domains=["example.com"],
                 ),
                 "Either x-k8s-authorization header or "
                 + "x-client-certificate-data and x-client-key-data headers are required.",
@@ -271,21 +278,22 @@ class TestK8sAuthHeaders:
                     x_k8s_authorization=None,
                     x_client_certificate_data="abc",
                     x_client_key_data=None,
+                    allowed_domains=["example.com"],
                 ),
                 "Either x-k8s-authorization header or "
                 + "x-client-certificate-data and x-client-key-data headers are required.",
             ),
             (
-                "all domains allowed for x_cluster_url",
+                "no allowed domains configured for x_cluster_url",
                 K8sAuthHeaders(
                     x_cluster_url="https://api.example.com",
                     x_cluster_certificate_authority_data="abc",
                     x_k8s_authorization="abc",
                     x_client_certificate_data="abc",
                     x_client_key_data=None,
-                    allowed_domains=[],  # No domains specified, should allow all
+                    allowed_domains=[],  # Empty domains must be rejected (fail-closed)
                 ),
-                None,
+                "ALLOWED_K8S_DOMAINS is not configured.",
             ),
             (
                 "allowed x_cluster_url domain",
@@ -348,11 +356,11 @@ class TestK8sAuthHeaders:
                 None,
             ),
             (
-                "No allowed domains (should skip validation and allow)",
+                "No allowed domains (should raise ValueError)",
                 "https://api.anything.com",
                 [],
-                True,
-                None,
+                False,
+                ValueError,
             ),
             (
                 "Malformed URL (should raise ValueError)",


### PR DESCRIPTION
# Enforce Non-Empty `ALLOWED_K8S_DOMAINS` for Cluster URL Validation (Fail-Closed)

### Bug Fix

🔒 Changed the cluster URL validation behavior when `ALLOWED_K8S_DOMAINS` is empty from silently allowing all domains (fail-open) to raising a `ValueError` (fail-closed). This ensures that a misconfigured or missing `ALLOWED_K8S_DOMAINS` setting does not inadvertently permit access to arbitrary cluster URLs.

### Changes

* `src/services/k8s.py`:
  - Replaced the static import of `ALLOWED_K8S_DOMAINS` with a dynamic reference via `import utils.settings as _settings`, so the field always reflects the current runtime value.
  - Changed `allowed_domains` field default from `ALLOWED_K8S_DOMAINS` to `Field(default_factory=lambda: _settings.ALLOWED_K8S_DOMAINS)` to avoid capturing the value at class definition time.
  - In `is_cluster_url_allowed()`, replaced the permissive warning-and-return-true behavior for empty `allowed_domains` with a `ValueError` requiring the setting to be explicitly configured.

* `src/utils/settings.py`:
  - Updated the comment for `ALLOWED_K8S_DOMAINS` to clarify that it must be set to a non-empty list and that leaving it empty disables all cluster URL access (fail-closed behavior).

* `tests/unit/routers/conftest.py`:
  - Added an `autouse` fixture that patches `utils.settings.ALLOWED_K8S_DOMAINS` to `["example.com"]` for all router unit tests, ensuring validation passes for the test cluster domain.

* `tests/unit/services/test_k8s.py`:
  - Added explicit `allowed_domains=["example.com"]` to all test `K8sAuthHeaders` instances that previously relied on the default.
  - Updated the "empty allowed domains" test case description from "all domains allowed" to "no allowed domains configured", flipped its expected result from `None` (no error) to `"ALLOWED_K8S_DOMAINS is not configured."`, and corrected `is_cluster_url_allowed` test expectations to expect `ValueError` for an empty domain list.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.14`

- Correlation ID: `1aed8b50-793c-11f1-887f-fefefa167fab`
- Event Trigger: `issue_comment.edited`
</details>
