### PR TITLE
chore: add component-config.yaml for OCM artifact builder onboarding

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,5 @@
+name: kyma-project.io/kyma-runtime/kcp-components/kyma-companion
+team: kyma/ai-force
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-companion:main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-companion-indexer:main


### PR DESCRIPTION
**Description**

Changes proposed in this pull request and why:

- Add `component-config.yaml` to onboard `kyma-companion` to the OCM artifact builder dev artifact pipeline
- Registers both runtime images (`kyma-companion` and `kyma-companion-indexer`) for automated security scanning via the OCM component descriptor

**Related issue(s)**

See also https://github.tools.sap/kyma/ocm-artifact-builder/issues/206

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `ai-force#4567` or `joule-capability#4321`.
- [x] All necessary steps are delivered, for example, tests, documentation, merging.
  - [x] Unit tests
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)
  - [x] Acceptance Criteria (ACs) mentioned in the issue.