### PR TITLE
chore: update pull-integration-test.yaml

### DIFF
--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Safe: the `environment: e2e` gate above requires codeowner approval before
+          # this job runs, so secrets are never exposed to unreviewed fork code.
+          allow-unsafe-pr-checkout: true
 
       - name: Extract Python version
         run: ./scripts/shell/extract-python-version.sh


### PR DESCRIPTION
# Allow Unsafe PR Checkout in Pull Integration Test Workflow

### Bug Fix / Chore

🔧 Updated the pull integration test workflow to allow unsafe PR checkouts from forks, with an added safety comment explaining why this is acceptable.

### Changes

* `.github/workflows/pull-integration-test.yaml`: Added `allow-unsafe-pr-checkout: true` to the `actions/checkout` step, along with a comment clarifying that this is safe because the `environment: e2e` gate requires codeowner approval before the job runs, ensuring secrets are never exposed to unreviewed fork code.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Correlation ID: `2c3dd120-804a-11f1-81f5-c0c53c3cbb68`
- Event Trigger: `issue_comment.edited`
</details>
