### PR TITLE
test: fix placeholder expected output in kyma agent test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -754,9 +754,10 @@ async def test_invoke_chain(
                 remaining_steps=AGENT_STEPS_NUMBER,
             ),  # context
             None,  # retrieval_context
-            """I encountered an error while retrieving the information about the Function 'func1' in the namespace 'kyma-app-serverless-syntax-err'. Unfortunately, I was unable to access the necessary tools to diagnose the issue directly.
-
-<SOME TROUBLESHOOTING TIPS HERE>""",  # expected_result
+            "I encountered an error while retrieving the information about the Function 'func1' in the namespace "
+            "'kyma-app-serverless-syntax-err'. Unfortunately, I was unable to access the necessary tools to diagnose "
+            "the issue directly. I cannot complete this request at this time due to repeated tool failures. "
+            "Please try again later or seek help from the Kyma community or support channels.",  # expected_result
             None,  # expected_tool_call
             False,  # should_raise
         ),


### PR DESCRIPTION
## Description

Fixes an incomplete placeholder `<SOME TROUBLESHOOTING TIPS HERE>` used as the `expected_result` in the "Should not retry tool calling as already failed multiple times" test case in `test_kyma_agent.py`.

GEval was scoring an actual LLM response against an intentionally incomplete string, producing unreliable and meaningless scores. The placeholder has been replaced with a proper expected output that describes the agent indicating it cannot complete the task and suggesting the user seek help from Kyma community or support channels.

Also includes a minor `pyproject.toml` change from `poetry sort` (alphabetical reordering of `a2a-sdk`).

## Related issue(s)

N/A

**Testing**

- `pre-commit-check` passes (lint, typecheck, format, unit tests all green)
- The updated expected output now accurately reflects what the agent should respond when repeated tool failures occur, making GEval scores meaningful for this test case