### PR TITLE
test: fix module-import-time cluster client construction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -32,9 +32,9 @@ class KymaAgentTestCase:
 
     name: str
     state: KymaAgentState
-    expected_tool_calls: list[ToolCall] = None
-    expected_response: str = None
-    expected_goal: str = None
+    expected_tool_calls: list[ToolCall] | None = None
+    expected_response: str | None = None
+    expected_goal: str | None = None
     should_raise: bool = False
 
 
@@ -68,7 +68,7 @@ def k8s_client(k8s_client_session: IK8sClient) -> IK8sClient:
 
 
 @pytest.fixture
-def kyma_agent(app_models):
+def kyma_agent(app_models) -> KymaAgent:
     """Create a KymaAgent instance."""
     return KymaAgent(app_models)
 
@@ -160,7 +160,7 @@ def create_test_cases(k8s_client: IK8sClient) -> list[KymaAgentTestCase]:
             expected_goal="Agent response should explain that user query is very broad and ask user to provide specific details",
         ),
         KymaAgentTestCase(
-            "Should ask more information from user for queries about all Kyma resources in cluster",
+            "Should ask more information -- check all Kyma resources",
             state=create_basic_state(
                 task_description="check all Kyma resources",
                 messages=[
@@ -182,7 +182,7 @@ def create_test_cases(k8s_client: IK8sClient) -> list[KymaAgentTestCase]:
             expected_goal="Agent response should explain that user query is very broad and ask user to provide specific details",
         ),
         KymaAgentTestCase(
-            "Should ask more information from user for queries about all Kyma resources in cluster",
+            "Should ask more information -- is there anything wrong with Kyma resources",
             state=create_basic_state(
                 task_description="is there anything wrong with Kyma resources?",
                 messages=[
@@ -204,7 +204,7 @@ def create_test_cases(k8s_client: IK8sClient) -> list[KymaAgentTestCase]:
             expected_goal="Agent response should explain that user query is very broad and ask user to provide specific details",
         ),
         KymaAgentTestCase(
-            "Should ask more information from user for queries about all Kyma resources in cluster",
+            "Should ask more information -- what is wrong with Kyma",
             state=create_basic_state(
                 task_description="what is wrong with Kyma?",
                 messages=[
@@ -228,17 +228,11 @@ def create_test_cases(k8s_client: IK8sClient) -> list[KymaAgentTestCase]:
     ]
 
 
-# Test case names used to generate stable parametrize IDs without constructing a k8s client.
-_TEST_CASE_NAMES = [
-    "Should find javascript Dates syntax error in Kyma function",
-    "Should ask more information from user for queries about Kyma resources status",
-    "Should ask more information from user for queries about all Kyma resources in cluster",
-    "Should ask more information from user for queries about Kyma resources health",
-    "Should ask more information from user for queries about all Kyma resources in cluster",
-    "Should ask more information from user for queries about showing all Kyma resources",
-    "Should ask more information from user for queries about all Kyma resources in cluster",
-    "Should ask more information from user for queries about Kyma cluster state",
-]
+# Derive parametrize IDs directly from the test case definitions so there is
+# a single source of truth.  None is a safe sentinel: create_test_cases uses
+# the client only to populate KymaAgentState.k8s_client, which is not accessed
+# during name extraction.
+_TEST_CASE_NAMES: list[str] = [tc.name for tc in create_test_cases(None)]  # type: ignore[arg-type]
 
 
 def pytest_generate_tests(metafunc):
@@ -248,7 +242,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def test_case(request, k8s_client_session):
+def test_case(request: pytest.FixtureRequest, k8s_client_session: IK8sClient) -> KymaAgentTestCase:
     """Resolve a test-case index into a KymaAgentTestCase, building it with the real k8s client."""
     return create_test_cases(k8s_client_session)[request.param]
 

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -38,7 +38,8 @@ class KymaAgentTestCase:
     should_raise: bool = False
 
 
-def create_k8s_client():
+def create_k8s_client() -> IK8sClient:
+    """Create a K8s client using configured cluster credentials."""
     data_sanitizer = DataSanitizer()
     k8s_auth_headers = K8sAuthHeaders(
         x_cluster_url=TEST_CLUSTER_URL,
@@ -47,7 +48,6 @@ def create_k8s_client():
         x_client_certificate_data=TEST_CLUSTER_CLIENT_CERTIFICATE_DATA,
         x_client_key_data=TEST_CLUSTER_CLIENT_KEY_DATA,
     )
-    # Initialize k8s client for the request.
     k8s_client: IK8sClient = K8sClient.new(
         k8s_auth_headers=k8s_auth_headers,
         data_sanitizer=data_sanitizer,
@@ -55,15 +55,21 @@ def create_k8s_client():
     return k8s_client
 
 
+@pytest.fixture(scope="session")
+def k8s_client_session() -> IK8sClient:
+    """Session-scoped K8s client fixture. Created once per test session."""
+    return create_k8s_client()
+
+
 @pytest.fixture
-def k8s_client():
-    # Initialize k8s client for the request.
-    k8s_client: IK8sClient = create_k8s_client()
-    return k8s_client
+def k8s_client(k8s_client_session: IK8sClient) -> IK8sClient:
+    """Function-scoped alias for the session K8s client."""
+    return k8s_client_session
 
 
 @pytest.fixture
 def kyma_agent(app_models):
+    """Create a KymaAgent instance."""
     return KymaAgent(app_models)
 
 
@@ -102,12 +108,14 @@ def create_basic_state(
 
 @pytest.fixture
 def evaluator_llm(app_models):
+    """Create a LangchainLLMWrapper for the main model."""
     main_model = app_models[MAIN_MODEL_NAME]
     return LangchainLLMWrapper(main_model.llm)
 
 
 @pytest.fixture
 def goal_accuracy_metric(evaluator_llm):
+    """Create a SimpleCriteriaScore metric for goal accuracy evaluation."""
     scorer = SimpleCriteriaScore(
         name="course_grained_score",
         definition="Score 0 to 10 by similarity",
@@ -117,12 +125,13 @@ def goal_accuracy_metric(evaluator_llm):
 
 
 async def call_kyma_agent(kyma_agent, state):
+    """Invoke the Kyma agent and return the response."""
     response = await kyma_agent.agent_node().ainvoke(state)
     return response
 
 
-def create_test_cases(k8s_client: IK8sClient):
-    """Fixture providing test cases for Kyma agent testing."""
+def create_test_cases(k8s_client: IK8sClient) -> list[KymaAgentTestCase]:
+    """Build the list of goal-accuracy test cases."""
     return [
         KymaAgentTestCase(
             "Should find javascript Dates syntax error in Kyma function",
@@ -219,10 +228,31 @@ def create_test_cases(k8s_client: IK8sClient):
     ]
 
 
-TEST_CASES = create_test_cases(create_k8s_client())
+# Test case names used to generate stable parametrize IDs without constructing a k8s client.
+_TEST_CASE_NAMES = [
+    "Should find javascript Dates syntax error in Kyma function",
+    "Should ask more information from user for queries about Kyma resources status",
+    "Should ask more information from user for queries about all Kyma resources in cluster",
+    "Should ask more information from user for queries about Kyma resources health",
+    "Should ask more information from user for queries about all Kyma resources in cluster",
+    "Should ask more information from user for queries about showing all Kyma resources",
+    "Should ask more information from user for queries about all Kyma resources in cluster",
+    "Should ask more information from user for queries about Kyma cluster state",
+]
 
 
-@pytest.mark.parametrize("test_case", TEST_CASES, ids=[tc.name for tc in TEST_CASES])
+def pytest_generate_tests(metafunc):
+    """Parametrize test_case lazily so collection never calls create_k8s_client()."""
+    if "test_case" in metafunc.fixturenames and metafunc.function.__name__ == "test_kyma_agent":
+        metafunc.parametrize("test_case", range(len(_TEST_CASE_NAMES)), ids=_TEST_CASE_NAMES, indirect=True)
+
+
+@pytest.fixture
+def test_case(request, k8s_client_session):
+    """Resolve a test-case index into a KymaAgentTestCase, building it with the real k8s client."""
+    return create_test_cases(k8s_client_session)[request.param]
+
+
 @pytest.mark.asyncio
 async def test_kyma_agent(kyma_agent, goal_accuracy_metric, test_case: KymaAgentTestCase):
     """

--- a/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
@@ -34,7 +34,8 @@ TOOL_FETCH_KYMA_VERSION = "fetch_kyma_resource_version"
 TOOL_SEARCH_KYMA_DOC = "search_kyma_doc"
 
 
-def create_k8s_client():
+def create_k8s_client() -> IK8sClient:
+    """Create a K8s client using configured cluster credentials."""
     data_sanitizer = DataSanitizer()
     k8s_auth_headers = K8sAuthHeaders(
         x_cluster_url=TEST_CLUSTER_URL,
@@ -43,7 +44,6 @@ def create_k8s_client():
         x_client_certificate_data=TEST_CLUSTER_CLIENT_CERTIFICATE_DATA,
         x_client_key_data=TEST_CLUSTER_CLIENT_KEY_DATA,
     )
-    # Initialize k8s client for the request.
     k8s_client: IK8sClient = K8sClient.new(
         k8s_auth_headers=k8s_auth_headers,
         data_sanitizer=data_sanitizer,
@@ -51,15 +51,21 @@ def create_k8s_client():
     return k8s_client
 
 
+@pytest.fixture(scope="session")
+def k8s_client_session() -> IK8sClient:
+    """Session-scoped K8s client fixture. Created once per test session."""
+    return create_k8s_client()
+
+
 @pytest.fixture
-def k8s_client():
-    # Initialize k8s client for the request.
-    k8s_client: IK8sClient = create_k8s_client()
-    return k8s_client
+def k8s_client(k8s_client_session: IK8sClient) -> IK8sClient:
+    """Function-scoped alias for the session K8s client."""
+    return k8s_client_session
 
 
 @pytest.fixture
 def kyma_agent(app_models):
+    """Create a KymaAgent instance."""
     return KymaAgent(app_models)
 
 
@@ -92,6 +98,8 @@ def create_basic_state(
 
 @dataclass
 class KymaKnowledgeTestCase:
+    """Test case for Kyma knowledge and cluster-scoped tool accuracy testing."""
+
     name: str
     state: KymaAgentState
     expected_tool_calls: list[ToolCall] | None = None
@@ -103,13 +111,14 @@ class KymaKnowledgeTestCase:
 
 @pytest.fixture
 def tool_accuracy_scorer():
+    """Create a ToolCallAccuracy scorer with string similarity metric."""
     metric = ToolCallAccuracy()
     metric.arg_comparison_metric = NonLLMStringSimilarity()
     return metric
 
 
 async def call_kyma_agent(kyma_agent, state):
-    # Invokes kyma agent subgraph.
+    """Invoke the Kyma agent subgraph and return the response."""
     response = await kyma_agent.agent_node().ainvoke(state)
     return response
 
@@ -143,8 +152,13 @@ def convert_agent_messages_to_ragas(agent_messages, metadata: bool = False):
     return convert_to_ragas_messages(messages, metadata=metadata)
 
 
-def create_test_cases_kyma_knowledge(k8s_client: IK8sClient):
-    """Fixture providing test cases for Kyma agent testing."""
+# ---------------------------------------------------------------------------
+# Kyma knowledge tests
+# ---------------------------------------------------------------------------
+
+
+def create_test_cases_kyma_knowledge(k8s_client: IK8sClient) -> list[KymaKnowledgeTestCase]:
+    """Build the list of Kyma-knowledge tool-accuracy test cases."""
     return [
         KymaKnowledgeTestCase(
             "Should call kyma doc search tool for general Kyma knowledge",
@@ -189,21 +203,15 @@ def create_test_cases_kyma_knowledge(k8s_client: IK8sClient):
     ]
 
 
-@pytest.mark.parametrize("test_case", create_test_cases_kyma_knowledge(create_k8s_client()), ids=lambda tc: tc.name)
-@pytest.mark.asyncio
-async def test_kyma_agent_kyma_knowledge(kyma_agent, tool_accuracy_scorer, test_case: KymaKnowledgeTestCase):
-    agent_response = await call_kyma_agent(kyma_agent, test_case.state)
-    agent_messages = convert_agent_messages_to_ragas(agent_response["agent_messages"], metadata=True)
+_KYMA_KNOWLEDGE_TEST_CASE_NAMES = [
+    "Should call kyma doc search tool for general Kyma knowledge",
+    "Should call kyma doc search tool for Kyma module enablement",
+]
 
-    test_case_sample = MultiTurnSample(
-        user_input=agent_messages,
-        reference_tool_calls=test_case.expected_tool_calls,
-    )
 
-    score = await tool_accuracy_scorer.multi_turn_ascore(test_case_sample)
-    assert score > TOOL_ACCURACY_THRESHOLD, (
-        f"Tool call accuracy ({score:.2f}) is below the acceptable threshold of {TOOL_ACCURACY_THRESHOLD}"
-    )
+# ---------------------------------------------------------------------------
+# Namespace-scoped tests
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -274,7 +282,7 @@ def assert_outcome_invariants(test_case: NamespaceScopedTestCase, agent_messages
         assert actual_count <= max_count, f"Tool '{tool_name}' called {actual_count} times, exceeds max of {max_count}"
 
 
-def create_test_cases_namespace_scoped(k8s_client: IK8sClient):
+def create_test_cases_namespace_scoped(k8s_client: IK8sClient) -> list[NamespaceScopedTestCase]:
     """Create table of namespace-scoped test cases with invariants."""
     return [
         NamespaceScopedTestCase(
@@ -332,30 +340,20 @@ def create_test_cases_namespace_scoped(k8s_client: IK8sClient):
     ]
 
 
-@pytest.mark.parametrize(
-    "test_case",
-    create_test_cases_namespace_scoped(create_k8s_client()),
-    ids=lambda tc: tc.name,
-)
-@pytest.mark.asyncio
-async def test_kyma_agent_namespace_scoped(kyma_agent, test_case: NamespaceScopedTestCase):
-    """Test agent behavior by verifying outcomes and invariants."""
-    # Build a fresh state on every invocation so reruns start clean.
-    state = test_case.state_factory()
-
-    # When: Agent processes the request
-    result = await call_kyma_agent(kyma_agent, state)
-
-    # Then: Agent should have made tool calls
-    agent_messages = result.get("agent_messages", [])
-    assert len(agent_messages) > 0, "Agent should have made tool calls"
-
-    # Then: Assert all invariants defined in the test case
-    assert_outcome_invariants(test_case, agent_messages)
+_NAMESPACE_SCOPED_TEST_CASE_NAMES = [
+    "Should handle wrong Subscription API version and correct it",
+    "Should handle correct Function API version without fetching version",
+    "Should handle wrong APIRule version (v1beta1) and correct to v2",
+]
 
 
-def create_test_cases_cluster_scoped(k8s_client: IK8sClient):
-    """Fixture providing test cases for Kyma agent testing."""
+# ---------------------------------------------------------------------------
+# Cluster-scoped tests
+# ---------------------------------------------------------------------------
+
+
+def create_test_cases_cluster_scoped(k8s_client: IK8sClient) -> list[KymaKnowledgeTestCase]:
+    """Build the list of cluster-scoped tool-accuracy test cases."""
     return [
         KymaKnowledgeTestCase(
             "Should use Kyma Resource Query and then Kyma Doc Search Tool Calls sequentially",
@@ -458,9 +456,104 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient):
     ]
 
 
-@pytest.mark.parametrize("test_case", create_test_cases_cluster_scoped(create_k8s_client()), ids=lambda tc: tc.name)
+_CLUSTER_SCOPED_TEST_CASE_NAMES = [
+    "Should use Kyma Resource Query and then Kyma Doc Search Tool Calls sequentially",
+    "Should use cluster scope retrieval with kyma query tool",
+    "Should use cluster scope retrieval with kyma query tool",
+    "Should use cluster scope retrieval with kyma query tool",
+]
+
+
+# ---------------------------------------------------------------------------
+# pytest_generate_tests -- defers all parametrize calls until fixture time
+# ---------------------------------------------------------------------------
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize all test functions lazily to avoid module-level client construction."""
+    if "test_case" not in metafunc.fixturenames:
+        return
+
+    fn = metafunc.function.__name__
+    if fn == "test_kyma_agent_kyma_knowledge":
+        metafunc.parametrize(
+            "test_case",
+            range(len(_KYMA_KNOWLEDGE_TEST_CASE_NAMES)),
+            ids=_KYMA_KNOWLEDGE_TEST_CASE_NAMES,
+            indirect=True,
+        )
+    elif fn == "test_kyma_agent_namespace_scoped":
+        metafunc.parametrize(
+            "test_case",
+            range(len(_NAMESPACE_SCOPED_TEST_CASE_NAMES)),
+            ids=_NAMESPACE_SCOPED_TEST_CASE_NAMES,
+            indirect=True,
+        )
+    elif fn == "test_kyma_agent_cluster_scoped":
+        metafunc.parametrize(
+            "test_case",
+            range(len(_CLUSTER_SCOPED_TEST_CASE_NAMES)),
+            ids=_CLUSTER_SCOPED_TEST_CASE_NAMES,
+            indirect=True,
+        )
+
+
+@pytest.fixture
+def test_case(request, k8s_client_session):
+    """Resolve a test-case index into the appropriate test case, built with the real k8s client."""
+    fn = request.node.originalname
+    idx = request.param
+    if fn == "test_kyma_agent_kyma_knowledge":
+        return create_test_cases_kyma_knowledge(k8s_client_session)[idx]
+    if fn == "test_kyma_agent_namespace_scoped":
+        return create_test_cases_namespace_scoped(k8s_client_session)[idx]
+    if fn == "test_kyma_agent_cluster_scoped":
+        return create_test_cases_cluster_scoped(k8s_client_session)[idx]
+    raise ValueError(f"Unknown test function: {fn}")
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kyma_agent_kyma_knowledge(kyma_agent, tool_accuracy_scorer, test_case: KymaKnowledgeTestCase):
+    """Test that the Kyma agent calls the correct tools for Kyma knowledge queries."""
+    agent_response = await call_kyma_agent(kyma_agent, test_case.state)
+    agent_messages = convert_agent_messages_to_ragas(agent_response["agent_messages"], metadata=True)
+
+    test_case_sample = MultiTurnSample(
+        user_input=agent_messages,
+        reference_tool_calls=test_case.expected_tool_calls,
+    )
+
+    score = await tool_accuracy_scorer.multi_turn_ascore(test_case_sample)
+    assert score > TOOL_ACCURACY_THRESHOLD, (
+        f"Tool call accuracy ({score:.2f}) is below the acceptable threshold of {TOOL_ACCURACY_THRESHOLD}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kyma_agent_namespace_scoped(kyma_agent, test_case: NamespaceScopedTestCase):
+    """Test agent behavior by verifying outcomes and invariants."""
+    # Build a fresh state on every invocation so reruns start clean.
+    state = test_case.state_factory()
+
+    # When: Agent processes the request
+    result = await call_kyma_agent(kyma_agent, state)
+
+    # Then: Agent should have made tool calls
+    agent_messages = result.get("agent_messages", [])
+    assert len(agent_messages) > 0, "Agent should have made tool calls"
+
+    # Then: Assert all invariants defined in the test case
+    assert_outcome_invariants(test_case, agent_messages)
+
+
 @pytest.mark.asyncio
 async def test_kyma_agent_cluster_scoped(kyma_agent, tool_accuracy_scorer, test_case: KymaKnowledgeTestCase):
+    """Test that the Kyma agent uses the correct cluster-scoped tool call sequence."""
     response = await call_kyma_agent(kyma_agent, test_case.state)
     ragas_messages = convert_agent_messages_to_ragas(response["agent_messages"])
 

--- a/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
@@ -64,7 +64,7 @@ def k8s_client(k8s_client_session: IK8sClient) -> IK8sClient:
 
 
 @pytest.fixture
-def kyma_agent(app_models):
+def kyma_agent(app_models) -> KymaAgent:
     """Create a KymaAgent instance."""
     return KymaAgent(app_models)
 
@@ -203,9 +203,9 @@ def create_test_cases_kyma_knowledge(k8s_client: IK8sClient) -> list[KymaKnowled
     ]
 
 
-_KYMA_KNOWLEDGE_TEST_CASE_NAMES = [
-    "Should call kyma doc search tool for general Kyma knowledge",
-    "Should call kyma doc search tool for Kyma module enablement",
+_KYMA_KNOWLEDGE_TEST_CASE_NAMES: list[str] = [
+    tc.name
+    for tc in create_test_cases_kyma_knowledge(None)  # type: ignore[arg-type]
 ]
 
 
@@ -340,10 +340,9 @@ def create_test_cases_namespace_scoped(k8s_client: IK8sClient) -> list[Namespace
     ]
 
 
-_NAMESPACE_SCOPED_TEST_CASE_NAMES = [
-    "Should handle wrong Subscription API version and correct it",
-    "Should handle correct Function API version without fetching version",
-    "Should handle wrong APIRule version (v1beta1) and correct to v2",
+_NAMESPACE_SCOPED_TEST_CASE_NAMES: list[str] = [
+    tc.name
+    for tc in create_test_cases_namespace_scoped(None)  # type: ignore[arg-type]
 ]
 
 
@@ -398,7 +397,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient) -> list[KymaKnowled
             ],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should retrieve all subscriptions cluster-wide",
             state=create_basic_state(
                 task_description="check all subscriptions in the cluster",
                 messages=[
@@ -424,7 +423,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient) -> list[KymaKnowled
             ],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should decline to enumerate all resources cluster-wide",
             state=create_basic_state(
                 task_description="check all resources in the cluster",
                 messages=[
@@ -439,7 +438,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient) -> list[KymaKnowled
             expected_tool_calls=[],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should decline broad show-all-Kyma-resources query",
             state=create_basic_state(
                 task_description="show me all Kyma resources",
                 messages=[
@@ -456,11 +455,9 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient) -> list[KymaKnowled
     ]
 
 
-_CLUSTER_SCOPED_TEST_CASE_NAMES = [
-    "Should use Kyma Resource Query and then Kyma Doc Search Tool Calls sequentially",
-    "Should use cluster scope retrieval with kyma query tool",
-    "Should use cluster scope retrieval with kyma query tool",
-    "Should use cluster scope retrieval with kyma query tool",
+_CLUSTER_SCOPED_TEST_CASE_NAMES: list[str] = [
+    tc.name
+    for tc in create_test_cases_cluster_scoped(None)  # type: ignore[arg-type]
 ]
 
 
@@ -499,7 +496,9 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def test_case(request, k8s_client_session):
+def test_case(
+    request: pytest.FixtureRequest, k8s_client_session: IK8sClient
+) -> KymaKnowledgeTestCase | NamespaceScopedTestCase:
     """Resolve a test-case index into the appropriate test case, built with the real k8s client."""
     fn = request.node.originalname
     idx = request.param


### PR DESCRIPTION
## Description

`test_kyma_agent_goal_accuracy.py` and `test_kyma_agent_tool_accuracy.py` previously called `create_k8s_client()` at module level inside `pytest.mark.parametrize` decorators. When cluster credentials are absent, this causes pytest collection failure for the entire module -- blocking all test runs, not just the affected tests.

Fix: replaced all module-level parametrize decorators with a `pytest_generate_tests` hook that parametrizes by integer index using stable name lists. Added a session-scoped `k8s_client_session` fixture that constructs the real `K8sClient` once at test execution time. Added an indirect `test_case` fixture that maps each index to the appropriate `KymaAgentTestCase`/`KymaKnowledgeTestCase`/`NamespaceScopedTestCase` by calling the existing `create_test_cases_*` functions with the session client. The `pyproject.toml` change is a dependency sort from poetry sort (run as part of pre-commit-check).

**Testing**

- `pre-commit-check` passes (sort, lint, typecheck, format, unit tests all green)
- pytest collection of both test modules succeeds without cluster credentials present