### PR TITLE
test: use per-case thresholds in RAG system tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/rag/test_rag_system.py
+++ b/tests/integration/rag/test_rag_system.py
@@ -35,15 +35,10 @@ def contextual_relevancy_metric(evaluator_model):
 
 
 @pytest.fixture(scope="module")
-def evaluation_metrics(evaluator_model, contextual_relevancy_metric):
+def evaluation_metrics(contextual_relevancy_metric):
     # test the reranking of the retrieved documents
     # calculates how much retrieved context aligns with the expected output
-    contextual_recall = ContextualRecallMetric(threshold=0.5, model=evaluator_model, include_reason=True)
-
-    return [
-        contextual_recall,
-        contextual_relevancy_metric,
-    ]
+    return [contextual_relevancy_metric]
 
 
 @pytest.fixture(scope="session")
@@ -89,6 +84,6 @@ async def test_rag_system(
     contextual_recall = ContextualRecallMetric(
         threshold=answer_relevancy_threshold, model=evaluator_model, include_reason=True
     )
-    metrics = [contextual_recall, *evaluation_metrics[1:]]
+    metrics = [contextual_recall, *evaluation_metrics]
     # evaluate the test case using deepeval metrics
     assert_test(test_case, metrics)

--- a/tests/integration/rag/test_rag_system.py
+++ b/tests/integration/rag/test_rag_system.py
@@ -13,7 +13,7 @@ from integration.rag.datasets.telemetry import cases as telemetry_cases
 from rag.system import Query, RAGSystem
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def contextual_relevancy_metric(evaluator_model):
     return GEval(
         name="ContextualRelevancy",
@@ -34,7 +34,7 @@ def contextual_relevancy_metric(evaluator_model):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def evaluation_metrics(evaluator_model, contextual_relevancy_metric):
     # test the reranking of the retrieved documents
     # calculates how much retrieved context aligns with the expected output
@@ -52,11 +52,12 @@ def rag_system(app_models):
 
 
 @pytest.mark.parametrize(
-    "user_query, expected_output",
+    "user_query, expected_output, answer_relevancy_threshold",
     [
         pytest.param(
             case["input"],
             case["expected_output"],
+            case["answer_relevancy_threshold"],
             id=case["input"],
         )
         for case in (istio_cases + serverless_cases + telemetry_cases + eventing_cases)
@@ -66,8 +67,10 @@ def rag_system(app_models):
 async def test_rag_system(
     user_query,
     expected_output,
+    answer_relevancy_threshold,
     rag_system,
     evaluation_metrics,
+    evaluator_model,
 ):
     query = Query(text=user_query)
     retrieved_docs = await rag_system.aretrieve(query, 10)
@@ -82,5 +85,10 @@ async def test_rag_system(
         retrieval_context=retrieved_docs_content,
         expected_output=expected_output,
     )
+    # build per-case metrics using the threshold defined in each dataset case
+    contextual_recall = ContextualRecallMetric(
+        threshold=answer_relevancy_threshold, model=evaluator_model, include_reason=True
+    )
+    metrics = [contextual_recall, *evaluation_metrics[1:]]
     # evaluate the test case using deepeval metrics
-    assert_test(test_case, evaluation_metrics)
+    assert_test(test_case, metrics)


### PR DESCRIPTION
## Description

Dataset files (`eventing.py`, `istio.py`, `serverless.py`, `telemetry.py`) already define `answer_relevancy_threshold` per test case (values 0.6--0.7), but `test_rag_system.py` was using a hardcoded `0.5` for all cases via a module-level `ContextualRecallMetric`. This change wires the per-case threshold through the parametrize tuple and uses it when constructing the metric, so each test case is evaluated against its intended threshold.

Changes:
- Added `answer_relevancy_threshold` as a third element in the parametrize tuple (alongside `user_query` and `expected_output`)
- Passed it through to the test function signature and used it to construct a per-case `ContextualRecallMetric` instead of the module-level one with hardcoded `0.5`
- The test now builds `metrics = [contextual_recall (per-case threshold), *evaluation_metrics[1:]]` so only the recall threshold varies per case while the shared `contextual_relevancy_metric` GEval is reused
- Raised fixture scope of both `contextual_relevancy_metric` and `evaluation_metrics` from `function` to `module`
- `pyproject.toml`: poetry sort reordered a2a-sdk entry alphabetically (no semantic change)

**Testing**

- `pre-commit-check` (sort, lint, typecheck, format, unit tests) passed cleanly