### PR TITLE
chore: fix CodeQL quality findings

### DIFF
--- a/doc_indexer/src/utils/logging.py
+++ b/doc_indexer/src/utils/logging.py
@@ -1,7 +1,6 @@
-import logging
 import sys
 from logging import Logger as LoggerType
-from logging import getLogger
+from logging import StreamHandler, getLogger
 
 from pythonjsonlogger.json import JsonFormatter
 
@@ -16,13 +15,12 @@ def _configure_logging() -> None:
     _logging_configured[0] = True
 
     formatter = JsonFormatter("%(asctime)s %(name)s %(levelname)s %(message)s")
-    handler = logging.StreamHandler(sys.stdout)
+    handler = StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
 
-    root = logging.getLogger()
+    root = getLogger()
     root.setLevel(LOG_LEVEL)
     root.addHandler(handler)
-
 
 
 _configure_logging()

--- a/doc_indexer/src/utils/logging.py
+++ b/doc_indexer/src/utils/logging.py
@@ -7,14 +7,13 @@ from pythonjsonlogger.json import JsonFormatter
 
 from utils.settings import LOG_LEVEL
 
-_logging_configured = False
+_logging_configured: list[bool] = [False]
 
 
 def _configure_logging() -> None:
-    global _logging_configured  # noqa: PLW0603
-    if _logging_configured:
+    if _logging_configured[0]:
         return
-    _logging_configured = True
+    _logging_configured[0] = True
 
     formatter = JsonFormatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     handler = logging.StreamHandler(sys.stdout)
@@ -23,6 +22,7 @@ def _configure_logging() -> None:
     root = logging.getLogger()
     root.setLevel(LOG_LEVEL)
     root.addHandler(handler)
+
 
 
 _configure_logging()

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,6 +25,7 @@ select = [
   "SIM",
   # flake8-pie
   "PIE",
+  "PIE790", # unnecessary placeholder (... or pass after docstring)
   # isort
   "I",
   # docstring

--- a/ruff.toml
+++ b/ruff.toml
@@ -23,9 +23,8 @@ select = [
   "B",
   # flake8-simplify
   "SIM",
-  # flake8-pie
+  # flake8-pie (PIE790: unnecessary placeholder -- ... or pass after docstring)
   "PIE",
-  "PIE790", # unnecessary placeholder (... or pass after docstring)
   # isort
   "I",
   # docstring

--- a/scripts/python/k8s_resources_discovery.py
+++ b/scripts/python/k8s_resources_discovery.py
@@ -82,7 +82,6 @@ def save_all_groups_with_resources(k8s_client: K8sClient, file_path: Path) -> No
 
 if __name__ == "__main__":
     # Validate if all the required K8s headers are provided.
-    config_path = Path(__file__).parent.parent.parent / "config" / "config.json"
     result_file = Path(__file__).parent.parent.parent / "config" / "api_resources.json"
 
     # check required envs are set or not.

--- a/scripts/python/wait-for-commit-check/run.py
+++ b/scripts/python/wait-for-commit-check/run.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 import time
 
 import requests
@@ -31,19 +32,19 @@ def read_inputs() -> dict:
     """Returns the dict with configs read from the environment variables."""
     github_token = os.environ.get("GITHUB_TOKEN")
     if github_token is None or github_token == "":
-        exit("ERROR: Env GITHUB_TOKEN is missing")
+        sys.exit("ERROR: Env GITHUB_TOKEN is missing")
 
     repository_full_name = os.environ.get("REPOSITORY_FULL_NAME")
     if repository_full_name is None or repository_full_name == "":
-        exit("ERROR: Env REPOSITORY_FULL_NAME is missing")
+        sys.exit("ERROR: Env REPOSITORY_FULL_NAME is missing")
 
     git_ref = os.environ.get("GIT_REF")
     if git_ref is None or git_ref == "":
-        exit("ERROR: Env GIT_REF is missing")
+        sys.exit("ERROR: Env GIT_REF is missing")
 
     git_check_run_name = os.environ.get("GIT_CHECK_RUN_NAME")
     if git_check_run_name is None or git_check_run_name == "":
-        exit("ERROR: Env GIT_CHECK_RUN_NAME is missing")
+        sys.exit("ERROR: Env GIT_CHECK_RUN_NAME is missing")
 
     # read and convert to integer.
     timeout_str = os.environ.get("TIMEOUT")  # seconds
@@ -51,9 +52,9 @@ def read_inputs() -> dict:
         if timeout_str is not None:
             timeout = int(timeout_str)
         else:
-            exit("ERROR: Env TIMEOUT is missing")
+            sys.exit("ERROR: Env TIMEOUT is missing")
     except Exception:
-        exit("ERROR: Env TIMEOUT is not an integer")
+        sys.exit("ERROR: Env TIMEOUT is not an integer")
 
     # read and convert to integer.
     interval_str = os.environ.get("INTERVAL")  # seconds
@@ -61,9 +62,9 @@ def read_inputs() -> dict:
         if interval_str is not None:
             interval = int(interval_str)
         else:
-            exit("ERROR: Env INTERVAL is missing")
+            sys.exit("ERROR: Env INTERVAL is missing")
     except Exception:
-        exit("ERROR: Env INTERVAL is missing or not an integer")
+        sys.exit("ERROR: Env INTERVAL is missing or not an integer")
 
     return {
         "token": github_token,
@@ -151,7 +152,7 @@ def main() -> None:
         )
         if elapsed_time > inputs["timeout"]:
             print("Error: Timed out!", flush=True)
-            exit(1)
+            sys.exit(1)
 
         # fetch check runs from GitHub.
         check_runs = fetch_check_runs(inputs["repository_full_name"], inputs["git_ref"], inputs["token"])
@@ -181,7 +182,7 @@ def main() -> None:
 
         if latest_check_run["conclusion"] == "success":
             print("Check run completed with success.", flush=True)
-            exit(0)
+            sys.exit(0)
 
         # https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
         if latest_check_run["conclusion"] in [
@@ -192,7 +193,7 @@ def main() -> None:
             "timed_out",
         ]:
             print("Check run completed with failure.", flush=True)
-            exit(1)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/python/wait-for-commit-check/run.py
+++ b/scripts/python/wait-for-commit-check/run.py
@@ -53,7 +53,7 @@ def read_inputs() -> dict:
             timeout = int(timeout_str)
         else:
             sys.exit("ERROR: Env TIMEOUT is missing")
-    except Exception:
+    except ValueError:
         sys.exit("ERROR: Env TIMEOUT is not an integer")
 
     # read and convert to integer.
@@ -63,7 +63,7 @@ def read_inputs() -> dict:
             interval = int(interval_str)
         else:
             sys.exit("ERROR: Env INTERVAL is missing")
-    except Exception:
+    except ValueError:
         sys.exit("ERROR: Env INTERVAL is missing or not an integer")
 
     return {

--- a/src/agents/common/agent.py
+++ b/src/agents/common/agent.py
@@ -77,12 +77,10 @@ class IAgent(Protocol):
 
     def agent_node(self) -> CompiledStateGraph:
         """Main agent function."""
-        ...
 
     @property
     def name(self) -> str:
         """Agent name."""
-        ...
 
 
 class BaseAgent:

--- a/src/agents/common/chunk_summarizer.py
+++ b/src/agents/common/chunk_summarizer.py
@@ -26,7 +26,6 @@ class IToolResponseSummarizer(Protocol):
         nums_of_chunks: int,
     ) -> str:
         """summarize each chunk and return final summarized response."""
-        ...
 
 
 class ToolResponseSummarizer:

--- a/src/agents/common/response_converter.py
+++ b/src/agents/common/response_converter.py
@@ -25,7 +25,6 @@ class IResponseConverter(Protocol):
         """
         Main conversion method that orchestrates the entire YAML to HTML conversion process.
         """
-        ...
 
 
 class ResponseConverter:

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -120,11 +120,9 @@ class IGraph(Protocol):
 
     def astream(self, conversation_id: str, message: Message, k8s_client: IK8sClient) -> AsyncIterator[str]:
         """Stream the output to the caller asynchronously."""
-        ...
 
     async def aget_messages(self, conversation_id: str) -> list[BaseMessage]:
         """Get messages from the graph state."""
-        ...
 
 
 class CompanionGraph:

--- a/src/agents/memory/async_redis_checkpointer.py
+++ b/src/agents/memory/async_redis_checkpointer.py
@@ -42,15 +42,12 @@ class IUsageMemory(Protocol):
 
     async def awrite_llm_usage(self, cluster_id: str, data: dict, ttl: int = 0) -> str:
         """Write LLM usage data to Redis. Return the key."""
-        ...
 
     async def adelete_expired_llm_usage_records(self, cluster_id: str, ttl: int) -> None:
         """Delete expired LLM usage records."""
-        ...
 
     async def alist_llm_usage_records(self, cluster_id: str, ttl: int) -> list[dict]:
         """List non-expired LLM usage records."""
-        ...
 
 
 # Utilities shared by both RedisSaver and AsyncRedisSaver

--- a/src/followup_questions/followup_questions.py
+++ b/src/followup_questions/followup_questions.py
@@ -25,7 +25,6 @@ class IFollowUpQuestionsHandler(Protocol):
 
     def generate_questions(self, messages: list[BaseMessage]) -> list[str]:
         """Generates follow-up questions given the conversation history."""
-        ...
 
 
 class FollowUpQuestionsHandler:

--- a/src/initial_questions/inital_questions.py
+++ b/src/initial_questions/inital_questions.py
@@ -25,7 +25,7 @@ class IInitialQuestionsHandler(Protocol):
         """Fetch the relevant data from Kubernetes cluster based on specified K8s resource in message."""
 
     def apply_token_limit(self, text: str, token_limit: int) -> str:
-        """Reduces the amount of tokens of a string by truncating exeeding tokens.
+        """Reduces the amount of tokens of a string by truncating exceeding tokens.
         Takes the template into account."""
 
 
@@ -70,7 +70,7 @@ class InitialQuestionsHandler:
             self._tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
 
     def apply_token_limit(self, text: str, token_limit: int) -> str:
-        """Reduces the amount of tokens of a string by truncating exeeding tokens.
+        """Reduces the amount of tokens of a string by truncating exceeding tokens.
         Takes the template into account."""
 
         tokens_template = self._tokenizer.encode(text=self._template)

--- a/src/initial_questions/inital_questions.py
+++ b/src/initial_questions/inital_questions.py
@@ -20,16 +20,13 @@ class IInitialQuestionsHandler(Protocol):
 
     def generate_questions(self, context: str) -> list[str]:
         """Generates initial questions given a context with cluster data."""
-        ...
 
     async def fetch_relevant_data_from_k8s_cluster(self, message: Message, k8s_client: IK8sClient) -> str:
         """Fetch the relevant data from Kubernetes cluster based on specified K8s resource in message."""
-        ...
 
     def apply_token_limit(self, text: str, token_limit: int) -> str:
         """Reduces the amount of tokens of a string by truncating exeeding tokens.
         Takes the template into account."""
-        ...
 
 
 class IEncoding(Protocol):
@@ -37,11 +34,9 @@ class IEncoding(Protocol):
 
     def encode(self, text: str) -> list[int]:
         """Encodes strings to tokens;"""
-        ...
 
     def decode(self, tokens: list[int]) -> str:
         """Decodes tokens to strings."""
-        ...
 
 
 class InitialQuestionsHandler:

--- a/src/initial_questions/output_parser.py
+++ b/src/initial_questions/output_parser.py
@@ -16,7 +16,6 @@ class IOutputParser(Protocol):
 
     def parse(self, output: str) -> list[str]:
         """Parse the output and return the questions."""
-        ...
 
 
 class QuestionOutputParser(BaseOutputParser):

--- a/src/rag/query_generator.py
+++ b/src/rag/query_generator.py
@@ -25,7 +25,6 @@ class IQueryGenerator(Protocol):
 
     async def agenerate_queries(self, query: str) -> Queries:
         """Generate multiple queries based on the input query."""
-        ...
 
 
 class QueryGenerator:

--- a/src/rag/reranker/reranker.py
+++ b/src/rag/reranker/reranker.py
@@ -41,7 +41,6 @@ class IReranker(Protocol):
         output_limit: int = 4,
     ) -> list[Document]:
         """Rerank the documents based on which documents are most relevant to the given queries."""
-        ...
 
 
 class LLMReranker(IReranker):

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -57,7 +57,6 @@ class IRetriever(Protocol):
 
     async def aretrieve(self, query: str, top_k: int = 3) -> list[Document]:
         """Retrieve relevant documents based on the query."""
-        ...
 
 
 class HanaDBRetriever:

--- a/src/rag/system.py
+++ b/src/rag/system.py
@@ -31,7 +31,6 @@ class IRAGSystem(Protocol):
 
     async def aretrieve(self, query: Query, top_k: int = 5) -> list[Document]:
         """Retrieve documents for a given query."""
-        ...
 
 
 class RAGSystem:

--- a/src/routers/probes.py
+++ b/src/routers/probes.py
@@ -200,3 +200,4 @@ def all_ready(response: HealthModel | ReadinessModel) -> bool:
             and response.are_models_initialized
             and response.is_key_store_initialized
         )
+    return False

--- a/src/routers/probes.py
+++ b/src/routers/probes.py
@@ -28,15 +28,12 @@ class IUsageTrackerProbe(Protocol):
 
     def reset_failure_count(self) -> None:
         """Sets the failure count back to 0."""
-        ...
 
     def increase_failure_count(self) -> None:
         """Increases the failure count by 1."""
-        ...
 
     def is_healthy(self) -> bool:
         """Checks if the failure count is equal or greater than the threshold."""
-        ...
 
 
 class IHanaConnection(Protocol):
@@ -44,7 +41,6 @@ class IHanaConnection(Protocol):
 
     def isconnected(self) -> bool:
         """Verifies if a connection to a Hana database is ready."""
-        ...
 
 
 class IHana(Protocol):
@@ -61,11 +57,9 @@ class IHana(Protocol):
         """
         Check if the Hana service is operational.
         """
-        ...
 
     def has_connection(self) -> bool:
         """Check if a connection exists."""
-        ...
 
 
 class IRedisConnection(Protocol):
@@ -75,7 +69,6 @@ class IRedisConnection(Protocol):
 
     def ping(self, **kwargs) -> ResponseT:  # noqa
         """Ping the Redis server."""
-        ...
 
 
 class IRedis(Protocol):
@@ -92,11 +85,9 @@ class IRedis(Protocol):
         """
         Check if the Redis service is operational.
         """
-        ...
 
     def has_connection(self) -> bool:
         """Check if a connection exists."""
-        ...
 
 
 class ILLMProbe(Protocol):
@@ -112,7 +103,6 @@ class ILLMProbe(Protocol):
             A dictionary where the keys are LLM names and the values are booleans
             indicating whether each LLM is ready.
         """
-        ...
 
     def has_models(self) -> bool:
         """
@@ -121,7 +111,6 @@ class ILLMProbe(Protocol):
         Returns:
             bool: True if models are available, False otherwise.
         """
-        ...
 
 
 @router.get("/healthz")

--- a/src/services/conversation.py
+++ b/src/services/conversation.py
@@ -39,23 +39,18 @@ class IService(Protocol):
 
     async def new_conversation(self, k8s_client: IK8sClient, message: Message) -> list[str]:
         """Initialize a new conversation."""
-        ...
 
     async def handle_followup_questions(self, conversation_id: str) -> list[str]:
         """Generate follow-up questions for a conversation."""
-        ...
 
     def handle_request(self, conversation_id: str, message: Message, k8s_client: IK8sClient) -> AsyncGenerator[bytes]:
         """Handle a request for a conversation"""
-        ...
 
     async def authorize_user(self, conversation_id: str, user_identifier: str) -> bool:
         """Authorize the user to access the conversation."""
-        ...
 
     async def is_usage_limit_exceeded(self, cluster_id: str) -> UsageExceedReport | None:
         """Check if the token usage limit is exceeded for the given cluster_id."""
-        ...
 
 
 class ConversationService(metaclass=SingletonMeta):

--- a/src/services/data_sanitizer.py
+++ b/src/services/data_sanitizer.py
@@ -187,7 +187,6 @@ class IDataSanitizer(Protocol):
 
     def sanitize(self, data: str | dict | list[dict]) -> dict | list[dict] | Any:
         """Sanitize the data by removing sensitive information."""
-        ...
 
 
 class DataSanitizer(metaclass=SingletonMeta):

--- a/src/services/encryption_cache.py
+++ b/src/services/encryption_cache.py
@@ -17,7 +17,6 @@ class IRedisService(Protocol):
 
     def get_connection(self) -> AsyncRedis:
         """Return an active Redis connection."""
-        ...
 
 
 @runtime_checkable
@@ -26,15 +25,12 @@ class IEncryptionCache(Protocol):
 
     async def save_client_public_key(self, session_id: str, public_key: str) -> None:
         """Persist a client public key."""
-        ...
 
     async def get_client_public_key(self, session_id: str) -> str | None:
         """Retrieve a client public key, or None if not found."""
-        ...
 
     async def is_nonce_allowed(self, session_id: str, nonce: str) -> bool:
         """Return True if the nonce is allowed (first use or within replay window)."""
-        ...
 
 
 class EncryptionCache:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -282,7 +282,8 @@ class K8sClient:
 
     def __del__(self) -> None:
         """Destructor to remove the temporary file containing certificates data."""
-        self._cleanup_temp_files()
+        with contextlib.suppress(Exception):
+            self._cleanup_temp_files()
 
     def _cleanup_temp_files(self) -> None:
         """Remove temporary certificate files created during initialization."""

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -282,7 +282,7 @@ class K8sClient:
 
     def __del__(self) -> None:
         """Destructor to remove the temporary file containing certificates data."""
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(OSError):
             self._cleanup_temp_files()
 
     def _cleanup_temp_files(self) -> None:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -131,19 +131,15 @@ class IK8sClient(Protocol):
 
     def get_api_server(self) -> str:
         """Returns the URL of the Kubernetes cluster."""
-        ...
 
     def model_dump(self) -> None:
         """Dump the model without any confidential data."""
-        ...
 
     async def execute_get_api_request(self, uri: str) -> dict | list[dict]:
         """Execute a GET request to the Kubernetes API."""
-        ...
 
     def list_resources(self, api_version: str, kind: str, namespace: str) -> list:
         """List resources of a specific kind in a namespace."""
-        ...
 
     def get_resource(
         self,
@@ -153,11 +149,9 @@ class IK8sClient(Protocol):
         namespace: str,
     ) -> dict:
         """Get a specific resource by name in a namespace."""
-        ...
 
     def get_resource_version(self, kind: str) -> str:
         """Get the resource version for a given kind."""
-        ...
 
     def describe_resource(
         self,
@@ -167,27 +161,21 @@ class IK8sClient(Protocol):
         namespace: str,
     ) -> dict:
         """Describe a specific resource by name in a namespace. This includes the resource and its events."""
-        ...
 
     def list_not_running_pods(self, namespace: str) -> list[dict]:
         """List all pods that are not in the Running phase"""
-        ...
 
     async def list_nodes_metrics(self) -> list[dict]:
         """List all node metrics."""
-        ...
 
     def list_k8s_events(self, namespace: str) -> list[dict]:
         """List all Kubernetes events."""
-        ...
 
     def list_k8s_warning_events(self, namespace: str) -> list[dict]:
         """List all Kubernetes warning events."""
-        ...
 
     def list_k8s_events_for_resource(self, kind: str, name: str, namespace: str) -> list[dict]:
         """List all Kubernetes events for a specific resource."""
-        ...
 
     async def fetch_pod_logs(
         self,
@@ -197,7 +185,6 @@ class IK8sClient(Protocol):
         tail_limit: int,
     ) -> PodLogsResult:
         """Fetch logs of Kubernetes Pod."""
-        ...
 
     async def get_namespace(self, name: str) -> dict:
         """
@@ -212,15 +199,12 @@ class IK8sClient(Protocol):
         Raises:
             ValueError: If the namespace is not found or the API call fails.
         """
-        ...
 
     async def get_group_version(self, group_version: str) -> dict:
         """Get the group version of the Kubernetes API."""
-        ...
 
     def get_data_sanitizer(self) -> IDataSanitizer | None:
         """Return the data sanitizer instance"""
-        ...
 
 
 def get_url_for_paged_request(base_url: str, continue_token: str) -> str:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import contextlib
 import copy
 import os
 import ssl
@@ -279,25 +280,20 @@ class K8sClient:
 
         self.data_sanitizer = data_sanitizer
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Destructor to remove the temporary file containing certificates data."""
-        if self.ca_temp_filename != "":
-            try:
-                os.remove(self.ca_temp_filename)
-            except FileNotFoundError:
-                return
+        self._cleanup_temp_files()
 
-        if self.client_cert_temp_filename != "":
-            try:
-                os.remove(self.client_cert_temp_filename)
-            except FileNotFoundError:
-                return
-
-        if self.client_key_temp_filename != "":
-            try:
-                os.remove(self.client_key_temp_filename)
-            except FileNotFoundError:
-                return
+    def _cleanup_temp_files(self) -> None:
+        """Remove temporary certificate files created during initialization."""
+        for filename in (
+            getattr(self, "ca_temp_filename", ""),
+            getattr(self, "client_cert_temp_filename", ""),
+            getattr(self, "client_key_temp_filename", ""),
+        ):
+            if filename:
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(filename)
 
     def get_api_server(self) -> str:
         """Returns the URL of the Kubernetes cluster."""

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -282,8 +282,7 @@ class K8sClient:
 
     def __del__(self) -> None:
         """Destructor to remove the temporary file containing certificates data."""
-        with contextlib.suppress(OSError):
-            self._cleanup_temp_files()
+        self._cleanup_temp_files()
 
     def _cleanup_temp_files(self) -> None:
         """Remove temporary certificate files created during initialization."""
@@ -293,7 +292,7 @@ class K8sClient:
             getattr(self, "client_key_temp_filename", ""),
         ):
             if filename:
-                with contextlib.suppress(FileNotFoundError):
+                with contextlib.suppress(OSError):
                     os.remove(filename)
 
     def get_api_server(self) -> str:

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -49,7 +49,8 @@ _logging_configured: list[bool] = [False]
 def _configure_logging() -> None:
     """Configure logging based on LOG_LEVEL and LOG_FORMAT settings.
 
-    Can be called multiple times safely - only configures once unless force=True.
+    Can be called multiple times safely -- only configures once.
+    Use reconfigure_logging() to force reconfiguration.
     """
     if _logging_configured[0]:
         return

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -42,23 +42,19 @@ class PrettyJSONFormatter(Formatter):
         return json.dumps(log_data, indent=2, sort_keys=False)
 
 
-# Flag to track if logging has been configured
-_logging_configured = False
-
-
 # Configure logging programmatically
+_logging_configured: list[bool] = [False]
+
+
 def _configure_logging() -> None:
     """Configure logging based on LOG_LEVEL and LOG_FORMAT settings.
 
     Can be called multiple times safely - only configures once unless force=True.
     """
-    global _logging_configured  # noqa: PLW0603
-
-    # Prevent duplicate configuration
-    if _logging_configured:
+    if _logging_configured[0]:
         return
 
-    _logging_configured = True
+    _logging_configured[0] = True
 
     # Determine formatter based on LOG_FORMAT
     format_type = LOG_FORMAT.lower()
@@ -107,6 +103,7 @@ def _configure_logging() -> None:
         uvicorn_logger.propagate = False
 
 
+
 # Initialize logging when module is imported
 _configure_logging()
 
@@ -120,8 +117,7 @@ def get_logger(name: str) -> Logger:
 
 def reconfigure_logging() -> None:
     """Force reconfiguration of logging (useful for testing or hot reload)."""
-    global _logging_configured  # noqa: PLW0603
-    _logging_configured = False
+    _logging_configured[0] = False
     _configure_logging()
 
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -109,7 +109,6 @@ def _configure_logging() -> None:
         uvicorn_logger.propagate = False
 
 
-
 # Initialize logging when module is imported
 _configure_logging()
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,8 +1,13 @@
 import json
-import logging
-import logging.config
 import sys
-from logging import Formatter, Logger, LogRecord, getLogger
+from logging import (
+    CRITICAL,
+    Formatter,
+    Logger,
+    LogRecord,
+    StreamHandler,
+    getLogger,
+)
 
 from tenacity import RetryCallState
 
@@ -72,34 +77,34 @@ def _configure_logging() -> None:
                 "WARNING: LOG_FORMAT=json specified but python-json-logger not installed. "
                 "Run 'poetry install' to enable JSON logging. Using standard format.\n"
             )
-            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            formatter = Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     elif format_type == "pretty":
         # Pretty-printed JSON for development (no external deps needed)
         formatter = PrettyJSONFormatter()
     else:
         # Standard human-readable format
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        formatter = Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
     # Configure console handler
-    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler = StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)
 
     # Configure root logger
-    root_logger = logging.getLogger()
+    root_logger = getLogger()
     root_logger.setLevel(LOG_LEVEL)
     # Clear existing handlers to prevent duplicates when reconfiguring
     root_logger.handlers.clear()
     root_logger.addHandler(console_handler)
 
     # Disable uvicorn.access logger (handled by middleware)
-    uvicorn_access = logging.getLogger("uvicorn.access")
+    uvicorn_access = getLogger("uvicorn.access")
     uvicorn_access.handlers.clear()  # Clear handlers properly
-    uvicorn_access.setLevel(logging.CRITICAL)
+    uvicorn_access.setLevel(CRITICAL)
     uvicorn_access.propagate = False
 
     # Configure other uvicorn loggers to use our handler
     for logger_name in ["uvicorn", "uvicorn.error"]:
-        uvicorn_logger = logging.getLogger(logger_name)
+        uvicorn_logger = getLogger(logger_name)
         uvicorn_logger.handlers = [console_handler]
         uvicorn_logger.propagate = False
 

--- a/src/utils/models/factory.py
+++ b/src/utils/models/factory.py
@@ -60,8 +60,6 @@ class IModel(Protocol):
     def name(self) -> str:
         """The name of the model."""
 
-    """The name of the model."""
-
     @property
     def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
         """The instance of the model."""

--- a/src/utils/models/factory.py
+++ b/src/utils/models/factory.py
@@ -59,14 +59,12 @@ class IModel(Protocol):
     @property
     def name(self) -> str:
         """The name of the model."""
-        ...
 
     """The name of the model."""
 
     @property
     def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
         """The instance of the model."""
-        ...
 
 
 @lru_cache(maxsize=1)
@@ -80,11 +78,9 @@ class IModelFactory(Protocol):
 
     def create_model(self, name: str) -> IModel | Embeddings:
         """Create a model."""
-        ...
 
     def create_models(self) -> dict[str, IModel | Embeddings]:
         """Create all models."""
-        ...
 
 
 class ModelFactory:

--- a/tests/blackbox/src/evaluation/process_scenario.py
+++ b/tests/blackbox/src/evaluation/process_scenario.py
@@ -102,17 +102,16 @@ def initialize_conversation(
             retry_wait_time += config.retry_wait_time
 
     # If we run out of retries, we set the scenario status to failed.
-    else:
-        scenario.test_status = TestStatus.FAILED
-        scenario.test_status_reason = (
-            f"failed to call initialize conversation endpoint after multiple retries. {companion_error}"
-        )
-        logger.error(
-            f"skipping scenario because failed to call initialize conversation endpoint "
-            f"after multiple retries. Error: {companion_error}"
-        )
-        # We return None to indicate that the initialization failed.
-        return None
+    scenario.test_status = TestStatus.FAILED
+    scenario.test_status_reason = (
+        f"failed to call initialize conversation endpoint after multiple retries. {companion_error}"
+    )
+    logger.error(
+        f"skipping scenario because failed to call initialize conversation endpoint "
+        f"after multiple retries. Error: {companion_error}"
+    )
+    # We return None to indicate that the initialization failed.
+    return None
 
 
 def get_companion_responses(

--- a/tests/integration/agents/k8s/test_k8s_agent.py
+++ b/tests/integration/agents/k8s/test_k8s_agent.py
@@ -27,7 +27,7 @@ def correctness_metric(evaluator_model):
             LLMTestCaseParams.EXPECTED_OUTPUT,
         ],
         evaluation_steps=[
-            "Evaluate whether two answers are semantically similar or convey the same meaning."
+            "Evaluate whether two answers are semantically similar or convey the same meaning.",
             "Check whether the facts in 'actual output' contradict any facts in 'expected output'",
             "Lightly penalize omissions of detail, focusing on the main idea",
             "Vague language are permissible",

--- a/tests/integration/agents/kyma/test_kyma_agent.py
+++ b/tests/integration/agents/kyma/test_kyma_agent.py
@@ -46,7 +46,7 @@ def correctness_metric(evaluator_model):
             LLMTestCaseParams.EXPECTED_OUTPUT,
         ],
         evaluation_steps=[
-            "Evaluate whether two answers are semantically similar or convey the same meaning."
+            "Evaluate whether two answers are semantically similar or convey the same meaning.",
             "Check whether the facts in 'actual output' contradict any facts in 'expected output'",
             "Lightly penalize omissions of detail, focusing on the main idea",
             "Vague language are permissible",

--- a/tests/unit/agents/common/test_response_converter.py
+++ b/tests/unit/agents/common/test_response_converter.py
@@ -516,7 +516,12 @@ def test_replace_yaml_with_html(response_converter, finalizer_response, replacem
             UPDATE_YAML,
             [
                 """invalid: :""",
-                '<div class="yaml-block"> <div class="yaml"> ```yaml apiVersion: apps/v1 kind: Service metadata: name: test-svc namespace: test-ns ``` </div> <div class="link" link-type="Update"> [Apply](/namespaces/test-ns/Service/test-svc) </div> </div>',  # noqa: E501
+                (
+                    '<div class="yaml-block"> <div class="yaml"> ```yaml apiVersion: apps/v1 '
+                    + "kind: Service metadata: name: test-svc namespace: test-ns ``` </div> <div "
+                    + 'class="link" link-type="Update"> '
+                    + "[Apply](/namespaces/test-ns/Service/test-svc) </div> </div>"
+                ),
             ],
         ),
         ([], NEW_YAML, []),

--- a/tests/unit/agents/common/test_response_converter.py
+++ b/tests/unit/agents/common/test_response_converter.py
@@ -516,10 +516,7 @@ def test_replace_yaml_with_html(response_converter, finalizer_response, replacem
             UPDATE_YAML,
             [
                 """invalid: :""",
-                '<div class="yaml-block"> <div class="yaml"> ```yaml apiVersion: apps/v1 '
-                "kind: Service metadata: name: test-svc namespace: test-ns ``` </div> <div "
-                'class="link" link-type="Update"> '
-                "[Apply](/namespaces/test-ns/Service/test-svc) </div> </div>",
+                '<div class="yaml-block"> <div class="yaml"> ```yaml apiVersion: apps/v1 kind: Service metadata: name: test-svc namespace: test-ns ``` </div> <div class="link" link-type="Update"> [Apply](/namespaces/test-ns/Service/test-svc) </div> </div>',  # noqa: E501
             ],
         ),
         ([], NEW_YAML, []),

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -414,7 +414,7 @@ class TestK8sClient:
     @pytest.fixture
     def k8s_client(self):
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             k8s_client.client_ssl_context = None
             return k8s_client
 
@@ -429,7 +429,7 @@ class TestK8sClient:
 
             # Create K8sClient instance
             with patch("services.k8s.K8sClient.__init__", return_value=None):
-                k8s_client = K8sClient()
+                k8s_client = K8sClient(Mock())
                 k8s_client._dynamic_client = None  # Simulate lazy initialization state
                 k8s_client._create_dynamic_client = mock_create
 
@@ -1966,7 +1966,7 @@ class TestParseContainerState:
         """Test parsing waiting state with reason and message."""
         # Given: Container in waiting state with reason and message
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {
                 "waiting": {
                     "reason": "CrashLoopBackOff",
@@ -1990,7 +1990,7 @@ class TestParseContainerState:
         expected_exit_code = 137
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {
                 "terminated": {
                     "reason": "OOMKilled",
@@ -2013,7 +2013,7 @@ class TestParseContainerState:
         """Test parsing running state."""
         # Given: Container in running state
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {"running": {}}
 
             # When: Parse the container state
@@ -2030,7 +2030,7 @@ class TestParseContainerState:
         """Test parsing unknown/empty state."""
         # Given: Empty container state dictionary
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {}
 
             # When: Parse the container state
@@ -2047,7 +2047,7 @@ class TestParseContainerState:
         """Test parsing waiting state when message is missing."""
         # Given: Container waiting with reason but no message
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {
                 "waiting": {
                     "reason": "ImagePullBackOff",
@@ -2068,7 +2068,7 @@ class TestParseContainerState:
         """Test parsing terminated state when optional fields are missing."""
         # Given: Container terminated with minimal fields
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             state = {
                 "terminated": {
                     "reason": "Error",
@@ -2093,7 +2093,7 @@ class TestFormatEventsForDiagnostic:
         """Test formatting with empty event list."""
         # Given: Empty event list
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = []
             tail_limit = 100
 
@@ -2108,7 +2108,7 @@ class TestFormatEventsForDiagnostic:
         """Test formatting a single event."""
         # Given: Single event with count of 1
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": "Started",
@@ -2133,7 +2133,7 @@ class TestFormatEventsForDiagnostic:
         expected_count = 15
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": "BackOff",
@@ -2157,7 +2157,7 @@ class TestFormatEventsForDiagnostic:
         expected_line_count = 11  # header + 10 events
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": f"Event{i}",
@@ -2189,7 +2189,7 @@ class TestFormatEventsForDiagnostic:
         expected_line_count = 4  # header + 3 events
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": f"Event{i}",
@@ -2216,7 +2216,7 @@ class TestFormatEventsForDiagnostic:
         """Test formatting event with missing reason, message, and count."""
         # Given: Event with all fields missing
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     # Missing all fields
@@ -2236,7 +2236,7 @@ class TestFormatEventsForDiagnostic:
         """Test that events are displayed in reverse chronological order (most recent first)."""
         # Given: Multiple events in chronological order
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {"reason": "Event1", "message": "Message 1", "count": 1},
                 {"reason": "Event2", "message": "Message 2", "count": 1},
@@ -2263,7 +2263,7 @@ class TestFormatPodEventsForDiagnostic:
         """Test formatting when no events are available."""
         # Given: No events available for pod
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             monkeypatch.setattr(k8s_client, "list_k8s_events_for_resource", Mock(return_value=[]))
 
             # When: Format pod events for diagnostic
@@ -2277,7 +2277,7 @@ class TestFormatPodEventsForDiagnostic:
         """Test formatting with a single event."""
         # Given: Pod with single event
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": "Started",
@@ -2300,7 +2300,7 @@ class TestFormatPodEventsForDiagnostic:
         # Given: Pod event with count greater than 1
         expected_event_count = 5
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": "BackOff",
@@ -2329,7 +2329,7 @@ class TestFormatPodEventsForDiagnostic:
         expected_newest_hidden_event_index = 0
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": f"Event{i}",
@@ -2367,7 +2367,7 @@ class TestFormatPodEventsForDiagnostic:
         expected_hidden_event_index = 6
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     "reason": f"Event{i}",
@@ -2394,7 +2394,7 @@ class TestFormatPodEventsForDiagnostic:
         """Test formatting handles missing event fields gracefully."""
         # Given: Pod event with missing fields
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             events = [
                 {
                     # Missing reason, message, and count
@@ -2417,7 +2417,7 @@ class TestFormatContainerStatusesStructured:
         """Test when pod has no container statuses."""
         # Given: Pod with no container statuses
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
         pod_description = {"status": {}}
 
         # When: Format container statuses structured
@@ -2431,7 +2431,7 @@ class TestFormatContainerStatusesStructured:
         """Test container in waiting state."""
         # Given: Container in waiting state
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
         pod_description = {
             "status": {
                 "containerStatuses": [
@@ -2469,7 +2469,7 @@ class TestFormatContainerStatusesStructured:
         expected_restart_count = 3
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "containerStatuses": [
@@ -2505,7 +2505,7 @@ class TestFormatContainerStatusesStructured:
         """Test container in running state."""
         # Given: Container in running state
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "containerStatuses": [
@@ -2536,7 +2536,7 @@ class TestFormatContainerStatusesStructured:
         expected_oom_exit_code = 137
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "containerStatuses": [
@@ -2574,7 +2574,7 @@ class TestFormatContainerStatusesStructured:
         expected_sidecar_restart_count = 5
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "containerStatuses": [
@@ -2613,7 +2613,7 @@ class TestFormatContainerStatusesStructured:
         """Test container with missing name defaults to 'unknown'."""
         # Given: Container status with missing name
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "containerStatuses": [
@@ -2642,7 +2642,7 @@ class TestFormatInitContainerStatusesStructured:
         """Test when pod has no init container statuses."""
         # Given: Pod with no init container statuses
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {"status": {}}
 
             # When: Format init container statuses structured
@@ -2658,7 +2658,7 @@ class TestFormatInitContainerStatusesStructured:
         expected_restart_count = 3
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "initContainerStatuses": [
@@ -2694,7 +2694,7 @@ class TestFormatInitContainerStatusesStructured:
         """Test init container in terminated state."""
         # Given: Init container in terminated state
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "initContainerStatuses": [
@@ -2729,7 +2729,7 @@ class TestFormatInitContainerStatusesStructured:
         """Test init container in running state."""
         # Given: Init container in running state
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "initContainerStatuses": [
@@ -2761,7 +2761,7 @@ class TestFormatInitContainerStatusesStructured:
         expected_cache_restart_count = 2
 
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "initContainerStatuses": [
@@ -2799,7 +2799,7 @@ class TestFormatInitContainerStatusesStructured:
         """Test init container with missing name defaults to 'unknown'."""
         # Given: Init container status with missing name
         with patch("services.k8s.K8sClient.__init__", return_value=None):
-            k8s_client = K8sClient()
+            k8s_client = K8sClient(Mock())
             pod_description = {
                 "status": {
                     "initContainerStatuses": [

--- a/tests/unit/services/test_langfuse.py
+++ b/tests/unit/services/test_langfuse.py
@@ -1,6 +1,6 @@
 import copy
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -13,7 +13,7 @@ from utils.settings import LangfuseMaskingModes
 
 def create_k8s_client():
     with patch("services.k8s.K8sClient.__init__", return_value=None):
-        return K8sClient()
+        return K8sClient(Mock())
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -37,7 +37,8 @@ class TestUsageTrackerCallback:
 
         # Then
         assert run_id in usage_tracker_callback.llm_start_times
-        assert usage_tracker_callback.llm_start_times.pop(run_id) > 0
+        start_time = usage_tracker_callback.llm_start_times.pop(run_id)
+        assert start_time > 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/utils/test_exceptions.py
+++ b/tests/unit/utils/test_exceptions.py
@@ -191,7 +191,7 @@ class TestK8sClientError:
                 "get_pod",
                 "/api/v1/pods/test",
                 HTTPStatus.NOT_FOUND,
-                lambda msg: "Pod not found" in msg,
+                lambda msg: "Pod not found" in str(msg),
             ),
             # ApiException with invalid status - non-numeric
             (
@@ -200,7 +200,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # ApiException with out of range status
             (
@@ -209,7 +209,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # ApiException below minimum range
             (
@@ -218,7 +218,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # ApiException above maximum range
             (
@@ -227,7 +227,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # ApiException without http_resp
             (
@@ -240,7 +240,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # ApiException with boundary status codes
             (
@@ -253,7 +253,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.CONTINUE,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             (
                 "api_exception",
@@ -261,7 +261,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 599,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             (
                 "api_exception",
@@ -269,7 +269,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.OK,
-                lambda msg: "Error" in msg,
+                lambda msg: "Error" in str(msg),
             ),
             # Generic exception
             (
@@ -287,7 +287,7 @@ class TestK8sClientError:
                 "test_tool",
                 "",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
-                lambda msg: "Custom error" in msg,
+                lambda msg: "Custom error" in str(msg),
             ),
         ],
     )


### PR DESCRIPTION
## Description

Fixes the following CodeQL quality findings and underlying bugs:

**Statement has no effect (63 findings)** -- Removes redundant `...` placeholders from Protocol and ABC stub method bodies across `src/`. Methods with a docstring need no additional placeholder body. `PIE790` (unnecessary placeholder) is already enforced via the `PIE` group in `ruff.toml`; a clarifying comment is added inline.

**Wrong number of arguments in a class instantiation (36 findings)** -- `K8sClient()` was called without the required `k8s_auth_headers` argument in tests that patch `__init__` to `return None`. Fixed by passing `Mock()` as a placeholder argument.

**Use of exit() or quit() (11 findings)** -- Replaces `exit()` with `sys.exit()` in `scripts/python/wait-for-commit-check/run.py`. `exit()` depends on the `site` module being loaded; `sys.exit()` is always available.

**Membership test with a non-container (10 findings)** -- Test lambdas used `"Error" in msg` where CodeQL could not prove `msg` is a container. Fixed by using `"Error" in str(msg)`.

**Implicit string concatenation in a list (3 findings)** -- Two evaluation steps in integration tests (`test_k8s_agent.py`, `test_kyma_agent.py`) were silently concatenated into one string due to a missing comma, reducing the number of evaluated criteria from 2 to 1. Fixed by adding the missing comma. The third was an intentional multi-line string literal, rewritten with explicit `+` concatenation.

**Unused global variable (3 findings)** -- `_logging_configured` in `src/utils/logging.py` and `doc_indexer/src/utils/logging.py` was flagged because it was only accessed via the `global` keyword inside functions. Replaced with a `list[bool]` so mutation does not require `global`. Also removes dead `config_path` variable in `scripts/python/k8s_resources_discovery.py`.

**Module is imported with 'import' and 'import from' (2 findings)** -- Both logging modules imported `logging` with both `import logging` and `from logging import ...`. Consolidated to a single `from logging import ...` block.

**Assert statement has a side-effect (1 finding)** -- `assert dict.pop(key) > 0` mutates the dict inside an assert, which is skipped when Python runs with `-O`. Fixed by extracting `pop()` to a variable before asserting.

**Unnecessary else clause in loop (1 finding)** -- `else` block after a `while` loop with no `break` is redundant. Removed the `else` and dedented the block.

**Overly complex __del__ method / resource leak bug** -- The original `__del__` used `except FileNotFoundError: return` inside each cleanup block. If the CA cert file was missing, the function returned immediately, leaving the client-cert and client-key temp files on disk. Fixed by extracting into `_cleanup_temp_files()` using independent `contextlib.suppress(OSError)` per file, so all three files are always cleaned up regardless of individual failures.

**Explicit returns mixed with implicit returns / latent type error (1 finding)** -- `all_ready()` in `probes.py` returned `None` (not `False`) when passed an unrecognised response type, violating its `-> bool` return type. Fixed by adding an explicit `return False`.

Also fixes:
- A pre-existing orphaned duplicate docstring in `src/utils/models/factory.py`
- A typo ("exeeding" -> "exceeding") in `src/initial_questions/inital_questions.py`

## Related issue(s)

<!-- No issue -->

## Testing

No logic changes beyond bug fixes noted above. `pre-commit-check` passes (lint, typecheck, format, unit tests).