### PR TITLE
test: add structural pre-checks before GEval assertions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/integration/agents/k8s/test_k8s_agent.py
+++ b/tests/integration/agents/k8s/test_k8s_agent.py
@@ -123,6 +123,9 @@ async def test_invoke_chain(
         assert tool_call.get("type") == "tool_call"
         assert tool_call.get("name") == expected_tool_call
     else:
+        # Pre-check: verify structural response before invoking the judge
+        assert response.content, f"KubernetesAgent returned an empty response for test case: {test_case}"
+
         # for content response cases, verify using deepeval metrics
         test_case = LLMTestCase(
             input=state.my_task.description,

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -657,6 +657,9 @@ async def test_invoke_chain(
             assert tool_call.get("type") == "tool_call"
             assert tool_call.get("name") == expected_tool_call
         else:
+            # Pre-check: verify structural response before invoking the judge
+            assert response.content, f"KymaAgent returned an empty response for test case: {test_case}"
+
             # for content response cases, verify using deepeval metrics
             test_case = LLMTestCase(
                 input=state.my_task.description,
@@ -948,6 +951,9 @@ async def test_tool_calling(
             assert tool_call.get("type") == "tool_call"
             assert tool_call.get("name") == expected_tool_call
         else:
+            # Pre-check: verify structural response before invoking the judge
+            assert response.content, f"KymaAgent returned an empty response for test case: {test_case}"
+
             # for content response cases, verify using deepeval metrics
             test_case = LLMTestCase(
                 input=state.my_task.description,

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -233,9 +233,21 @@ async def test_kyma_agent(kyma_agent, goal_accuracy_metric, test_case: KymaAgent
     agent_response = await call_kyma_agent(kyma_agent, test_case.state)
     agent_messages = convert_to_ragas_messages(agent_response["agent_messages"])
 
+    # Pre-check: verify structural response before invoking the judge
+    assert len(agent_messages) > 0, f"Agent produced no messages for test case: {test_case.name}"
+    actual_output = agent_messages[-1].content
+    assert actual_output, f"Agent returned an empty response for test case: {test_case.name}"
+
+    # For broad-query "ask for more info" cases, verify the response requests clarification
+    if "ask more information" in test_case.name.lower() or "broad" in test_case.expected_goal.lower():
+        clarification_keywords = ["specific", "more information", "which", "please"]
+        assert any(kw in actual_output.lower() for kw in clarification_keywords), (
+            f"Expected clarification keywords {clarification_keywords} in response, got: {actual_output!r}"
+        )
+
     sample = SingleTurnSample(
         user_input=user_query,
-        response=agent_messages[-1].content,
+        response=actual_output,
         reference=test_case.expected_goal,
     )
 

--- a/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
+++ b/tests/integration/agents/kyma/test_kyma_agent_goal_accuracy.py
@@ -239,8 +239,17 @@ async def test_kyma_agent(kyma_agent, goal_accuracy_metric, test_case: KymaAgent
     assert actual_output, f"Agent returned an empty response for test case: {test_case.name}"
 
     # For broad-query "ask for more info" cases, verify the response requests clarification
-    if "ask more information" in test_case.name.lower() or "broad" in test_case.expected_goal.lower():
-        clarification_keywords = ["specific", "more information", "which", "please"]
+    if "ask more information" in test_case.name.lower():
+        clarification_keywords = [
+            "specific",
+            "more information",
+            "which",
+            "please",
+            "clarif",
+            "specify",
+            "particular",
+            "detail",
+        ]
         assert any(kw in actual_output.lower() for kw in clarification_keywords), (
             f"Expected clarification keywords {clarification_keywords} in response, got: {actual_output!r}"
         )
@@ -256,7 +265,7 @@ async def test_kyma_agent(kyma_agent, goal_accuracy_metric, test_case: KymaAgent
         print(
             f"**Test case failed to meet expectation:**\n"
             f"--> Expected goal: {test_case.expected_goal}\n"
-            f"--> Agent response: \n{agent_messages[-1].content}"
+            f"--> Agent response: \n{actual_output}"
         )
 
     assert score >= GOAL_ACCURACY_THRESHOLD, (

--- a/tests/integration/agents/supervisor/test_finalizer.py
+++ b/tests/integration/agents/supervisor/test_finalizer.py
@@ -499,10 +499,22 @@ async def test_generate_final_response(test_case, messages, expected_answer, com
     # When: The Finalizer generates a final response
     assert state.input is not None
     result = await companion_graph.supervisor_agent._generate_final_response(state)
+
+    # Pre-check: verify structural response before invoking the judge
+    actual_output = result["messages"][0].content
+    assert actual_output, f"Finalizer returned an empty response for test case: {test_case}"
+
+    # For "should not answer itself" cases, verify the response declines rather than answers
+    if "do not answer the question itself" in test_case.lower():
+        refuse_keywords = ["not able", "cannot", "no information"]
+        assert any(kw in actual_output.lower() for kw in refuse_keywords), (
+            f"Expected refusal keywords {refuse_keywords} in response, got: {actual_output!r}"
+        )
+
     latest_human_message = HumanMessage(content=state.input.query)
     test_case = LLMTestCase(
         input=str(latest_human_message),
-        actual_output=result["messages"][0].content,
+        actual_output=actual_output,
         expected_output=expected_answer,
     )
 

--- a/tests/integration/agents/supervisor/test_finalizer.py
+++ b/tests/integration/agents/supervisor/test_finalizer.py
@@ -501,12 +501,13 @@ async def test_generate_final_response(test_case, messages, expected_answer, com
     result = await companion_graph.supervisor_agent._generate_final_response(state)
 
     # Pre-check: verify structural response before invoking the judge
+    assert result["messages"], f"Finalizer returned no messages for test case: {test_case}"
     actual_output = result["messages"][0].content
     assert actual_output, f"Finalizer returned an empty response for test case: {test_case}"
 
     # For "should not answer itself" cases, verify the response declines rather than answers
     if "do not answer the question itself" in test_case.lower():
-        refuse_keywords = ["not able", "cannot", "no information"]
+        refuse_keywords = ["not able", "cannot", "unable", "did not provide", "sorry"]
         assert any(kw in actual_output.lower() for kw in refuse_keywords), (
             f"Expected refusal keywords {refuse_keywords} in response, got: {actual_output!r}"
         )

--- a/tests/integration/agents/test_common_node.py
+++ b/tests/integration/agents/test_common_node.py
@@ -38,6 +38,9 @@ async def test_invoke_common_node(messages, expected_answer, companion_graph, an
     # When: the common node's invoke_common_node method is invoked
     result = await companion_graph._invoke_common_node(state, messages[-1].content)
 
+    # Pre-check: verify structural response before invoking the judge
+    assert result, f"Common node returned an empty response for input: {messages[-1].content!r}"
+
     # Then: we evaluate the response using deepeval metrics
     test_case = LLMTestCase(
         input=messages[-1].content,


### PR DESCRIPTION
## Description

Every GEval test currently invokes the live LLM then immediately scores with the judge -- no intermediate guards. A structural failure (empty response, wrong type) looks identical to a content quality failure.

Changes: add deterministic pre-checks before the judge call in \`test_invoke_chain\`, \`test_finalizer\`, \`test_goal_accuracy\`, \`test_common_node\`:
- \`assert len(agent_messages) > 0\` and \`assert actual_output\` before GEval
- Keyword presence checks for "ask for more info" cases
- Refusal keyword checks for finalizer "should not answer" cases

**Testing**
- \`poetry run poe pre-commit-check\` passes