### PR TITLE
test: fix duplicate parametrize IDs in integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -812,7 +812,7 @@ async def test_invoke_chain(
         ),
         # Should return use search_kyma_doc tool for Kyma question for general Kyma knowledge query
         (
-            "Should return use search_kyma_doc tool for Kyma question",
+            "Should use search_kyma_doc tool for query about creating Kyma application",
             KymaAgentState(
                 agent_messages=[],
                 messages=[
@@ -849,7 +849,7 @@ async def test_invoke_chain(
         ),
         # Should return use search_kyma_doc tool for Kyma question for general Kyma knowledge query
         (
-            "Should return use search_kyma_doc tool for Kyma question",
+            "Should use search_kyma_doc tool for query about enabling a Kyma module",
             KymaAgentState(
                 agent_messages=[],
                 messages=[
@@ -880,7 +880,7 @@ async def test_invoke_chain(
         ),
         # Should return use search_kyma_doc tool for Kyma question for general Kyma knowledge query
         (
-            "Should return use search_kyma_doc tool for Kyma question",
+            "Should use search_kyma_doc tool for query about creating an API Rule",
             KymaAgentState(
                 agent_messages=[],
                 messages=[

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -173,7 +173,7 @@ def create_test_cases(k8s_client: IK8sClient):
             expected_goal="Agent response should explain that user query is very broad and ask user to provide specific details",
         ),
         KymaAgentTestCase(
-            "Should ask more information from user for queries about all Kyma resources in cluster",
+            "Should ask more information from user for queries about whether Kyma resources have issues",
             state=create_basic_state(
                 task_description="is there anything wrong with Kyma resources?",
                 messages=[
@@ -195,7 +195,7 @@ def create_test_cases(k8s_client: IK8sClient):
             expected_goal="Agent response should explain that user query is very broad and ask user to provide specific details",
         ),
         KymaAgentTestCase(
-            "Should ask more information from user for queries about all Kyma resources in cluster",
+            "Should ask more information from user for queries about what is wrong with Kyma",
             state=create_basic_state(
                 task_description="what is wrong with Kyma?",
                 messages=[

--- a/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_tool_accuracy.py
@@ -400,7 +400,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient):
             ],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should use cluster scope retrieval to check all subscriptions in the cluster",
             state=create_basic_state(
                 task_description="check all subscriptions in the cluster",
                 messages=[
@@ -426,7 +426,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient):
             ],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should not make tool calls for broad cluster resources query",
             state=create_basic_state(
                 task_description="check all resources in the cluster",
                 messages=[
@@ -441,7 +441,7 @@ def create_test_cases_cluster_scoped(k8s_client: IK8sClient):
             expected_tool_calls=[],
         ),
         KymaKnowledgeTestCase(
-            "Should use cluster scope retrieval with kyma query tool",
+            "Should not make tool calls for broad show all Kyma resources query",
             state=create_basic_state(
                 task_description="show me all Kyma resources",
                 messages=[

--- a/tests/integration/agents/test_gatekeeper_node.py
+++ b/tests/integration/agents/test_gatekeeper_node.py
@@ -309,7 +309,7 @@ from integration.conftest import convert_dict_to_messages, create_mock_state
             False,
         ),
         (
-            "correctly forward the query",
+            "correctly forward deployment problem query",
             [
                 SystemMessage(content="{'resource_api_version': 'v1', 'resource_namespace': 'nginx-oom'}"),
                 HumanMessage(content="What is problem with my deployment?"),
@@ -318,7 +318,7 @@ from integration.conftest import convert_dict_to_messages, create_mock_state
             True,
         ),
         (
-            "correctly forward the query",
+            "correctly forward kyma function deployment query",
             [
                 SystemMessage(content="{'resource_api_version': 'v1', 'resource_namespace': 'nginx-oom'}"),
                 HumanMessage(content="how to deploy a kyma function?"),
@@ -327,7 +327,7 @@ from integration.conftest import convert_dict_to_messages, create_mock_state
             True,
         ),
         (
-            "correctly forward the query",
+            "correctly forward api status query",
             [
                 SystemMessage(content="{'resource_api_version': 'v1', 'resource_namespace': 'nginx-oom'}"),
                 HumanMessage(content="what is the status of my api"),
@@ -336,7 +336,7 @@ from integration.conftest import convert_dict_to_messages, create_mock_state
             True,
         ),
         (
-            "correctly forward the query",
+            "correctly forward pod status query",
             [
                 SystemMessage(content="{'resource_api_version': 'v1', 'resource_namespace': 'nginx-oom'}"),
                 HumanMessage(content="what is the status of my pod"),
@@ -562,7 +562,7 @@ async def test_gatekeeper_categorization(
     "test_description, conversation_history, user_query, expected_answer, expected_query_forwarding",
     [
         (
-            "answer the question based on the conversation history",
+            "answer question about issue based on conversation history with serverless function context",
             conversation_sample_2,
             "what was the issue?",
             "The issue with the serverless Function `func1` in the namespace `kyma-serverless-function-no-replicas` not being ready "
@@ -572,7 +572,7 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about what was wrong based on conversation history with serverless function context",
             conversation_sample_2,
             "what was wrong?",
             "The issue with the serverless Function `func1` in the namespace `kyma-serverless-function-no-replicas` not being ready "
@@ -582,7 +582,7 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about what was the problem based on conversation history with serverless function context",
             conversation_sample_2,
             "what was the problem?",
             "The issue with the serverless Function `func1` in the namespace `kyma-serverless-function-no-replicas` not being ready "
@@ -592,7 +592,7 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about cause based on conversation history with pod permissions context",
             conversation_sample_5,
             "what was the cause?",
             "The cause of the Pod `pod-check` being in an error state is likely due to insufficient permissions "
@@ -603,7 +603,7 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about reason based on conversation history with pod permissions context",
             conversation_sample_5,
             "what was the reason?",
             "The cause of the Pod `pod-check` being in an error state is likely due to insufficient permissions "
@@ -614,7 +614,7 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about issue based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "what was the issue?",
             "The issue with the function in the `test-function-8` namespace was a syntax error in the JavaScript code.\n"
@@ -623,49 +623,49 @@ async def test_gatekeeper_categorization(
             False,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about function issue based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "what is the issue with function?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about any problem with function based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "any problem with function?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about finding issue with function based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "find issue with function?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about error in tracing pipeline based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "any error in tracing pipeline?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about anything wrong with api rules based on conversation history with javascript syntax error context",
             conversation_sample_7,
             "anything wrong with api rules?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "forward query about function issue based on conversation history with serverless function context",
             conversation_sample_2,
             "what is the issue with function?",
             "",
             True,
         ),
         (
-            "answer the question based on the conversation history",
+            "answer question about implicit issue reference based on conversation history with serverless function context",
             conversation_sample_2,
             "what is the issue?",  # this is implicitly referring to the conversation history
             "The issue with the serverless Function `func1` in the namespace `kyma-serverless-function-no-replicas` not being ready "


### PR DESCRIPTION
## Description

Multiple integration test files had non-unique `pytest.mark.parametrize` IDs, making targeted reruns by test name impossible. This PR gives each test case a unique, descriptive ID.

Changes per file:

- **test_kyma_agent.py** (`test_tool_calling`): 3x "Should return use search_kyma_doc tool for Kyma question" renamed to describe the specific query topic (creating Kyma application, enabling a Kyma module, creating an API Rule).
- **test_kyma_agent_goal_accuracy.py**: 2x "Should ask more information from user for queries about all Kyma resources in cluster" -- renamed to distinguish the "is there anything wrong with Kyma resources?" case from the "what is wrong with Kyma?" case.
- **test_gatekeeper_node.py** (`test_gatekeeper_with_conversation_history`): 9x "answer the question based on the conversation history" renamed to encode conversation context and actual question; 4x "correctly forward the query" renamed to describe the specific query.
- **test_kyma_agent_tool_accuracy.py** (`create_test_cases_cluster_scoped`): 3x "Should use cluster scope retrieval with kyma query tool" renamed to describe the specific scenario.

`pyproject.toml` has a dependency ordering change from poetry sort (no semantic change).

**Testing**

- `pre-commit-check` passed (sort, lint, typecheck, format, unit tests all green).
- No test logic was changed -- only parametrize ID strings.