### PR TITLE
test: move router tests from integration to unit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/unit/agents/supervisor/test_router.py
+++ b/tests/unit/agents/supervisor/test_router.py
@@ -1,11 +1,31 @@
+from unittest.mock import MagicMock
+
 import pytest
+from langchain_core.embeddings import Embeddings
 from langchain_core.messages import SystemMessage
 
 from agents.common.constants import COMMON
 from agents.common.state import SubTask
 from agents.k8s.agent import K8S_AGENT
 from agents.kyma.agent import KYMA_AGENT
-from integration.agents.test_common_node import create_mock_state
+from agents.supervisor.agent import FINALIZER, SupervisorAgent
+from agents.supervisor.state import SupervisorState
+from utils.models.factory import IModel
+from utils.settings import (
+    MAIN_EMBEDDING_MODEL_NAME,
+    MAIN_MODEL_MINI_NAME,
+    MAIN_MODEL_NAME,
+)
+
+
+@pytest.fixture
+def supervisor_agent():
+    mock_models = {
+        MAIN_MODEL_MINI_NAME: MagicMock(spec=IModel),
+        MAIN_MODEL_NAME: MagicMock(spec=IModel),
+        MAIN_EMBEDDING_MODEL_NAME: MagicMock(spec=Embeddings),
+    }
+    return SupervisorAgent(models=mock_models, members=[K8S_AGENT, KYMA_AGENT, COMMON, FINALIZER])
 
 
 @pytest.mark.parametrize(
@@ -223,15 +243,13 @@ from integration.agents.test_common_node import create_mock_state
         ),
     ],
 )
-def test_route(messages, subtasks, expected_answer, companion_graph):
-    """Tests the router method of CompanionGraph."""
-    # Given: A conversation state with messages and subtasks
-    state = create_mock_state(messages, subtasks)
+def test_route(messages, subtasks, expected_answer, supervisor_agent):
+    """Tests the _route method of SupervisorAgent."""
+    # Given: A supervisor state with messages and subtasks
+    state = SupervisorState(messages=messages, subtasks=subtasks)
 
-    # When: The supervisor agent's route method is invoked
-    result = companion_graph.supervisor_agent._route(state)
+    # When: The supervisor agent's _route method is invoked
+    result = supervisor_agent._route(state)
 
     # Then: We verify the routing matches the expected output
-    actual_output = result["next"]
-    expected_output = expected_answer
-    assert actual_output == expected_output, "Router did not return expected next step"
+    assert result["next"] == expected_answer, "Router did not return expected next step"

--- a/tests/unit/agents/supervisor/test_router.py
+++ b/tests/unit/agents/supervisor/test_router.py
@@ -19,7 +19,8 @@ from utils.settings import (
 
 
 @pytest.fixture
-def supervisor_agent():
+def supervisor_agent() -> SupervisorAgent:
+    """Create a SupervisorAgent with mocked models for unit testing."""
     mock_models = {
         MAIN_MODEL_MINI_NAME: MagicMock(spec=IModel),
         MAIN_MODEL_NAME: MagicMock(spec=IModel),
@@ -241,6 +242,43 @@ def supervisor_agent():
             ],
             COMMON,
         ),
+        # All subtasks completed: Finalizer is 'Next' agent
+        (
+            [
+                SystemMessage(
+                    content="""
+                {'resource_api_version': 'v1', 'resource_namespace': 'nginx-oom'}
+                """
+                )
+            ],
+            [
+                SubTask(
+                    description="Task 1",
+                    task_title="Task 1",
+                    assigned_to=K8S_AGENT,
+                    status="completed",
+                ),
+                SubTask(
+                    description="Task 2",
+                    task_title="Task 2",
+                    assigned_to=KYMA_AGENT,
+                    status="completed",
+                ),
+            ],
+            FINALIZER,
+        ),
+    ],
+    ids=[
+        "single_k8s_pending",
+        "single_kyma_pending",
+        "single_common_pending",
+        "multi_all_pending_first_k8s",
+        "multi_all_pending_first_kyma",
+        "multi_all_pending_first_common",
+        "multi_first_completed_k8s_next",
+        "multi_first_completed_kyma_next",
+        "multi_first_completed_common_next",
+        "all_completed_finalizer",
     ],
 )
 def test_route(messages, subtasks, expected_answer, supervisor_agent):


### PR DESCRIPTION
## Description

The supervisor router's \`_route\` method is a pure function -- it picks the first pending subtask (or routes to the finalizer) with no LLM involvement. Running these 9 test cases through the full live \`companion_graph\` incurs unnecessary LLM cost and integration test flakiness for what is a deterministic algorithmic check.

Changes:
- Add \`tests/unit/agents/supervisor/test_router.py\` with all 9 routing cases plus a new finalizer-route case (all subtasks completed)
- Delete \`tests/integration/agents/supervisor/test_router.py\`
- Instantiate \`SupervisorAgent\` with mocked models, call \`_route\` directly

**Testing**
- \`poetry run poe pre-commit-check\` passes (1125+ unit tests, mypy, ruff)