### PR TITLE
refactor: make REST API handlers fully async

### DIFF
--- a/src/agents/common/utils.py
+++ b/src/agents/common/utils.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -163,41 +164,45 @@ async def get_relevant_context_from_k8s_cluster(message: Message, k8s_client: IK
     context = ""
 
     if is_empty_str(namespace) and kind.lower() == CLUSTER:
-        # Get an overview of the cluster
-        # by fetching all not running pods, all K8s Nodes metrics,
-        # and all K8s events with warning type.
+        # Get an overview of the cluster by fetching all not running pods, all K8s Nodes metrics,
+        # and all K8s events with warning type. Fan out the three independent calls concurrently.
         logger.info("Fetching all not running Pods, Node metrics, and K8s Events with warning type")
-        pods = yaml.dump_all(k8s_client.list_not_running_pods(namespace=namespace))
-        metrics = yaml.dump_all(await k8s_client.list_nodes_metrics())
-        events = yaml.dump_all(k8s_client.list_k8s_warning_events(namespace=namespace))
+        pods_raw, metrics_raw, events_raw = await asyncio.gather(
+            asyncio.to_thread(k8s_client.list_not_running_pods, namespace=namespace),
+            k8s_client.list_nodes_metrics(),
+            asyncio.to_thread(k8s_client.list_k8s_warning_events, namespace=namespace),
+        )
+        pods = yaml.dump_all(pods_raw)
+        metrics = yaml.dump_all(metrics_raw)
+        events = yaml.dump_all(events_raw)
 
         context = f"{pods}\n{metrics}\n{events}"
 
     elif is_non_empty_str(namespace) and kind.lower() == "namespace":
-        # Get an overview of the namespace
-        # by fetching all K8s events with warning type.
+        # Get an overview of the namespace by fetching all K8s events with warning type.
         logger.debug("Fetching all K8s Events with warning type")
-        context = yaml.dump_all(k8s_client.list_k8s_warning_events(namespace=namespace))
+        context = yaml.dump_all(await asyncio.to_thread(k8s_client.list_k8s_warning_events, namespace=namespace))
 
     elif is_non_empty_str(kind) and is_non_empty_str(api_version):
-        # Describe a specific resource. Not-namespaced resources need the namespace
-        # field to be empty. Finally, get all events related to given resource.
+        # Describe a specific resource and fetch related events concurrently.
         logger.info(f"Fetching all entities of Kind {kind} with API version {api_version}")
-        resources = yaml.dump(
-            k8s_client.describe_resource(
+        resources_raw, events_raw = await asyncio.gather(
+            asyncio.to_thread(
+                k8s_client.describe_resource,
                 api_version=api_version,
                 kind=kind,
                 name=name,
                 namespace=namespace,
-            )
-        )
-        events = yaml.dump_all(
-            k8s_client.list_k8s_events_for_resource(
+            ),
+            asyncio.to_thread(
+                k8s_client.list_k8s_events_for_resource,
                 kind=kind,
                 name=name,
                 namespace=namespace,
-            )
+            ),
         )
+        resources = yaml.dump(resources_raw)
+        events = yaml.dump_all(events_raw)
 
         context = f"{resources}\n{events}"
 

--- a/src/agents/common/utils.py
+++ b/src/agents/common/utils.py
@@ -184,27 +184,16 @@ async def get_relevant_context_from_k8s_cluster(message: Message, k8s_client: IK
         context = yaml.dump_all(await asyncio.to_thread(k8s_client.list_k8s_warning_events, namespace=namespace))
 
     elif is_non_empty_str(kind) and is_non_empty_str(api_version):
-        # Describe a specific resource and fetch related events concurrently.
+        # Describe a specific resource; describe_resource already embeds related events internally.
         logger.info(f"Fetching all entities of Kind {kind} with API version {api_version}")
-        resources_raw, events_raw = await asyncio.gather(
-            asyncio.to_thread(
-                k8s_client.describe_resource,
-                api_version=api_version,
-                kind=kind,
-                name=name,
-                namespace=namespace,
-            ),
-            asyncio.to_thread(
-                k8s_client.list_k8s_events_for_resource,
-                kind=kind,
-                name=name,
-                namespace=namespace,
-            ),
+        resources_raw = await asyncio.to_thread(
+            k8s_client.describe_resource,
+            api_version=api_version,
+            kind=kind,
+            name=name,
+            namespace=namespace,
         )
-        resources = yaml.dump(resources_raw)
-        events = yaml.dump_all(events_raw)
-
-        context = f"{resources}\n{events}"
+        context = yaml.dump(resources_raw)
 
     else:
         raise Exception("Invalid message provided.")

--- a/src/followup_questions/followup_questions.py
+++ b/src/followup_questions/followup_questions.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 class IFollowUpQuestionsHandler(Protocol):
     """Protocol for IFollowUpQuestionsHandler."""
 
-    def generate_questions(self, messages: list[BaseMessage]) -> list[str]:
+    async def generate_questions(self, messages: list[BaseMessage]) -> list[str]:
         """Generates follow-up questions given the conversation history."""
         ...
 
@@ -60,7 +60,7 @@ class FollowUpQuestionsHandler:
             logger.warning(f"Model '{self._model.name}' not recognized by tiktoken, using cl100k_base encoding")
             self._tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
 
-    def generate_questions(self, messages: list[BaseMessage]) -> list[str]:
+    async def generate_questions(self, messages: list[BaseMessage]) -> list[str]:
         """Generates follow-up questions given the conversation history."""
         if len(messages) == 0:
             return []
@@ -68,7 +68,7 @@ class FollowUpQuestionsHandler:
         # filter down the conversation history to limit the token count.
         history = self._get_filtered_history(messages)
         # invoke the chain to generate follow-up questions.
-        return self._chain.invoke({"history": history})  # type: ignore
+        return await self._chain.ainvoke({"history": history})  # type: ignore
 
     def _get_prompt_template_token_count(self) -> int:
         """Computes the token count of the prompt template."""

--- a/src/initial_questions/inital_questions.py
+++ b/src/initial_questions/inital_questions.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 class IInitialQuestionsHandler(Protocol):
     """Protocol for InitialQuestionsHandler."""
 
-    def generate_questions(self, context: str) -> list[str]:
+    async def generate_questions(self, context: str) -> list[str]:
         """Generates initial questions given a context with cluster data."""
         ...
 
@@ -92,10 +92,10 @@ class InitialQuestionsHandler:
 
         return self._tokenizer.decode(tokens=tokens_text)
 
-    def generate_questions(self, context: str) -> list[str]:
+    async def generate_questions(self, context: str) -> list[str]:
         """Generates initial questions given a context with cluster data."""
         # Format prompt and send to llm.
-        return self._chain.invoke({"context": context})  # type: ignore
+        return await self._chain.ainvoke({"context": context})  # type: ignore
 
     async def fetch_relevant_data_from_k8s_cluster(self, message: Message, k8s_client: IK8sClient) -> str:
         """Fetch the relevant data from Kubernetes cluster based on specified K8s resource in message."""

--- a/src/routers/kyma_tools_api.py
+++ b/src/routers/kyma_tools_api.py
@@ -91,7 +91,7 @@ async def get_resource_version(
     logger.info(f"Resource version request: kind={request.resource_kind}")
 
     try:
-        result = fetch_kyma_resource_version.invoke(
+        result = await fetch_kyma_resource_version.ainvoke(
             {
                 "resource_kind": request.resource_kind,
                 "k8s_client": k8s_client,

--- a/src/routers/probes.py
+++ b/src/routers/probes.py
@@ -57,7 +57,7 @@ class IHana(Protocol):
 
     connection: IHanaConnection
 
-    def is_connection_operational(self) -> bool:
+    async def is_connection_operational(self) -> bool:
         """
         Check if the Hana service is operational.
         """
@@ -104,7 +104,7 @@ class ILLMProbe(Protocol):
     Protocol for probing the readiness of LLMs (Large Language Models).
     """
 
-    def get_llms_states(self) -> dict[str, bool]:
+    async def get_llms_states(self) -> dict[str, bool]:
         """
         Retrieve the readiness states of all LLMs.
 
@@ -137,11 +137,11 @@ async def healthz(
 
     logger.debug("Health probe called.")
     response = HealthModel(
-        is_hana_healthy=hana.is_connection_operational(),
+        is_hana_healthy=await hana.is_connection_operational(),
         is_redis_healthy=await redis.is_connection_operational(),
         is_usage_tracker_healthy=usage_tracker_probe.is_healthy(),
         is_key_store_healthy=KeyStore().is_healthy(),
-        llms=llm_probe.get_llms_states(),
+        llms=await llm_probe.get_llms_states(),
     )
 
     status = HTTP_503_SERVICE_UNAVAILABLE

--- a/src/services/cluster_region.py
+++ b/src/services/cluster_region.py
@@ -6,6 +6,8 @@ Fetches the Runtime CR for a given shoot-id from the local Kubernetes cluster
 in Redis for 3 days.
 """
 
+import asyncio
+import functools
 from http import HTTPStatus
 
 from kubernetes import client, config, dynamic
@@ -95,14 +97,17 @@ async def get_cluster_region(shoot_id: str) -> ClusterRegionResponse:
     # --- Fetch from KCP ---
     logger.info(f"Cache miss for shoot_id={shoot_id}, fetching Runtime CR")
     try:
-        dynamic_client = _get_dynamic_client()
+        dynamic_client = await asyncio.to_thread(_get_dynamic_client)
         resource_api = dynamic_client.resources.get(
             api_version=f"{_RUNTIME_GROUP}/{_RUNTIME_VERSION}",
             kind="Runtime",
         )
-        result = resource_api.get(
-            namespace=_KCP_NAMESPACE,
-            label_selector=f"{_LABEL_SHOOT_NAME}={shoot_id}",
+        result = await asyncio.to_thread(
+            functools.partial(
+                resource_api.get,
+                namespace=_KCP_NAMESPACE,
+                label_selector=f"{_LABEL_SHOOT_NAME}={shoot_id}",
+            )
         )
     except ApiException as e:
         logger.exception(f"Kubernetes API error fetching Runtime CR for shoot_id={shoot_id}")

--- a/src/services/cluster_region.py
+++ b/src/services/cluster_region.py
@@ -98,9 +98,12 @@ async def get_cluster_region(shoot_id: str) -> ClusterRegionResponse:
     logger.info(f"Cache miss for shoot_id={shoot_id}, fetching Runtime CR")
     try:
         dynamic_client = await asyncio.to_thread(_get_dynamic_client)
-        resource_api = dynamic_client.resources.get(
-            api_version=f"{_RUNTIME_GROUP}/{_RUNTIME_VERSION}",
-            kind="Runtime",
+        resource_api = await asyncio.to_thread(
+            functools.partial(
+                dynamic_client.resources.get,
+                api_version=f"{_RUNTIME_GROUP}/{_RUNTIME_VERSION}",
+                kind="Runtime",
+            )
         )
         result = await asyncio.to_thread(
             functools.partial(

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -120,7 +120,7 @@ class ConversationService(metaclass=SingletonMeta):
         k8s_context = self._init_questions_handler.apply_token_limit(k8s_context, TOKEN_LIMIT)
 
         # Pass the context to the initial question handler to generate the questions.
-        questions = self._init_questions_handler.generate_questions(context=k8s_context)
+        questions = await self._init_questions_handler.generate_questions(context=k8s_context)
 
         return questions
 
@@ -132,7 +132,7 @@ class ConversationService(metaclass=SingletonMeta):
         # Fetch the conversation history from the LangGraph.
         messages = await self._companion_graph.aget_messages(conversation_id)
         # Generate follow-up questions based on the conversation history.
-        return self._followup_questions_handler.generate_questions(messages=messages)
+        return await self._followup_questions_handler.generate_questions(messages=messages)
 
     async def handle_request(
         self, conversation_id: str, message: Message, k8s_client: IK8sClient

--- a/src/services/hana.py
+++ b/src/services/hana.py
@@ -30,8 +30,10 @@ class Hana(metaclass=SingletonMeta):
     _last_health_check: datetime | None = None
     _last_health_state: bool = False
     _health_check_ttl: timedelta = timedelta(seconds=HANA_HEALTH_CHECK_CACHE_TTL_SECONDS)
+    _lock: asyncio.Lock
 
     def __init__(self, connection_factory: Callable[[], dbapi.Connection] | None = None) -> None:
+        self._lock = asyncio.Lock()
         try:
             self.connection = connection_factory() if connection_factory else _get_hana_connection()
         except dbapi.Error:
@@ -52,36 +54,37 @@ class Hana(metaclass=SingletonMeta):
         Returns:
             bool: True if HANA is ready, False otherwise.
         """
-        # Return cached state if last check was within TTL
-        now = datetime.now()
-        if self._last_health_check and (now - self._last_health_check) < self._health_check_ttl:
-            logger.debug(f"Returning cached HANA health state: {self._last_health_state}")
-            return self._last_health_state
+        async with self._lock:
+            # Return cached state if last check was within TTL
+            now = datetime.now()
+            if self._last_health_check and (now - self._last_health_check) < self._health_check_ttl:
+                logger.debug(f"Returning cached HANA health state: {self._last_health_state}")
+                return self._last_health_state
 
-        # Perform actual health check
-        if not self.connection:
-            logger.warning("HANA DB connection is not initialized.")
-            self._last_health_check = now
-            self._last_health_state = False
-            return False
+            # Perform actual health check
+            if not self.connection:
+                logger.warning("HANA DB connection is not initialized.")
+                self._last_health_check = now
+                self._last_health_state = False
+                return False
 
-        try:
+            try:
 
-            def _run_query() -> None:
-                with self.connection.cursor() as cursor:
-                    cursor.execute("SELECT 1 FROM DUMMY")
-                    cursor.fetchone()
+                def _run_query() -> None:
+                    with self.connection.cursor() as cursor:
+                        cursor.execute("SELECT 1 FROM DUMMY")
+                        cursor.fetchone()
 
-            await asyncio.to_thread(_run_query)
-            logger.debug("HANA DB connection is ready.")
-            self._last_health_check = now
-            self._last_health_state = True
-            return True
-        except Exception:
-            logger.exception("Error while connecting to HANA DB.")
-            self._last_health_check = now
-            self._last_health_state = False
-            return False
+                await asyncio.to_thread(_run_query)
+                logger.debug("HANA DB connection is ready.")
+                self._last_health_check = now
+                self._last_health_state = True
+                return True
+            except Exception:
+                logger.exception("Error while connecting to HANA DB.")
+                self._last_health_check = now
+                self._last_health_state = False
+                return False
 
     def has_connection(self) -> bool:
         """Check if a connection exists."""

--- a/src/services/hana.py
+++ b/src/services/hana.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Callable
 from datetime import datetime, timedelta
 
@@ -40,7 +41,7 @@ class Hana(metaclass=SingletonMeta):
             logger.exception("Unknown error occurred.")
             self.connection = None
 
-    def is_connection_operational(self) -> bool:
+    async def is_connection_operational(self) -> bool:
         """
         Check if the HANA database is ready by executing a test query.
 
@@ -65,9 +66,13 @@ class Hana(metaclass=SingletonMeta):
             return False
 
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute("SELECT 1 FROM DUMMY")
-                cursor.fetchone()
+
+            def _run_query() -> None:
+                with self.connection.cursor() as cursor:
+                    cursor.execute("SELECT 1 FROM DUMMY")
+                    cursor.fetchone()
+
+            await asyncio.to_thread(_run_query)
             logger.debug("HANA DB connection is ready.")
             self._last_health_check = now
             self._last_health_state = True

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -680,8 +680,12 @@ class K8sClient:
 
         # Try to get pod description (which includes events) and statuses
         try:
-            pod_description = self.describe_resource(
-                api_version="v1", kind=K8sResourceKind.POD, name=name, namespace=namespace
+            pod_description = await asyncio.to_thread(
+                self.describe_resource,
+                api_version="v1",
+                kind=K8sResourceKind.POD,
+                name=name,
+                namespace=namespace,
             )
 
             if pod_description:
@@ -700,7 +704,7 @@ class K8sClient:
         except Exception:
             # Pod doesn't exist or can't be accessed - try to get events directly
             try:
-                events = self._format_pod_events_for_diagnostic(name, namespace, tail_limit)
+                events = await asyncio.to_thread(self._format_pod_events_for_diagnostic, name, namespace, tail_limit)
             except Exception:
                 events = "No pod events available"
 

--- a/src/services/probes.py
+++ b/src/services/probes.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Callable
 
 from langchain_core.embeddings import Embeddings
@@ -51,7 +52,7 @@ class LLMProbe(metaclass=SingletonMeta):
         """
         return bool(self._models) and len(self._models or {}) > 0
 
-    def are_llms_ready(self) -> bool:
+    async def are_llms_ready(self) -> bool:
         """
         Check if all LLMs (Large Language Models) are ready.
         Once a model is successfully checked, it will not be checked again
@@ -72,15 +73,15 @@ class LLMProbe(metaclass=SingletonMeta):
                 continue
 
             try:
-                # Check if the model is an implementation of IModel or an embedding and test accordingly,
-                # if they are operational.
-
                 logger.info(
                     f"Invoking the mode: {name} to check its accessibility. "
                     f"This should only be done once. If you see this log message multiple "
                     f"times, please open a bug report."
                 )
-                response = model.invoke("Test.") if isinstance(model, IModel) else model.embed_query("Test.")
+                if isinstance(model, IModel):
+                    response = await asyncio.to_thread(model.invoke, "Test.")
+                else:
+                    response = await asyncio.to_thread(model.embed_query, "Test.")
                 # If we got a response, we will store the state of the corresponding model.
                 self._model_states[name] = bool(response)
                 if response:
@@ -96,7 +97,7 @@ class LLMProbe(metaclass=SingletonMeta):
 
         return all_ready
 
-    def get_llms_states(self) -> dict[str, bool]:
+    async def get_llms_states(self) -> dict[str, bool]:
         """
         Get the readiness states of all LLMs.
 
@@ -104,7 +105,7 @@ class LLMProbe(metaclass=SingletonMeta):
             dict[str, bool]: A dictionary where keys are LLM names and values
             are their readiness states.
         """
-        self.are_llms_ready()
+        await self.are_llms_ready()
         return self._model_states or {}
 
     @classmethod

--- a/src/services/probes.py
+++ b/src/services/probes.py
@@ -23,6 +23,7 @@ class LLMProbe(metaclass=SingletonMeta):
 
     _models: dict[str, IModel | Embeddings]
     _model_states: dict[str, bool]
+    _lock: asyncio.Lock
 
     def __init__(self, model_factory: Callable[[], dict[str, IModel | Embeddings]] | None = None) -> None:
         """
@@ -34,6 +35,7 @@ class LLMProbe(metaclass=SingletonMeta):
                 created using the ModelFactory.
         """
         logger.info("Creating new LLM readiness probe")
+        self._lock = asyncio.Lock()
 
         try:
             self._models = model_factory() if model_factory else _get_models()
@@ -61,41 +63,42 @@ class LLMProbe(metaclass=SingletonMeta):
         Returns:
             bool: True if all LLMs are ready, False otherwise.
         """
-        if not self._models or not self._model_states:
-            logger.warning("No models available for readiness check.")
-            return False
+        async with self._lock:
+            if not self._models or not self._model_states:
+                logger.warning("No models available for readiness check.")
+                return False
 
-        all_ready = True
-        for name, model in self._models.items():
-            # If the current model already is ready, we will not check the state again.
-            if self._model_states.get(name, False):
-                logger.debug(f"{name} connection is ready.")
-                continue
+            all_ready = True
+            for name, model in self._models.items():
+                # If the current model already is ready, we will not check the state again.
+                if self._model_states.get(name, False):
+                    logger.debug(f"{name} connection is ready.")
+                    continue
 
-            try:
-                logger.info(
-                    f"Invoking the mode: {name} to check its accessibility. "
-                    f"This should only be done once. If you see this log message multiple "
-                    f"times, please open a bug report."
-                )
-                if isinstance(model, IModel):
-                    response = await asyncio.to_thread(model.invoke, "Test.")
-                else:
-                    response = await asyncio.to_thread(model.embed_query, "Test.")
-                # If we got a response, we will store the state of the corresponding model.
-                self._model_states[name] = bool(response)
-                if response:
-                    logger.info(f"{name} connection is ready.")
-                else:
-                    logger.warning(f"{name} connection is not working.")
-                    # If any model is not ready, we will return `False`, eventually.
+                try:
+                    logger.info(
+                        f"Invoking the mode: {name} to check its accessibility. "
+                        f"This should only be done once. If you see this log message multiple "
+                        f"times, please open a bug report."
+                    )
+                    if isinstance(model, IModel):
+                        response = await asyncio.to_thread(model.invoke, "Test.")
+                    else:
+                        response = await asyncio.to_thread(model.embed_query, "Test.")
+                    # If we got a response, we will store the state of the corresponding model.
+                    self._model_states[name] = bool(response)
+                    if response:
+                        logger.info(f"{name} connection is ready.")
+                    else:
+                        logger.warning(f"{name} connection is not working.")
+                        # If any model is not ready, we will return `False`, eventually.
+                        all_ready = False
+
+                except Exception:
+                    logger.exception(f"{name} connection has an error")
                     all_ready = False
 
-            except Exception:
-                logger.exception(f"{name} connection has an error")
-                all_ready = False
-
-        return all_ready
+            return all_ready
 
     async def get_llms_states(self) -> dict[str, bool]:
         """

--- a/tests/unit/followup_questions/test_followup_questions.py
+++ b/tests/unit/followup_questions/test_followup_questions.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import tiktoken
@@ -46,7 +46,8 @@ class TestFollowUpQuestionsHandler:
         "followup_questions.followup_questions.FollowUpQuestionsHandler.__init__",
         return_value=None,
     )
-    def test_generate_questions(self, mock, dummy_conversation_history):
+    @pytest.mark.asyncio
+    async def test_generate_questions(self, mock, dummy_conversation_history):
         """Test generate_questions method."""
         # given
         # initialize FollowUpQuestionsHandler instance.
@@ -56,18 +57,18 @@ class TestFollowUpQuestionsHandler:
         filtered_history = dummy_conversation_history[:2]
         given_handler._get_filtered_history = Mock(return_value=filtered_history)
 
-        # define mock for _chain.invoke method.
+        # define mock for _chain.ainvoke method.
         given_handler._chain = Mock()
         dummy_questions = ["question1", "question2", "question3"]
-        given_handler._chain.invoke = Mock(return_value=dummy_questions)
+        given_handler._chain.ainvoke = AsyncMock(return_value=dummy_questions)
 
         # when
-        got_questions = given_handler.generate_questions(dummy_conversation_history)
+        got_questions = await given_handler.generate_questions(dummy_conversation_history)
 
         # then
         assert got_questions == dummy_questions
         given_handler._get_filtered_history.assert_called_once_with(dummy_conversation_history)
-        given_handler._chain.invoke.assert_called_once_with({"history": filtered_history})
+        given_handler._chain.ainvoke.assert_called_once_with({"history": filtered_history})
 
     @patch(
         "followup_questions.followup_questions.FollowUpQuestionsHandler.__init__",

--- a/tests/unit/initial_questions/test_initial_questions.py
+++ b/tests/unit/initial_questions/test_initial_questions.py
@@ -45,26 +45,27 @@ def test_apply_token_limit():
     "initial_questions.inital_questions.InitialQuestionsHandler.__init__",
     return_value=None,
 )
-def test_generate_questions(mock_init):
+@pytest.mark.asyncio
+async def test_generate_questions(mock_init):
     # The purpose of this test to verify that the generate_questions method
-    # calls the chain.invoke method with the correct context.
+    # calls the chain.ainvoke method with the correct context.
 
     # Given:
     given_context = "This is a sample context with k8s data"
     expected_output = "question1\nquestion2\nquestion3"
 
     class MockChain:
-        def invoke(self, inputs: dict):
+        async def ainvoke(self, inputs: dict):
             if inputs["context"] == given_context:
                 return expected_output
             raise ValueError("context was not passed correctly")
 
     given_handler = InitialQuestionsHandler(model=Mock())
 
-    # Mock the invoke method.
+    # Mock the ainvoke method.
     given_handler._chain = MockChain()
     # When:
-    result = given_handler.generate_questions(given_context)
+    result = await given_handler.generate_questions(given_context)
 
     # Then:
     assert result == expected_output

--- a/tests/unit/initial_questions/test_initial_questions.py
+++ b/tests/unit/initial_questions/test_initial_questions.py
@@ -87,7 +87,7 @@ def mock_k8s_client():
         MOCK_DICT,
     ]
     mock.get_resource.return_value = {KEY: GET_RESOURCE}
-    mock.describe_resource.return_value = {KEY: DESCRIBE_RESOURCE}
+    mock.describe_resource.return_value = {KEY: DESCRIBE_RESOURCE, "events": [{KEY: LIST_K8S_EVENTS_FOR_RESOURCE}]}
     mock.get_data_sanitizer.return_value = None
     return mock
 

--- a/tests/unit/routers/test_kyma_errors.py
+++ b/tests/unit/routers/test_kyma_errors.py
@@ -59,7 +59,7 @@ class TestKymaAPIErrorHandling:
                 "tool_name": "fetch_kyma_resource_version",
                 "handler": get_resource_version,
                 "request": KymaResourceVersionRequest(resource_kind="Function"),
-                "is_async": False,
+                "is_async": True,
             },
         ]
 

--- a/tests/unit/routers/test_probes.py
+++ b/tests/unit/routers/test_probes.py
@@ -77,7 +77,7 @@ def test_healthz_probe(
     """
     # Given:
     mock_hana_conn = MagicMock(spec=IHana)
-    mock_hana_conn.is_connection_operational = MagicMock(return_value=hana_ready)
+    mock_hana_conn.is_connection_operational = AsyncMock(return_value=hana_ready)
     app.dependency_overrides[get_hana] = lambda: mock_hana_conn
 
     mock_redis = MagicMock(spec=IRedis)
@@ -89,7 +89,7 @@ def test_healthz_probe(
     app.dependency_overrides[get_usage_tracker_probe] = lambda: usage_tracker_probe
 
     mock_llm_probe = MagicMock(spec=ILLMProbe)
-    mock_llm_probe.get_llms_states.return_value = llm_states
+    mock_llm_probe.get_llms_states = AsyncMock(return_value=llm_states)
     app.dependency_overrides[get_llm_probe] = lambda: mock_llm_probe
 
     mock_key_store = MagicMock()

--- a/tests/unit/services/test_conversation.py
+++ b/tests/unit/services/test_conversation.py
@@ -107,9 +107,7 @@ class TestConversation:
         mock_handler = Mock()
         mock_handler.fetch_relevant_data_from_k8s_cluster = fetch_relevant_data_from_k8s_cluster_mock
         mock_handler.apply_token_limit = Mock(return_value=k8s_context)
-        mock_handler.generate_questions = Mock(return_value=QUESTIONS)
-
-        # Reset singleton instances to ensure test isolation.
+        mock_handler.generate_questions = AsyncMock(return_value=QUESTIONS)
         ConversationService._instances = {}
         conversation_service = ConversationService(
             config=mock_config,
@@ -150,7 +148,7 @@ class TestConversation:
         ]
         # define mock for FollowUpQuestionsHandler.
         mock_handler = Mock()
-        mock_handler.generate_questions = Mock(return_value=QUESTIONS)
+        mock_handler.generate_questions = AsyncMock(return_value=QUESTIONS)
         # initialize ConversationService instance.
         conversation_service = ConversationService(
             config=mock_config,

--- a/tests/unit/services/test_hana.py
+++ b/tests/unit/services/test_hana.py
@@ -33,7 +33,8 @@ class TestHana:
             ),
         ],
     )
-    def test_is_hana_ready_with_query(self, test_case, cursor_behavior, expected):
+    @pytest.mark.asyncio
+    async def test_is_hana_ready_with_query(self, test_case, cursor_behavior, expected):
         """
         Test the `is_connection_operational` method executes test query.
 
@@ -63,7 +64,7 @@ class TestHana:
 
         # When:
         hana = Hana(connection_factory)
-        result = hana.is_connection_operational()
+        result = await hana.is_connection_operational()
 
         # Then:
         assert result == expected, f"Failed test case: {test_case}"
@@ -80,14 +81,15 @@ class TestHana:
         # Clean up by resetting the instance.
         hana._reset_for_tests()
 
-    def test_is_hana_ready_no_connection(self):
+    @pytest.mark.asyncio
+    async def test_is_hana_ready_no_connection(self):
         """Test that is_connection_operational returns False when no connection."""
         # Given: No connection
         connection_factory = MagicMock(return_value=None)
 
         # When:
         hana = Hana(connection_factory)
-        result = hana.is_connection_operational()
+        result = await hana.is_connection_operational()
 
         # Then:
         assert result is False
@@ -95,14 +97,15 @@ class TestHana:
         # Clean up
         hana._reset_for_tests()
 
-    def test_is_hana_ready_connection_fails_during_init(self):
+    @pytest.mark.asyncio
+    async def test_is_hana_ready_connection_fails_during_init(self):
         """Test that is_connection_operational returns False when connection init fails."""
         # Given: Connection factory that raises exception
         connection_factory = MagicMock(side_effect=Exception("Connection error"))
 
         # When:
         hana = Hana(connection_factory)
-        result = hana.is_connection_operational()
+        result = await hana.is_connection_operational()
 
         # Then:
         assert result is False
@@ -158,7 +161,8 @@ class TestHana:
 
         hana2._reset_for_tests()
 
-    def test_health_check_caching(self):
+    @pytest.mark.asyncio
+    async def test_health_check_caching(self):
         """
         Test that is_connection_operational caches results within TTL.
 
@@ -184,26 +188,27 @@ class TestHana:
         with patch("services.hana.datetime") as mock_datetime:
             # First call - should execute query
             mock_datetime.now.return_value = base_time
-            result1 = hana.is_connection_operational()
+            result1 = await hana.is_connection_operational()
             assert result1 is True
             assert mock_cursor.execute.call_count == 1
 
             # Second call within TTL - should use cache
             mock_datetime.now.return_value = base_time + timedelta(seconds=60)
-            result2 = hana.is_connection_operational()
+            result2 = await hana.is_connection_operational()
             assert result2 is True
             assert mock_cursor.execute.call_count == 1  # Still 1, cache was used
 
             # Third call after TTL expires - should execute query again
             mock_datetime.now.return_value = base_time + timedelta(seconds=301)
-            result3 = hana.is_connection_operational()
+            result3 = await hana.is_connection_operational()
             assert result3 is True
             assert mock_cursor.execute.call_count == expected_query_count_after_cache_expiry
 
         # Clean up
         hana._reset_for_tests()
 
-    def test_health_check_caches_failure_state(self):
+    @pytest.mark.asyncio
+    async def test_health_check_caches_failure_state(self):
         """
         Test that is_connection_operational caches failure state as well.
 
@@ -227,13 +232,13 @@ class TestHana:
         with patch("services.hana.datetime") as mock_datetime:
             # First call - should execute query and fail
             mock_datetime.now.return_value = base_time
-            result1 = hana.is_connection_operational()
+            result1 = await hana.is_connection_operational()
             assert result1 is False
             assert mock_cursor.execute.call_count == 1
 
             # Second call within TTL - should use cached failure state
             mock_datetime.now.return_value = base_time + timedelta(seconds=60)
-            result2 = hana.is_connection_operational()
+            result2 = await hana.is_connection_operational()
             assert result2 is False
             assert mock_cursor.execute.call_count == 1  # Still 1, cache was used
 

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -1957,6 +1957,42 @@ class TestK8sClient:
             assert result.diagnostic_context is not None
             assert "nginx" in result.diagnostic_context.container_statuses
 
+    @pytest.mark.asyncio
+    async def test_gather_pod_diagnostic_context_structured_fallback(self, k8s_client):
+        """Test that when describe_resource raises, the fallback to _format_pod_events_for_diagnostic is used."""
+        k8s_client.data_sanitizer = None
+
+        fallback_events = "event1\nevent2"
+        k8s_client.describe_resource = Mock(side_effect=Exception("pod not found"))
+        k8s_client._format_pod_events_for_diagnostic = Mock(return_value=fallback_events)
+
+        has_useful_info, diagnostic_context = await k8s_client._gather_pod_diagnostic_context_structured(
+            name="missing-pod", namespace="default", container_name="app", tail_limit=20
+        )
+
+        assert has_useful_info is True
+        assert diagnostic_context is not None
+        assert diagnostic_context.events == fallback_events
+        assert diagnostic_context.container_statuses is None
+        assert diagnostic_context.init_container_statuses is None
+        k8s_client._format_pod_events_for_diagnostic.assert_called_once_with("missing-pod", "default", 20)
+
+    @pytest.mark.asyncio
+    async def test_gather_pod_diagnostic_context_structured_both_fail(self, k8s_client):
+        """Test that when both describe_resource and _format_pod_events_for_diagnostic raise, events is the fallback string."""
+        k8s_client.data_sanitizer = None
+
+        k8s_client.describe_resource = Mock(side_effect=Exception("pod not found"))
+        k8s_client._format_pod_events_for_diagnostic = Mock(side_effect=Exception("events not found"))
+
+        has_useful_info, diagnostic_context = await k8s_client._gather_pod_diagnostic_context_structured(
+            name="missing-pod", namespace="default", container_name="app", tail_limit=20
+        )
+
+        assert has_useful_info is False
+        assert diagnostic_context is not None
+        assert diagnostic_context.events == "No pod events available"
+
 
 class TestParseContainerState:
     """Test _parse_container_state helper method."""

--- a/tests/unit/services/test_probes.py
+++ b/tests/unit/services/test_probes.py
@@ -60,7 +60,8 @@ class TestLLMReadinessProbe:
             ),
         ],
     )
-    def test_llm_readiness_probe(
+    @pytest.mark.asyncio
+    async def test_llm_readiness_probe(
         self,
         test_case,
         model_factory,
@@ -83,13 +84,14 @@ class TestLLMReadinessProbe:
 
         # Then:
         assert probe.has_models() == expected_has_models, test_case
-        assert probe.are_llms_ready() == expected_are_llms_ready, test_case
-        assert probe.get_llms_states() == expected_states, test_case
+        assert await probe.are_llms_ready() == expected_are_llms_ready, test_case
+        assert await probe.get_llms_states() == expected_states, test_case
 
         # Clean up by resetting the instance:
         LLMProbe()._reset_for_tests()
 
-    def test_llm_readiness_probe_model_tested_once(self):
+    @pytest.mark.asyncio
+    async def test_llm_readiness_probe_model_tested_once(self):
         """
         Test the readiness probe for LLMs ensures that models are tested only once, if they return readiness.
 
@@ -112,7 +114,7 @@ class TestLLMReadinessProbe:
 
         # When:
         # Call `are_llms_ready` to evaluate the readiness of the models.
-        overall_state = probe.are_llms_ready()
+        overall_state = await probe.are_llms_ready()
 
         # Then:
         # The overall state should match the model's state.
@@ -124,7 +126,7 @@ class TestLLMReadinessProbe:
 
         # When:
         # Call `are_llms_ready` again.
-        overall_state = probe.are_llms_ready()
+        overall_state = await probe.are_llms_ready()
 
         # Then:
         # The overall state should still match the model's state.

--- a/tests/unit/utils/test_src_utils.py
+++ b/tests/unit/utils/test_src_utils.py
@@ -386,6 +386,24 @@ async def test_cluster_overview_sanitization(mock_k8s_client, input_context, exp
         assert pattern not in result, f"Sensitive data '{pattern}' should be redacted"
 
 
+@pytest.mark.asyncio
+async def test_cluster_overview_all_three_calls_made(mock_k8s_client):
+    """All three concurrent gather arms are actually invoked for the cluster-overview path."""
+    message = Message(
+        query="test",
+        namespace="",
+        resource_kind="cluster",
+        resource_name="",
+        resource_api_version="",
+    )
+
+    await get_relevant_context_from_k8s_cluster(message, mock_k8s_client)
+
+    mock_k8s_client.list_not_running_pods.assert_called_once_with(namespace="")
+    mock_k8s_client.list_nodes_metrics.assert_called_once()
+    mock_k8s_client.list_k8s_warning_events.assert_called_once_with(namespace="")
+
+
 @pytest.mark.parametrize(
     "input_context,expected_patterns",
     [


### PR DESCRIPTION
**Description**

- Replace `fetch_kyma_resource_version.invoke()` with `ainvoke()` in the `/resource-version` endpoint (sibling `/query` already used `ainvoke`)
- Make `generate_questions()` async in `InitialQuestionsHandler` and `FollowUpQuestionsHandler` (and their protocols); replace `chain.invoke()` with `await chain.ainvoke()`; propagate `await` to callers in `ConversationService`
- Wrap four sync kubernetes-client calls in `agents/common/utils.py` with `asyncio.to_thread()`; fan out the three independent cluster-overview fetches concurrently with `asyncio.gather()`
- Wrap sync `DynamicClient` calls in `K8sClient._gather_pod_diagnostic_context_structured` with `asyncio.to_thread()`
- Wrap `_get_dynamic_client()` and `resource_api.get()` in `services/cluster_region.py` with `asyncio.to_thread()`
- Make `LLMProbe.are_llms_ready()` and `get_llms_states()` async; replace `model.invoke()` / `model.embed_query()` with `asyncio.to_thread()` equivalents; update `ILLMProbe` protocol and `healthz` caller
- Make `Hana.is_connection_operational()` async; wrap the blocking HANA cursor call with `asyncio.to_thread()`; update `IHana` protocol and `healthz` caller

**Related issue(s)**

**Testing**

- Updated unit tests for all changed methods to use `@pytest.mark.asyncio` / `AsyncMock` where required -- all 1125 unit tests pass