### PR TITLE
fix: skip non-directory entries when loading evaluation test scenarios

### DIFF
--- a/tests/blackbox/src/evaluation/scenario/scenario.py
+++ b/tests/blackbox/src/evaluation/scenario/scenario.py
@@ -149,8 +149,10 @@ class ScenarioList(BaseModel):
         """Load all the scenarios from the namespace scoped test data path."""
         logger.info(f"Reading NamespaceScoped scenarios from: {path}")
 
-        # get all the directories in the path.
-        directories: list[str] = os.listdir(path)
+        # get all the directories in the path (skip plain files like deploy_all.sh).
+        directories: list[str] = [
+            entry for entry in os.listdir(path) if os.path.isdir(os.path.join(path, entry))
+        ]
         if directories:
             # sort directories to ensure consistent order
             directories.sort(reverse=True)

--- a/tests/blackbox/src/evaluation/scenario/scenario.py
+++ b/tests/blackbox/src/evaluation/scenario/scenario.py
@@ -150,9 +150,7 @@ class ScenarioList(BaseModel):
         logger.info(f"Reading NamespaceScoped scenarios from: {path}")
 
         # get all the directories in the path (skip plain files like deploy_all.sh).
-        directories: list[str] = [
-            entry for entry in os.listdir(path) if os.path.isdir(os.path.join(path, entry))
-        ]
+        directories: list[str] = [entry for entry in os.listdir(path) if os.path.isdir(os.path.join(path, entry))]
         if directories:
             # sort directories to ensure consistent order
             directories.sort(reverse=True)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request and why:

- `ScenarioList.load_all_namespace_scope_scenarios` used `os.listdir()` and treated every entry as a subdirectory, expecting a `scenario.yml` inside it.
- The recently added `tests/blackbox/data/test-cases/deploy_all.sh` script (PR #1317) sits directly in the `test-cases/` directory and caused the evaluation CI to fail with `Exception: Error reading scenario file: ./data/test-cases/deploy_all.sh/scenario.yml`.
- Fix: filter `os.listdir()` results to only include actual directories using `os.path.isdir()`.

**Related issue(s)**

N/A

**Definition of done**

- [ ] The PR is linked to a GitHub issue.
- [x] All necessary steps are delivered, for example, tests, documentation, merging.
  - [x] Unit tests — no unit tests cover this loader; change is a one-line filter guard
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests (add label `evaluation requested` to the PR to run)
  - [ ] API tests (add label `api-tests` to the PR to run)