### PR TITLE
test: split integration tests into 4 parallel subsets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -180,12 +180,20 @@ jobs:
   run-integration-tests:
     ## **IMPORTANT**: If any changes are made to how to run the integration tests
     ## in the release-workflow, make sure to update
-    ## in the run-integration-test.yaml workflow as well.
-    name: Run integration tests
+    ## in the pull-integration-test.yaml workflow as well.
+    name: "Run integration tests / ${{ matrix.subset.name }}"
     needs: validate-input-params
     runs-on: ubuntu-latest
     environment: e2e
     permissions: read-all
+    strategy:
+      fail-fast: false  # keep other subsets running if one fails
+      matrix:
+        subset:
+          - name: kyma-agent
+          - name: k8s-supervisor
+          - name: gatekeeper
+          - name: rag-services
     env:
       RELEASE_BRANCH: ${{ needs.validate-input-params.outputs.release_branch }}
     steps:
@@ -216,12 +224,12 @@ jobs:
       - name: Install dependencies
         run: poetry install --with dev
 
-      - name: Run integration tests
+      - name: Run integration tests (${{ matrix.subset.name }})
         env:
           LOG_LEVEL: "DEBUG"
         run: |
           echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
-          poetry run poe test-integration
+          poetry run poe test-integration-${{ matrix.subset.name }}
 
   run-integration-tests-indexer:
     ## **IMPORTANT**: If any changes are made to how to run the integration tests

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -9,46 +9,123 @@ on:
     branches:
       - "main"
       - "release-**"
+  workflow_dispatch:
+    inputs:
+      subset:
+        description: "Test subset to run (leave empty to run all: kyma-agent | k8s-supervisor | gatekeeper | rag-services)"
+        required: false
+        default: ""
 
 permissions: read-all
 
 jobs:
   integration-test:
-    if: contains(github.event.pull_request.labels.*.name, 'run-integration-test')
+    # pull_request_target: run when run-integration-test label (or a subset label) is present.
+    # workflow_dispatch: always run (subset filter applied per-job below).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration-test') ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration-test-kyma') ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration-test-k8s-supervisor') ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration-test-gatekeeper') ||
+      contains(github.event.pull_request.labels.*.name, 'run-integration-test-rag-services')
+
     runs-on: ubuntu-latest
     environment: e2e
 
+    strategy:
+      fail-fast: false  # keep other subsets running if one fails
+      matrix:
+        subset:
+          - name: kyma-agent
+            paths: tests/integration/agents/kyma
+          - name: k8s-supervisor
+            # space-separated list; the poe task expands it
+            paths: >-
+              tests/integration/agents/k8s
+              tests/integration/agents/supervisor
+              tests/integration/agents/test_common_node.py
+              tests/integration/agents/test_followup_questions.py
+          - name: gatekeeper
+            paths: >-
+              tests/integration/agents/test_gatekeeper_node.py
+              tests/integration/agents/test_gatekeeper_security.py
+              tests/integration/agents/summarization
+              tests/integration/agents/common
+          - name: rag-services
+            paths: >-
+              tests/integration/rag
+              tests/integration/services
+
+    name: "integration-test / ${{ matrix.subset.name }}"
+
     permissions:
       contents: read
+
     steps:
+      - name: Check if this subset should run
+        id: check
+        run: |
+          name="${{ matrix.subset.name }}"
+          event="${{ github.event_name }}"
+          dispatch_subset="${{ github.event.inputs.subset }}"
+          pr_labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+
+          if [ "$event" = "workflow_dispatch" ]; then
+            # Run all when no subset requested; run only the matching one otherwise.
+            if [ -z "$dispatch_subset" ] || [ "$dispatch_subset" = "$name" ]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # Run if the all-subsets label is present OR this subset's specific label is present.
+            if echo " $pr_labels " | grep -qw "run-integration-test" || \
+               echo " $pr_labels " | grep -qw "run-integration-test-$name"; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
       - name: Checkout code
+        if: steps.check.outputs.run == 'true'
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # Safe: the `environment: e2e` gate above requires codeowner approval before
           # this job runs, so secrets are never exposed to unreviewed fork code.
           allow-unsafe-pr-checkout: true
 
       - name: Extract Python version
+        if: steps.check.outputs.run == 'true'
         run: ./scripts/shell/extract-python-version.sh
 
       - name: Setup Python
+        if: steps.check.outputs.run == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
+        if: steps.check.outputs.run == 'true'
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
+        if: steps.check.outputs.run == 'true'
         run: poetry install --with dev
 
-      - name: Run integration tests
+      - name: Run integration tests (${{ matrix.subset.name }})
+        if: steps.check.outputs.run == 'true'
         env:
           LOG_LEVEL: "DEBUG"
         run: |
           echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
-          poetry run poe test-integration
+          poetry run poe test-integration-${{ matrix.subset.name }}
+
+      - name: Subset skipped
+        if: steps.check.outputs.run != 'true'
+        run: echo "Subset '${{ matrix.subset.name }}' not selected -- skipping."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 ]
 requires-python = "==3.13.*"
 dependencies = [
+  "a2a-sdk[http-server] (>=1.1.0,<2.0)",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=49.0.0,<50.0.0)",
   "fastapi[standard] (>=0.139.0,<0.140.0)",
@@ -39,8 +40,7 @@ dependencies = [
   "starlette (>=1.3.1,<2.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.13.0,<0.14.0)",
-  "uvicorn (>=0.49.0,<0.50.0)",
-  "a2a-sdk[http-server] (>=1.1.0,<2.0)"
+  "uvicorn (>=0.49.0,<0.50.0)"
 ]
 [tool.poetry]
 package-mode = false
@@ -93,6 +93,12 @@ test = "pytest -n 2 -v tests/unit"
 test-local = "pytest -n auto -v tests/unit"
 test-integration = "pytest -n 2 -v tests/integration -x --reruns=6 --reruns-delay=10 -r=aR"
 test-integration-local = "pytest -n auto -v tests/integration -x --reruns=6 --reruns-delay=10 -r=aR"
+# Subset tasks: each runs a logical slice of integration tests with -n 4 for higher parallelism.
+# These are invoked by the CI matrix; use the subset-specific label to rerun only one slice.
+test-integration-kyma-agent = "pytest -n 4 -v tests/integration/agents/kyma -x --reruns=6 --reruns-delay=10 -r=aR"
+test-integration-k8s-supervisor = "pytest -n 4 -v tests/integration/agents/k8s tests/integration/agents/supervisor tests/integration/agents/test_common_node.py tests/integration/agents/test_followup_questions.py -x --reruns=6 --reruns-delay=10 -r=aR"
+test-integration-gatekeeper = "pytest -n 4 -v tests/integration/agents/test_gatekeeper_node.py tests/integration/agents/test_gatekeeper_security.py tests/integration/agents/summarization tests/integration/agents/common -x --reruns=6 --reruns-delay=10 -r=aR"
+test-integration-rag-services = "pytest -n 4 -v tests/integration/rag tests/integration/services -x --reruns=6 --reruns-delay=10 -r=aR"
 run = "fastapi run src/main.py --port 8000"
 run-local = "fastapi dev src/main.py --port 8000"
 sort = "poetry sort"


### PR DESCRIPTION
## Description

Splits the single monolithic integration test job into 4 parallel matrix jobs, each covering a logical domain. Increases parallelism from 2 workers total to 4 workers per subset (16 total), and allows reruns of individual failing subsets without re-running the entire suite.

**Subsets:**

| Subset | Test paths |
|---|---|
| `kyma-agent` | `tests/integration/agents/kyma/` |
| `k8s-supervisor` | `tests/integration/agents/k8s/`, `supervisor/`, `test_common_node.py`, `test_followup_questions.py` |
| `gatekeeper` | `test_gatekeeper_node.py`, `test_gatekeeper_security.py`, `summarization/`, `common/` |
| `rag-services` | `tests/integration/rag/`, `tests/integration/services/` |

**How to rerun a subset:**
- Add `run-integration-test` to run all 4 subsets (existing behaviour)
- Add `run-integration-test-kyma` (or `-k8s-supervisor`, `-gatekeeper`, `-rag-services`) to run only that subset
- Use `workflow_dispatch` with the `subset` input to manually trigger one slice

**Changes:**
- `.github/workflows/pull-integration-test.yaml` -- matrix strategy, `fail-fast: false`, subset filter logic, `workflow_dispatch` with `subset` input
- `.github/workflows/create-release.yml` -- same matrix for the release pipeline
- `pyproject.toml` -- 4 new `poe test-integration-<subset>` tasks with `-n 4`

**Testing**
- `poetry run poe pre-commit-check` passes (1125 unit tests, mypy, ruff, actionlint)
- Add `run-integration-test` label to verify all 4 subsets trigger and run correctly