### PR TITLE
fix: handle diverged status in draft release compare

### DIFF
--- a/scripts/shell/create_draft_release.sh
+++ b/scripts/shell/create_draft_release.sh
@@ -94,7 +94,7 @@ if [ -n "${PREVIOUS_TAG:-}" ]; then
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "${GITHUB_URL}/compare/${PREVIOUS_TAG}...${RELEASE_TAG}")
   compare_status=$(echo "${compare_response}" | jq -r '.status // empty')
-  if [ -n "${compare_status}" ]; then
+  if echo "${compare_status}" | grep -qE '^[0-9]+$'; then
     echo "Warning: Failed to fetch compare (status: ${compare_status}). Sections will be empty."
   else
     # extract first line of each commit message and group by conventional commit prefix.

--- a/scripts/shell/create_draft_release.sh
+++ b/scripts/shell/create_draft_release.sh
@@ -96,6 +96,10 @@ if [ -n "${PREVIOUS_TAG:-}" ]; then
   compare_status=$(echo "${compare_response}" | jq -r '.status // empty')
   if echo "${compare_status}" | grep -qE '^[0-9]+$'; then
     echo "Warning: Failed to fetch compare (status: ${compare_status}). Sections will be empty."
+  elif [ -n "${compare_status}" ] && ! echo "${compare_status}" | grep -qE '^(ahead|behind|identical|diverged)$'; then
+    echo "Warning: Unexpected compare status '${compare_status}'. Sections will be empty."
+  else
+    echo "Warning: Failed to fetch compare (status: ${compare_status}). Sections will be empty."
   else
     # extract first line of each commit message and group by conventional commit prefix.
     while IFS= read -r msg; do

--- a/scripts/shell/create_draft_release.sh
+++ b/scripts/shell/create_draft_release.sh
@@ -94,12 +94,12 @@ if [ -n "${PREVIOUS_TAG:-}" ]; then
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "${GITHUB_URL}/compare/${PREVIOUS_TAG}...${RELEASE_TAG}")
   compare_status=$(echo "${compare_response}" | jq -r '.status // empty')
-  if echo "${compare_status}" | grep -qE '^[0-9]+$'; then
+  if [ -z "${compare_status}" ]; then
+    echo "Warning: Failed to fetch compare (missing status). Sections will be empty."
+  elif echo "${compare_status}" | grep -qE '^[0-9]+$'; then
     echo "Warning: Failed to fetch compare (status: ${compare_status}). Sections will be empty."
-  elif [ -n "${compare_status}" ] && ! echo "${compare_status}" | grep -qE '^(ahead|behind|identical|diverged)$'; then
+  elif ! echo "${compare_status}" | grep -qE '^(ahead|behind|identical|diverged)$'; then
     echo "Warning: Unexpected compare status '${compare_status}'. Sections will be empty."
-  else
-    echo "Warning: Failed to fetch compare (status: ${compare_status}). Sections will be empty."
   else
     # extract first line of each commit message and group by conventional commit prefix.
     while IFS= read -r msg; do


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix a false-positive warning in \`scripts/shell/create_draft_release.sh\` where a valid GitHub Compare API response with \`status: diverged\` was incorrectly treated as an error, causing the release notes sections (Features, Fixes, Other) to be left empty.

**Root cause:** The guard condition \`if [ -n "\${compare_status}" ]\` triggered on any non-empty status string. The GitHub Compare API always returns a \`status\` field for successful responses (\`ahead\`, \`behind\`, \`identical\`, \`diverged\`). Since release tags live on separate release branches that diverged from main, the compare between e.g. \`0.9.0\` and \`0.10.0\` legitimately returns \`diverged\` — but the old condition treated it as a failure.

**Fix:** Only treat numeric HTTP error codes (e.g. \`404\`, \`422\`) as failures, since GitHub error responses use a numeric string for \`status\` while all valid comparison statuses are non-numeric words.

**Related issue(s)**

See failing job: https://github.com/kyma-project/kyma-companion/actions/runs/28576975382/job/84740242875 (step "Create draft release", warning at line 20)