### PR TITLE
test: fix event loop closed errors in async GEval tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/common/test_chunk_summarization.py
+++ b/tests/integration/agents/common/test_chunk_summarization.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 from langchain_core.runnables import RunnableConfig
@@ -13,6 +12,7 @@ from integration.agents.fixtures.k8_query_tool_response import (
     sample_pods_tool_response,
     sample_services_tool_response,
 )
+from integration.conftest import async_assert_test
 from utils.settings import MAIN_MODEL_NAME
 
 
@@ -176,4 +176,4 @@ async def test_summarize_tool_response_integration(
         actual_output=generated_summary,
     )
 
-    assert_test(llm_test_case, [tool_response_summarization_metric])
+    await async_assert_test(llm_test_case, [tool_response_summarization_metric])

--- a/tests/integration/agents/k8s/test_k8s_agent.py
+++ b/tests/integration/agents/k8s/test_k8s_agent.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import (
     FaithfulnessMetric,
     GEval,
@@ -12,6 +11,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from agents.common.state import SubTask
 from agents.k8s.agent import KubernetesAgent
 from agents.k8s.state import KubernetesAgentState
+from integration.conftest import async_assert_test
 from services.k8s import IK8sClient
 from utils.settings import DEEPEVAL_TESTCASE_VERBOSE, MAIN_MODEL_NAME
 
@@ -131,7 +131,7 @@ async def test_invoke_chain(
             retrieval_context=([retrieval_context] if retrieval_context else []),
         )
         # evaluate if the gotten response is semantically similar and faithful to the expected response
-        assert_test(test_case, [correctness_metric, faithfulness_metric]), test_case
+        await async_assert_test(test_case, [correctness_metric, faithfulness_metric])
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import (
     FaithfulnessMetric,
     GEval,
@@ -30,6 +29,7 @@ from integration.agents.fixtures.serverless_function import (
     KYMADOC_FUNCTION_TROUBLESHOOTING,
     SERVERLESS_FUNCTION_WITH_SYNTAX_ERROR,
 )
+from integration.conftest import async_assert_test
 from services.k8s import IK8sClient
 from utils.settings import DEEPEVAL_TESTCASE_VERBOSE
 
@@ -665,7 +665,7 @@ async def test_invoke_chain(
                 retrieval_context=([retrieval_context] if retrieval_context else []),
             )
             # evaluate if the gotten response is semantically similar and faithful to the expected response
-            assert_test(test_case, [correctness_metric, faithfulness_metric])
+            await async_assert_test(test_case, [correctness_metric, faithfulness_metric])
 
 
 @pytest.mark.parametrize(
@@ -956,4 +956,4 @@ async def test_tool_calling(
                 retrieval_context=([retrieval_context] if retrieval_context else []),
             )
             # evaluate if the gotten response is semantically similar and faithful to the expected response
-            assert_test(test_case, [correctness_metric, faithfulness_metric])
+            await async_assert_test(test_case, [correctness_metric, faithfulness_metric])

--- a/tests/integration/agents/summarization/test_summarization.py
+++ b/tests/integration/agents/summarization/test_summarization.py
@@ -1,5 +1,4 @@
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import (
     LLMTestCase,
@@ -17,6 +16,7 @@ from integration.agents.fixtures.messages import (
     conversation_sample_3,
     conversation_sample_4,
 )
+from integration.conftest import async_assert_test
 from utils.settings import MAIN_MODEL_MINI_NAME, MAIN_MODEL_NAME
 
 
@@ -87,4 +87,4 @@ async def test_get_summary(
         actual_output=generated_summary,
     )
 
-    assert_test(test_case, [summarization_metric])
+    await async_assert_test(test_case, [summarization_metric])

--- a/tests/integration/agents/supervisor/test_finalizer.py
+++ b/tests/integration/agents/supervisor/test_finalizer.py
@@ -1,11 +1,11 @@
 from textwrap import dedent
 
 import pytest
-from deepeval import assert_test
 from deepeval.test_case.llm_test_case import LLMTestCase
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from integration.agents.test_common_node import create_mock_state
+from integration.conftest import async_assert_test
 
 
 @pytest.mark.parametrize(
@@ -506,4 +506,4 @@ async def test_generate_final_response(test_case, messages, expected_answer, com
         expected_output=expected_answer,
     )
 
-    assert_test(test_case, [goal_accuracy_metric]), test_case
+    await async_assert_test(test_case, [goal_accuracy_metric])

--- a/tests/integration/agents/supervisor/test_finalizer_security.py
+++ b/tests/integration/agents/supervisor/test_finalizer_security.py
@@ -1,11 +1,11 @@
 from textwrap import dedent
 
 import pytest
-from deepeval import assert_test
 from deepeval.test_case.llm_test_case import LLMTestCase
 from langchain_core.messages import AIMessage, HumanMessage
 
 from integration.agents.test_common_node import create_mock_state
+from integration.conftest import async_assert_test
 
 
 @pytest.mark.parametrize(
@@ -217,4 +217,4 @@ async def test_generate_final_response(messages, expected_answer, companion_grap
         expected_output=expected_answer,
     )
 
-    assert_test(test_case, [security_metric])
+    await async_assert_test(test_case, [security_metric])

--- a/tests/integration/agents/supervisor/test_planner.py
+++ b/tests/integration/agents/supervisor/test_planner.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -9,7 +8,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from integration.agents.fixtures.messages import (
     conversation_sample_6,
 )
-from integration.conftest import convert_dict_to_messages, create_mock_state
+from integration.conftest import async_assert_test, convert_dict_to_messages, create_mock_state
 
 
 # Correctness metric for not general queries that needs planning
@@ -269,7 +268,7 @@ async def test_invoke_planner(
             expected_output=expected_answer,
         )
 
-        assert_test(test_case, [planner_correctness_metric(threshold)])
+        await async_assert_test(test_case, [planner_correctness_metric(threshold)])
     else:
         # For general queries, check answer relevancy where planner directly answers
         # Then: We evaluate the response using deepeval metrics
@@ -280,7 +279,7 @@ async def test_invoke_planner(
             expected_output=expected_answer,
         )
 
-        assert_test(test_case, [answer_relevancy_metric])
+        await async_assert_test(test_case, [answer_relevancy_metric])
 
 
 @pytest.fixture
@@ -369,4 +368,4 @@ async def test_planner_with_conversation_history(
         expected_output=str(expected_subtasks),
     )
 
-    assert_test(test_case, [planner_conversation_history_metric(threshold)])
+    await async_assert_test(test_case, [planner_conversation_history_metric(threshold)])

--- a/tests/integration/agents/test_common_node.py
+++ b/tests/integration/agents/test_common_node.py
@@ -1,9 +1,8 @@
 import pytest
-from deepeval import assert_test
 from deepeval.test_case import LLMTestCase
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from integration.conftest import create_mock_state
+from integration.conftest import async_assert_test, create_mock_state
 
 
 @pytest.mark.parametrize(
@@ -44,4 +43,4 @@ async def test_invoke_common_node(messages, expected_answer, companion_graph, an
         actual_output=result,
         expected_output=expected_answer,
     )
-    assert_test(test_case, [answer_relevancy_metric])
+    await async_assert_test(test_case, [answer_relevancy_metric])

--- a/tests/integration/agents/test_followup_questions.py
+++ b/tests/integration/agents/test_followup_questions.py
@@ -32,6 +32,11 @@ def followup_correctness_metric(evaluator_model):
         ],
         model=evaluator_model,
         threshold=0.5,
+        # async_mode=False ensures deepeval executes this metric synchronously inside
+        # a_execute_test_cases.  This is the per-metric equivalent of the old
+        # run_async=False argument that was previously passed to assert_test at the
+        # call site.  The two settings are equivalent: a_execute_test_cases respects
+        # each metric's async_mode flag, so no separate run_async guard is needed.
         async_mode=False,
     )
 

--- a/tests/integration/agents/test_followup_questions.py
+++ b/tests/integration/agents/test_followup_questions.py
@@ -2,7 +2,6 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -10,6 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.types import StateSnapshot
 
 from followup_questions.followup_questions import FollowUpQuestionsHandler
+from integration.conftest import async_assert_test
 from services.conversation import ConversationService
 from utils.settings import MAIN_MODEL_MINI_NAME
 
@@ -129,4 +129,4 @@ async def test_followup_questions(messages, conversation_service, followup_corre
         input=messages[-1].content,
         actual_output=got_questions,
     )
-    assert_test(test_case, [followup_correctness_metric], run_async=False)
+    await async_assert_test(test_case, [followup_correctness_metric])

--- a/tests/integration/agents/test_gatekeeper_node.py
+++ b/tests/integration/agents/test_gatekeeper_node.py
@@ -1,5 +1,4 @@
 import pytest
-from deepeval import assert_test
 from deepeval.test_case.llm_test_case import LLMTestCase
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
@@ -9,7 +8,7 @@ from integration.agents.fixtures.messages import (
     conversation_sample_6,
     conversation_sample_7,
 )
-from integration.conftest import convert_dict_to_messages, create_mock_state
+from integration.conftest import async_assert_test, convert_dict_to_messages, create_mock_state
 
 
 @pytest.mark.parametrize(
@@ -419,7 +418,7 @@ async def test_invoke_gatekeeper_node(
             actual_output=actual_response.direct_response,
             expected_output=expected_answer,
         )
-        assert_test(test_case, [goal_accuracy_metric])
+        await async_assert_test(test_case, [goal_accuracy_metric])
 
 
 @pytest.mark.parametrize(
@@ -810,4 +809,4 @@ async def test_gatekeeper_with_conversation_history(
             actual_output=result.direct_response,
             expected_output=expected_answer,
         )
-        assert_test(test_case, [goal_accuracy_metric])
+        await async_assert_test(test_case, [goal_accuracy_metric])

--- a/tests/integration/agents/test_gatekeeper_security.py
+++ b/tests/integration/agents/test_gatekeeper_security.py
@@ -1,10 +1,9 @@
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from integration.conftest import create_mock_state
+from integration.conftest import async_assert_test, create_mock_state
 
 
 # Correctness metric for not general queries that needs planning
@@ -247,4 +246,4 @@ async def test_gatekeeper_security(
         actual_output=actual_response.direct_response,
         expected_output=expected_answer,
     )
-    assert_test(test_case, [gatekeeper_correctness_metric])
+    await async_assert_test(test_case, [gatekeeper_correctness_metric])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,14 @@ if "langchain_community.chat_models.vertexai" not in sys.modules:
     sys.modules["langchain_community.chat_models.vertexai"] = _stub
 
 import pytest
+
+# deepeval internal API usage notice:
+# The imports below (deepeval.evaluate.execute.a_execute_test_cases and
+# deepeval.evaluate.configs.*) are not part of deepeval's public API.  They were
+# verified against deepeval==4.0.7.  deepeval is pinned to ^4.0.7 in pyproject.toml,
+# which allows 4.x minor upgrades.  If deepeval is upgraded and these imports break,
+# update this wrapper to match the new internal API or propose an upstream
+# async_assert_test to avoid relying on internals.
 from deepeval.evaluate.configs import AsyncConfig, CacheConfig, DisplayConfig, ErrorConfig
 from deepeval.evaluate.execute import a_execute_test_cases
 from deepeval.metrics import AnswerRelevancyMetric, GEval
@@ -104,6 +112,17 @@ async def async_assert_test(
     event loop (via nest_asyncio), which then leaves cleanup coroutines pending.
     When pytest tears down the loop those coroutines raise "event loop is closed"
     errors. Awaiting a_execute_test_cases() directly avoids that problem entirely.
+
+    Note on run_async=False callers: some tests previously passed run_async=False to
+    assert_test to suppress async metric execution.  Those tests now use async_mode=False
+    on the GEval fixture itself, which controls per-metric execution inside deepeval and is
+    sufficient: a_execute_test_cases respects each metric's async_mode flag, so setting it
+    to False on the fixture is equivalent to the old run_async=False guard at the call site.
+
+    Note on cache_config: write_cache is tied to get_is_running_deepeval() (True only when
+    tests are invoked via deepeval's own CLI runner, not plain pytest).  This replicates
+    deepeval's own internal logic: caching is disabled in normal pytest runs, matching the
+    behaviour of the original assert_test call.
     """
     async_config = AsyncConfig(throttle_value=0, max_concurrent=100)
     display_config = DisplayConfig(verbose_mode=should_verbose_print(), show_indicator=True)
@@ -128,7 +147,13 @@ async def async_assert_test(
     )[0]
 
     if not test_result.success:
-        failed_metrics_data = [md for md in test_result.metrics_data if md.error is not None or not md.success]
+        failed_metrics_data = []
+        for md in test_result.metrics_data:
+            try:
+                if md.error is not None or not md.success:
+                    failed_metrics_data.append(md)
+            except Exception:  # noqa: BLE001
+                failed_metrics_data.append(md)
         failed_metrics_str = ", ".join(
             f"{md.name} (score: {md.score}, threshold: {md.threshold}, "
             f"strict: {md.strict_mode}, error: {md.error}, reason: {md.reason})"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,9 +14,20 @@ if "langchain_community.chat_models.vertexai" not in sys.modules:
     sys.modules["langchain_community.chat_models.vertexai"] = _stub
 
 import pytest
+from deepeval.evaluate.configs import AsyncConfig, CacheConfig, DisplayConfig, ErrorConfig
+from deepeval.evaluate.execute import a_execute_test_cases
 from deepeval.metrics import AnswerRelevancyMetric, GEval
+from deepeval.metrics.base_metric import BaseMetric
 from deepeval.models import DeepEvalBaseLLM
-from deepeval.test_case import LLMTestCaseParams
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+from deepeval.utils import (
+    get_identifier,
+    get_is_running_deepeval,
+    should_ignore_errors,
+    should_skip_on_missing_params,
+    should_use_cache,
+    should_verbose_print,
+)
 from fakeredis import TcpFakeServer
 from langchain_core.messages import (
     AIMessage,
@@ -80,6 +91,50 @@ class LangChainOpenAI(DeepEvalBaseLLM):
 
     def get_model_name(self):
         return "Custom Azure OpenAI Model"
+
+
+async def async_assert_test(
+    test_case: LLMTestCase,
+    metrics: list[BaseMetric],
+) -> None:
+    """Async replacement for deepeval's assert_test.
+
+    Calling the synchronous assert_test() inside an @pytest.mark.asyncio test
+    body causes it to call loop.run_until_complete() on the already-running
+    event loop (via nest_asyncio), which then leaves cleanup coroutines pending.
+    When pytest tears down the loop those coroutines raise "event loop is closed"
+    errors. Awaiting a_execute_test_cases() directly avoids that problem entirely.
+    """
+    async_config = AsyncConfig(throttle_value=0, max_concurrent=100)
+    display_config = DisplayConfig(verbose_mode=should_verbose_print(), show_indicator=True)
+    error_config = ErrorConfig(
+        ignore_errors=should_ignore_errors(),
+        skip_on_missing_params=should_skip_on_missing_params(),
+    )
+    cache_config = CacheConfig(write_cache=get_is_running_deepeval(), use_cache=should_use_cache())
+
+    test_result = (
+        await a_execute_test_cases(
+            [test_case],
+            metrics,
+            error_config=error_config,
+            display_config=display_config,
+            async_config=async_config,
+            cache_config=cache_config,
+            identifier=get_identifier(),
+            _use_bar_indicator=True,
+            _is_assert_test=True,
+        )
+    )[0]
+
+    if not test_result.success:
+        failed_metrics_data = [md for md in test_result.metrics_data if md.error is not None or not md.success]
+        failed_metrics_str = ", ".join(
+            f"{md.name} (score: {md.score}, threshold: {md.threshold}, "
+            f"strict: {md.strict_mode}, error: {md.error}, reason: {md.reason})"
+            for md in failed_metrics_data
+        )
+        raise AssertionError(f"Metrics: {failed_metrics_str} failed.")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/rag/test_query_generator.py
+++ b/tests/integration/rag/test_query_generator.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
+from integration.conftest import async_assert_test
 from rag.query_generator import Queries, QueryGenerator
 from utils.settings import MAIN_MODEL_NAME
 
@@ -93,4 +93,4 @@ async def test_generate_queries(input_query, expected_queries, query_generator, 
         expected_output=expected_json,
     )
 
-    assert_test(test_case, [correctness_metric], run_async=False)
+    await async_assert_test(test_case, [correctness_metric])

--- a/tests/integration/rag/test_rag_system.py
+++ b/tests/integration/rag/test_rag_system.py
@@ -1,11 +1,11 @@
 import pytest
-from deepeval import assert_test
 from deepeval.metrics import (
     ContextualRecallMetric,
     GEval,
 )
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
 
+from integration.conftest import async_assert_test
 from integration.rag.datasets.eventing import cases as eventing_cases
 from integration.rag.datasets.istio import cases as istio_cases
 from integration.rag.datasets.serverless import cases as serverless_cases
@@ -83,4 +83,4 @@ async def test_rag_system(
         expected_output=expected_output,
     )
     # evaluate the test case using deepeval metrics
-    assert_test(test_case, evaluation_metrics)
+    await async_assert_test(test_case, evaluation_metrics)

--- a/tests/integration/rag/test_reranker.py
+++ b/tests/integration/rag/test_reranker.py
@@ -1,13 +1,13 @@
 import os
 
 import pytest
-from deepeval import assert_test
 from deepeval.metrics.contextual_precision.contextual_precision import (
     ContextualPrecisionMetric,
 )
 from deepeval.test_case.llm_test_case import LLMTestCase
 from langchain_core.documents import Document
 
+from integration.conftest import async_assert_test
 from rag.reranker.reranker import (
     LLMReranker,
     format_documents,
@@ -278,7 +278,7 @@ async def test_chain_ainvoke(
     # Assert that the expected documents are in the actual list of documents.
     assert set(expected_docs_titles).issubset(set(actual_docs_titles)), "Expected documents not found in actual output"
     # Assert that the contextual precision is above the threshold.
-    assert_test(test_case, [contextual_precision(threshold)])
+    await async_assert_test(test_case, [contextual_precision(threshold)])
 
 
 def load_docs_in_path(path: str, extension: str, sort: bool = True) -> list[Document]:


### PR DESCRIPTION
## Description

GEval metrics with `async_mode=False` were called synchronously inside `@pytest.mark.asyncio` test bodies. The synchronous executor calls `loop.run_until_complete()` on the already-running event loop (via nest_asyncio), and on teardown the loop is already closed when deepeval tries to clean up -- producing \"Event loop is closed\" CI annotations across integration tests.

Fix: added `async_assert_test()` coroutine to `conftest.py` that directly awaits deepeval's `a_execute_test_cases()` instead of going through `assert_test()`. Replaced all `assert_test()` calls in integration test files with `await async_assert_test()`.

The fix covers all async integration tests across agents (kyma, k8s, supervisor, gatekeeper, summarization, chunk summarization, follow-up questions) and RAG tests (query generator, reranker, RAG system). `pyproject.toml` was sorted alphabetically by poetry sort (pre-commit).

**Testing**

- `pre-commit-check` passed (sort, lint, typecheck, format, unit tests all green)
- Replaced 15 `assert_test()` call sites with `await async_assert_test()` -- no functional logic changed, only the async dispatch path