### PR TITLE
ci: add explicit CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,61 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
+      - "sec-scanners-config.yaml"
+  pull_request:
+    branches:
+      - "main"
+      - "release-*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
+      - "sec-scanners-config.yaml"
+  schedule:
+    - cron: '30 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Description

Adds an explicit CodeQL workflow file to satisfy the SAP repository linter rule `rl-vulnerability_alerts`, which requires code scan alerts to be enabled.

The repository was already running CodeQL via GitHub's org-level default setup, but the linter requires an explicit workflow file in the repository itself to detect the rule as satisfied. The workflow scans Python and GitHub Actions code on push/PR to main and release branches, plus weekly on Mondays.

Closes #981

## Related issue(s)

Fixes #981

## Testing

GHA workflow change -- cannot be verified before merge. Will verify that the workflow runs successfully immediately after the PR merges.