### PR TITLE
chore: switch doc_indexer base image to python:3.13-slim-bookworm

### DIFF
--- a/doc_indexer/Dockerfile
+++ b/doc_indexer/Dockerfile
@@ -11,7 +11,7 @@ COPY docs_sources.json ./
 RUN apt-get update && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends build-essential gcc git \
   && python -m venv ./venv \
-  && ./venv/bin/pip install --no-cache-dir poetry>=2.1 \
+  && ./venv/bin/pip install --no-cache-dir "poetry>=2.1" \
   && ./venv/bin/poetry config virtualenvs.in-project true \
   && ./venv/bin/poetry install --only main --no-interaction --no-ansi \
   && cd /app/.venv && ../venv/bin/pip uninstall -y poetry pip setuptools wheel \

--- a/doc_indexer/Dockerfile
+++ b/doc_indexer/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: install dependencies
-FROM ghcr.io/gardenlinux/gardenlinux:2150.7.0 AS builder
+FROM python:3.13-slim-bookworm AS builder
 WORKDIR /app
 
 # Copy necessary files for dependency installation
@@ -8,9 +8,9 @@ COPY src ./src
 COPY docs_sources.json ./
 
 # Install dependencies with Poetry and aggressively clean up
-RUN apt update && apt upgrade -y \
-  && apt install -y --no-install-recommends build-essential gcc python3.13 python3.13-dev python3.13-venv git \
-  && python3.13 -m venv ./venv \
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends build-essential gcc git \
+  && python -m venv ./venv \
   && ./venv/bin/pip install --no-cache-dir poetry>=2.1 \
   && ./venv/bin/poetry config virtualenvs.in-project true \
   && ./venv/bin/poetry install --only main --no-interaction --no-ansi \
@@ -23,15 +23,15 @@ RUN apt update && apt upgrade -y \
   && rm -rf ./lib/python3.13/site-packages/pip* \
   && rm -rf ./lib/python3.13/site-packages/setuptools* \
   && rm -rf ./lib/python3.13/site-packages/wheel* \
-  && find . -name "*.so" -exec strip --strip-debug {} + 2>/dev/null || true
+  && find . -name "*.so" -not -path "*.libs/*" -exec strip --strip-debug {} + 2>/dev/null || true
 
-# Runtime stage: fresh GardenLinux with only runtime files
-FROM ghcr.io/gardenlinux/gardenlinux:2150.7.0
+# Runtime stage: fresh slim image with only runtime files
+FROM python:3.13-slim-bookworm
 WORKDIR /app
 
-# Install Python runtime and git (needed for runtime)
-RUN apt update && apt upgrade -y \
-  && apt install -y --no-install-recommends python3.13 git \
+# Install git (needed by the fetch task) and CA certificates for outbound HTTPS
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy virtual environment from builder (Poetry creates .venv with in-project)


### PR DESCRIPTION
## Description

Switches the `doc_indexer` base image from GardenLinux
(`ghcr.io/gardenlinux/gardenlinux:2150.7.0`) to `python:3.13-slim-bookworm` in
both the builder and runtime stages, to **reduce the OS-level CVE surface**.
GardenLinux bundles many OS packages the indexer never uses, inflating the
findings reported by BDBA/Mend scans. The slim glibc image ships only what the
indexer actually needs.

The indexer's real runtime requirements are minimal and fully satisfied by slim:

- **CPython 3.13** — provided at `/usr/local/bin/python` by the slim image.
- **glibc** — required by `hdbcli` (SAP's HANA client), which ships only
  compiled `manylinux`/`musllinux` wheels with no pure-Python fallback. This is
  why a glibc base is mandatory and Alpine/musl is not an option.
- **`git` binary** — the `fetch` task shells out to `git clone`
  (`src/utils/utils.py`).
- **CA certificates** — outbound HTTPS to GitHub, SAP AI Core, and HANA Cloud.

Nothing control-plane-specific lives in the image: the Istio sidecar is injected
at pod admission, and the task (`fetch`/`index`/`drop`/`tables`) is supplied by
the KCP Job/CronJob manifest, not the image. So the switch is a drop-in.

## Changes

- Both stages: `FROM python:3.13-slim-bookworm` (no `python3.13` apt package
  needed — slim already provides CPython 3.13).
- Builder: create the venv with `python -m venv` so its symlinks resolve in the
  runtime stage; switch to `apt-get ... --no-install-recommends`.
- Runtime: install only `git` + `ca-certificates`, then clean apt lists.
- Fix the `strip` step to exclude wheel-vendored libraries
  (`-not -path "*.libs/*"`). Without this, `strip --strip-debug` corrupts
  numpy's bundled OpenBLAS `.so`, which then fails to load on the slim base
  (`ELF load command address/offset not page-aligned`).

## Testing

Verified end-to-end against **real HANA Cloud + SAP AI Core** using a
throwaway test table (production `kyma_docs` untouched):

- `fetch` — cloned all 24 doc sources via the `git` binary, saved 2555 documents.
- `index` — embedded **5813 chunks** via AI Core (all HTTP 200, no rate-limit
  errors) and wrote them to HANA in ~591s.
- `tables` — confirmed 5813 rows / ~73 MB written.
- `drop` — cleaned up the test table.

This is the same workload the doc-indexer E2E workflow runs. Existing unit tests
also pass (`poe test-unit`). Functionally identical to the GardenLinux image.

## Related issues
<!-- add if applicable -->