### PR TITLE
test: remove FaithfulnessMetric where retrieval_context is empty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -664,8 +664,12 @@ async def test_invoke_chain(
                 expected_output=expected_result if expected_result else None,
                 retrieval_context=([retrieval_context] if retrieval_context else []),
             )
-            # evaluate if the gotten response is semantically similar and faithful to the expected response
-            assert_test(test_case, [correctness_metric, faithfulness_metric])
+            # Only include FaithfulnessMetric when retrieval_context is non-empty;
+            # faithfulness against no context is undefined and produces random scores.
+            metrics = [correctness_metric]
+            if retrieval_context:
+                metrics.append(faithfulness_metric)
+            assert_test(test_case, metrics)
 
 
 @pytest.mark.parametrize(
@@ -955,5 +959,9 @@ async def test_tool_calling(
                 expected_output=expected_result if expected_result else None,
                 retrieval_context=([retrieval_context] if retrieval_context else []),
             )
-            # evaluate if the gotten response is semantically similar and faithful to the expected response
-            assert_test(test_case, [correctness_metric, faithfulness_metric])
+            # Only include FaithfulnessMetric when retrieval_context is non-empty;
+            # faithfulness against no context is undefined and produces random scores.
+            metrics = [correctness_metric]
+            if retrieval_context:
+                metrics.append(faithfulness_metric)
+            assert_test(test_case, metrics)

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -452,7 +452,7 @@ def kyma_agent(app_models):
                 is_last_step=False,
                 remaining_steps=AGENT_STEPS_NUMBER,
             ),
-            "",
+            RETRIEVAL_CONTEXT,
             EXPECTED_BTP_MANAGER_RESPONSE,
             None,
             False,


### PR DESCRIPTION
## Description

Most content test cases pass \`retrieval_context=[]\` to \`FaithfulnessMetric\`. Faithfulness against no context is undefined -- the metric produces random scores that cause spurious test failures. Either populate the retrieval context from actual RAG output or drop the metric from tests where context is unavailable.

**Testing**
- \`poetry run poe pre-commit-check\` passes