### PR TITLE
fix: allow unsafe PR checkout in doc-indexer tests workflow

### DIFF
--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
 
       - name: Extract Python version
         working-directory: ./doc_indexer


### PR DESCRIPTION
## Description

`actions/checkout@v7` introduced a new security restriction that blocks
checking out fork PR code in `pull_request_target` workflows unless
`allow-unsafe-pr-checkout: true` is explicitly set.

`pull-tests-doc-indexer.yaml` checks out the fork's head SHA directly
(`github.event.pull_request.head.sha` + `head.repo.full_name`), which
triggers this restriction. The other `pull_request_target` workflows
only check out `main` or the default ref and are not affected.

The `pull-integration-test.yaml` workflow was already fixed in #1262.

## Related issue(s)

N/A

## Testing

GHA workflow change -- cannot be verified before merge. Will confirm on
the next fork PR that targets `doc_indexer/**`.