### PR TITLE
fix: sensitive details are not getting sanatized

### DIFF
--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -369,6 +369,7 @@ class K8sClient:
             page_count = 0
             all_items: list[dict] = []
             continue_token = ""
+            response_kind: str | None = None
 
             # loop until all items are fetched or continue token is empty.
             while True:
@@ -400,13 +401,24 @@ class K8sClient:
                     if "items" not in result:
                         return all_items if len(all_items) else result
 
+                    # Preserve the list kind from the first page so the sanitizer can
+                    # dispatch correctly (e.g. SecretList items must be sanitized as secrets).
+                    if response_kind is None:
+                        response_kind = result.get("kind")
+
                     if len(result["items"]) > 0:
                         all_items.extend(result["items"])
 
                     # Check for continue token
                     continue_token = result.get("metadata", {}).get("continue", "")
                     if not continue_token:
-                        return all_items if len(all_items) else result
+                        if not all_items:
+                            return result
+                        # Re-wrap items with the list kind so the sanitizer can dispatch
+                        # on kind (e.g. SecretList) instead of receiving bare item dicts.
+                        if response_kind:
+                            return {"kind": response_kind, "items": all_items}
+                        return all_items
 
     async def execute_get_api_request(self, uri: str) -> dict | list[dict]:
         """Execute a GET request to the Kubernetes API"""
@@ -425,6 +437,10 @@ class K8sClient:
 
         if self.data_sanitizer:
             result = self.data_sanitizer.sanitize(result)
+            # _paginated_api_request re-wraps accumulated items in {"kind": ..., "items": [...]}
+            # so the sanitizer can dispatch on kind. Unwrap back to a flat list for callers.
+            if isinstance(result, dict) and "items" in result and "kind" in result:
+                return result["items"]
         return result
 
     def list_resources(self, api_version: str, kind: str, namespace: str) -> list[dict]:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -437,10 +437,11 @@ class K8sClient:
 
         if self.data_sanitizer:
             result = self.data_sanitizer.sanitize(result)
-            # _paginated_api_request re-wraps accumulated items in {"kind": ..., "items": [...]}
-            # so the sanitizer can dispatch on kind. Unwrap back to a flat list for callers.
-            if isinstance(result, dict) and "items" in result and "kind" in result:
-                return result["items"]
+
+        # _paginated_api_request re-wraps accumulated items in {"kind": ..., "items": [...]}
+        # so the sanitizer can dispatch on kind. Unwrap back to a flat list for callers.
+        if isinstance(result, dict) and "items" in result and "kind" in result:
+            return result["items"]
         return result
 
     def list_resources(self, api_version: str, kind: str, namespace: str) -> list[dict]:

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -377,7 +377,7 @@ class K8sClient:
                             uri=base_url,
                         )
 
-                    result = await response.json()
+                    result: dict[str, Any] = await response.json()
                     if "items" not in result:
                         return all_items if len(all_items) else result
 
@@ -421,8 +421,8 @@ class K8sClient:
         # _paginated_api_request re-wraps accumulated items in {"kind": ..., "items": [...]}
         # so the sanitizer can dispatch on kind. Unwrap back to a flat list for callers.
         if isinstance(result, dict) and "items" in result and "kind" in result:
-            return result["items"]
-        return result
+            return cast(list[dict[Any, Any]], result["items"])
+        return cast(dict[Any, Any] | list[dict[Any, Any]], result)
 
     def list_resources(self, api_version: str, kind: str, namespace: str) -> list[dict]:
         """List resources of a specific kind in a namespace.

--- a/src/services/k8s.py
+++ b/src/services/k8s.py
@@ -420,7 +420,7 @@ class K8sClient:
 
         # _paginated_api_request re-wraps accumulated items in {"kind": ..., "items": [...]}
         # so the sanitizer can dispatch on kind. Unwrap back to a flat list for callers.
-        if isinstance(result, dict) and "items" in result and "kind" in result:
+        if isinstance(result, dict) and set(result.keys()) == {"kind", "items"}:
             return cast(list[dict[Any, Any]], result["items"])
         return cast(dict[Any, Any] | list[dict[Any, Any]], result)
 

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -723,6 +723,69 @@ class TestK8sClient:
                 ],
                 "multi-page",
             ),
+            (
+                "should return flat item list for single-page SecretList response without sanitizer",
+                None,
+                [
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "my-secret"},
+                                "data": {"password": "c3VwZXItc2VjcmV0"},
+                            }
+                        ],
+                        "metadata": {},
+                    }
+                ],
+                [
+                    {
+                        "metadata": {"name": "my-secret"},
+                        "data": {"password": "c3VwZXItc2VjcmV0"},
+                    }
+                ],
+                "single-page",
+            ),
+            (
+                "should return flat item list for multi-page SecretList response without sanitizer",
+                None,
+                [
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "secret-1"},
+                                "data": {"password": "c2VjcmV0LTE="},
+                            }
+                        ],
+                        "metadata": {"continue": "token123"},
+                    },
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "secret-2"},
+                                "data": {"token": "c2VjcmV0LTI="},
+                            }
+                        ],
+                        "metadata": {},
+                    },
+                ],
+                [
+                    {
+                        "metadata": {"name": "secret-1"},
+                        "data": {"password": "c2VjcmV0LTE="},
+                    },
+                    {
+                        "metadata": {"name": "secret-2"},
+                        "data": {"token": "c2VjcmV0LTI="},
+                    },
+                ],
+                "multi-page",
+            ),
         ],
     )
     async def test_get_api_request_list_with_pagination(

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -670,7 +670,7 @@ class TestK8sClient:
                         "items": [
                             {
                                 "metadata": {"name": "my-secret"},
-                                "data": {"password": "c3VwZXItc2VjcmV0"},
+                                "data": {".dockerconfigjson": "c3VwZXItc2VjcmV0"},
                             }
                         ],
                         "metadata": {},

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -656,6 +656,73 @@ class TestK8sClient:
                 [{"raw": "data"}],
                 "single-page",
             ),
+            # Bug: paginated list strips the outer SecretList dict (which has `kind`),
+            # returning a bare list of items. Real K8s list items do NOT carry `kind`,
+            # so _sanitize_object never dispatches to _sanitize_secret and secret data
+            # passes through unsanitized.
+            (
+                "should sanitize secret data for single-page SecretList response",
+                DataSanitizer(),
+                [
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "my-secret"},
+                                "data": {"password": "c3VwZXItc2VjcmV0"},
+                            }
+                        ],
+                        "metadata": {},
+                    }
+                ],
+                [
+                    {
+                        "metadata": {"name": "my-secret"},
+                        "data": {},
+                    }
+                ],
+                "single-page",
+            ),
+            (
+                "should sanitize secret data for multi-page SecretList response",
+                DataSanitizer(),
+                [
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "secret-1"},
+                                "data": {"password": "c2VjcmV0LTE="},
+                            }
+                        ],
+                        "metadata": {"continue": "token123"},
+                    },
+                    {
+                        "kind": "SecretList",
+                        "apiVersion": "v1",
+                        "items": [
+                            {
+                                "metadata": {"name": "secret-2"},
+                                "data": {"token": "c2VjcmV0LTI="},
+                            }
+                        ],
+                        "metadata": {},
+                    },
+                ],
+                [
+                    {
+                        "metadata": {"name": "secret-1"},
+                        "data": {},
+                    },
+                    {
+                        "metadata": {"name": "secret-2"},
+                        "data": {},
+                    },
+                ],
+                "multi-page",
+            ),
         ],
     )
     async def test_get_api_request_list_with_pagination(
@@ -707,7 +774,7 @@ class TestK8sClient:
             result = await k8s_client.execute_get_api_request("/test/uri")
 
         # then
-        if data_sanitizer:
+        if data_sanitizer and isinstance(data_sanitizer, Mock):
             assert data_sanitizer.sanitize.call_count == 1
 
         assert result == expected_result

--- a/tests/unit/services/test_k8s.py
+++ b/tests/unit/services/test_k8s.py
@@ -694,7 +694,7 @@ class TestK8sClient:
                         "items": [
                             {
                                 "metadata": {"name": "secret-1"},
-                                "data": {"password": "c2VjcmV0LTE="},
+                                "data": {"ca.crt": "c2VjcmV0LTE="},
                             }
                         ],
                         "metadata": {"continue": "token123"},
@@ -705,7 +705,7 @@ class TestK8sClient:
                         "items": [
                             {
                                 "metadata": {"name": "secret-2"},
-                                "data": {"token": "c2VjcmV0LTI="},
+                                "data": {".dockerconfigjson": "c2VjcmV0LTI="},
                             }
                         ],
                         "metadata": {},


### PR DESCRIPTION
# Fix: Preserve `kind` in Paginated SecretList Responses for Proper Sanitization

### Bug Fix

When the Kubernetes agent listed secrets in a namespace (e.g. `GET /api/v1/namespaces/default/secrets`),
the API returns a `SecretList` object. The pagination handler was collecting all items across pages and
returning them as a **bare list** — stripping off the outer `{"kind": "SecretList", ...}` wrapper.

Because individual secret items inside a list do not carry their own `kind` field, the data sanitizer
had no way to identify them as secrets. Instead of routing to `_sanitize_secret()` (which clears `data`
completely), it fell through to the generic `_sanitize_dict()` path, which only redacts fields whose
**name** matches a known sensitive keyword. Fields like `ca.crt`, `tls.key`, or `.dockerconfigjson` do
not match any keyword, so their base64-encoded values were returned to the agent unredacted.

Fetching a **single named secret** (e.g. `GET /api/v1/namespaces/default/secrets/my-secret`) was never
affected — that response includes `"kind": "Secret"` at the top level and was always sanitized correctly.

The bug only affected list endpoints:

- /api/v1/namespaces/default/secrets → returns SecretList → bug triggered, secrets leaked
- /api/v1/namespaces/default/secrets/random-secret → returns single Secret → always sanitized correctly

### Changes

* `src/services/k8s.py`: Updated `_paginated_api_request` to capture the `kind` from the first response page. When all pages have been accumulated, the method now re-wraps the items into `{"kind": <list-kind>, "items": [...]}` instead of returning a bare list. After sanitization in `execute_get_api_request`, the wrapper dict is unwrapped back to a flat list for callers, preserving the existing interface.

* `tests/unit/services/test_k8s.py`: Added two new parameterized test cases:
  - `should sanitize secret data for single-page SecretList response` — verifies that secret `data` is cleared when a single-page `SecretList` is processed.
  - `should sanitize secret data for multi-page SecretList response` — verifies that secret `data` is cleared across multiple paginated pages of a `SecretList`.
  - Also narrowed the existing sanitizer assertion to only check `call_count` when the sanitizer is a `Mock` instance (avoiding attribute errors on real `DataSanitizer` objects).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.2`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `d50336b0-850e-11f1-8b4c-d583a657356b`
</details>
