### PR TITLE
fix: allow unsafe PR checkout for evaluation tests job

### DIFF
--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -41,6 +41,9 @@ jobs:
         with:
           ref: ${{ inputs.TEST_REF }}
           repository: ${{ inputs.TEST_REPO_FULLNAME }}
+          # Safe: the `environment: e2e` gate above requires codeowner approval before
+          # this job runs, so secrets are never exposed to unreviewed fork code.
+          allow-unsafe-pr-checkout: true
 
       - name: K3d Setup - Install Kubectl CLI
         run: |


### PR DESCRIPTION
# Allow Unsafe PR Checkout for Evaluation Tests Job

### Bug Fix

🔧 Enables the `allow-unsafe-pr-checkout: true` flag in the reusable evaluation tests workflow to allow checking out code from fork PRs. This is safe because the `environment: e2e` gate requires codeowner approval before the job runs, ensuring secrets are never exposed to unreviewed fork code.

### Changes

* `.github/workflows/evaluation-test-reusable.yaml`: Added `allow-unsafe-pr-checkout: true` to the `actions/checkout` step, along with an explanatory comment clarifying why this is safe given the `environment: e2e` approval gate.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Correlation ID: `27da22a0-7eba-11f1-95c3-b9e3f5e62455`
- Event Trigger: `issue_comment.edited`
</details>
