### PR TITLE
chore: consolidate e2e test configs into a shared base + per-suite overrides

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -223,8 +223,11 @@ jobs:
       - name: Run integration tests
         env:
           LOG_LEVEL: "DEBUG"
+          COMPANION_TESTS_DEFAULT_CONFIG: ${{ secrets.COMPANION_TESTS_DEFAULT_CONFIG }}
+          INTEGRATION_TEST_CONFIG: ${{ secrets.INTEGRATION_TEST_CONFIG }}
         run: |
-          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
+          echo "$COMPANION_TESTS_DEFAULT_CONFIG" \
+            | jq --argjson override "$INTEGRATION_TEST_CONFIG" '. * $override' > "$GITHUB_WORKSPACE/config/config.json"
           poetry run poe test-integration
 
   run-integration-tests-indexer:
@@ -275,10 +278,10 @@ jobs:
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
           DOCS_TABLE_NAME: "kc_pr_release_${{ inputs.name }}"
+          DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          export CONFIG_PATH="$GITHUB_WORKSPACE/config/config.json"
-          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
+          echo "$DOC_INDEXER_TESTS_CONFIG" > "$CONFIG_PATH"
           poetry run poe test-integration
 
   get-image-sha:

--- a/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
+++ b/.github/workflows/e2e-tests-doc-indexer-reusable.yaml
@@ -63,8 +63,9 @@ jobs:
 
       - name: Create config secret
         env:
-          DOC_INDEXER_CONFIG_BASE64: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
+          DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
         run: |
+          DOC_INDEXER_CONFIG_BASE64=$(echo "$DOC_INDEXER_TESTS_CONFIG" | base64 -w 0)
           cat <<EOF | kubectl apply -f -
           apiVersion: v1
           kind: Secret

--- a/.github/workflows/evaluation-test-reusable.yaml
+++ b/.github/workflows/evaluation-test-reusable.yaml
@@ -129,9 +129,12 @@ jobs:
 
       - name: Companion Deploy - Create secret
         env:
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
+          COMPANION_TESTS_DEFAULT_CONFIG: ${{ secrets.COMPANION_TESTS_DEFAULT_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
-          COMPANION_CONFIG_BASE64=$(echo -n "$EVALUATION_TESTS_CONFIG" | base64 -w 0)
+          COMPANION_CONFIG_BASE64=$(echo "$COMPANION_TESTS_DEFAULT_CONFIG" \
+            | jq --argjson override "$EVALUATION_TESTS_CONFIG" '. * $override' \
+            | base64 -w 0)
           export COMPANION_CONFIG_BASE64
           kubectl create namespace ai-system
           ./scripts/k8s/create-secret.sh
@@ -210,10 +213,12 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
           COMPANION_API_URL: "http://localhost:32000"
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
+          COMPANION_TESTS_DEFAULT_CONFIG: ${{ secrets.COMPANION_TESTS_DEFAULT_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"
+          echo "$COMPANION_TESTS_DEFAULT_CONFIG" \
+            | jq --argjson override "$EVALUATION_TESTS_CONFIG" '. * $override' > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH! Running API tests against Companion at $COMPANION_API_URL"
           poetry run pytest src/api_tests/ -v
 
@@ -226,10 +231,12 @@ jobs:
           COMPANION_API_URL: "http://localhost:32000"
           REDIS_URL: "redis://localhost:32100"
           KC_EVAL_RETRIES: "5"
-          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG_JSON }}
+          COMPANION_TESTS_DEFAULT_CONFIG: ${{ secrets.COMPANION_TESTS_DEFAULT_CONFIG }}
+          EVALUATION_TESTS_CONFIG: ${{ secrets.EVALUATION_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${EVALUATION_TESTS_CONFIG}" | jq > "$CONFIG_PATH"
+          echo "$COMPANION_TESTS_DEFAULT_CONFIG" \
+            | jq --argjson override "$EVALUATION_TESTS_CONFIG" '. * $override' > "$CONFIG_PATH"
           echo "saved config to $CONFIG_PATH! Running A2A Kyma Agent tests"
           poetry run python src/run_a2a_evaluation.py
 

--- a/.github/workflows/pull-integration-test.yaml
+++ b/.github/workflows/pull-integration-test.yaml
@@ -50,6 +50,9 @@ jobs:
         env:
           LOG_LEVEL: "DEBUG"
           DEEPEVAL_DISABLE_TIMEOUTS: "true"
+          COMPANION_TESTS_DEFAULT_CONFIG: ${{ secrets.COMPANION_TESTS_DEFAULT_CONFIG }}
+          INTEGRATION_TEST_CONFIG: ${{ secrets.INTEGRATION_TEST_CONFIG }}
         run: |
-          echo "${{ secrets.INTEGRATION_TEST_CONFIG }}" | base64 --decode | jq > "$GITHUB_WORKSPACE/config/config.json"
+          echo "$COMPANION_TESTS_DEFAULT_CONFIG" \
+            | jq --argjson override "$INTEGRATION_TEST_CONFIG" '. * $override' > "$GITHUB_WORKSPACE/config/config.json"
           poetry run poe test-integration

--- a/.github/workflows/pull-tests-doc-indexer.yaml
+++ b/.github/workflows/pull-tests-doc-indexer.yaml
@@ -73,7 +73,8 @@ jobs:
           DOCS_SOURCES_FILE_PATH: "./docs_sources.json"
           DOCS_PATH: "/test-data"
           DOCS_TABLE_NAME: "kc_pr_${{ github.event.pull_request.number }}"
+          DOC_INDEXER_TESTS_CONFIG: ${{ secrets.DOC_INDEXER_TESTS_CONFIG }}
         run: |
           export CONFIG_PATH=$GITHUB_WORKSPACE/config/config.json
-          echo "${{ secrets.DOC_INDEXER_TESTS_CONFIG }}" | base64 --decode | jq > "$CONFIG_PATH"
+          echo "$DOC_INDEXER_TESTS_CONFIG" > "$CONFIG_PATH"
           poetry run poe test-integration


### PR DESCRIPTION
## Summary
The three e2e test-config secrets (`INTEGRATION_TEST_CONFIG`,
`EVALUATION_TESTS_CONFIG`, `DOC_INDEXER_TESTS_CONFIG`) each stored a full
config JSON that duplicated the same shared credentials (AICORE, DATABASE,
TEST_CLUSTER, models). Rotating a credential meant editing all three.

This introduces a shared base config plus small per-suite overrides:
- New `COMPANION_TESTS_DEFAULT_CONFIG` holds everything shared across suites.
- Each suite secret is slimmed to only the keys it overrides.
- Workflows merge them at runtime: `jq --argjson override "$SUITE_CONFIG" '. * $override'`
  (override keys win; omitted keys fall back to the base).
- All configs are plain JSON now; k8s Secret steps base64-encode the merged
  result on the fly.

CI-only change — no runtime/prod impact (deploys to a throwaway k3d cluster).

## Secrets required in the `e2e` environment (all plain JSON)
| Secret | Content |
|---|---|
| `COMPANION_TESTS_BASE_CONFIG` (new) | Shared: AICORE, DATABASE, TEST_CLUSTER, LANGFUSE, all models |
| `INTEGRATION_TEST_CONFIG` | Only integration-specific overrides |
| `EVALUATION_TESTS_CONFIG` | Only eval-specific overrides (`REDIS_*`, `ENCRYPTION_PRIVATE_KEY_PATH`) |
| `DOC_INDEXER_TESTS_CONFIG` | Only doc-indexer overrides (`models` = embedding-only) |

## Merge order
1. Add `COMPANION_TESTS_DEFAULT_CONFIG` and update the three suite secrets to
   their slimmed plain-JSON form in the `e2e` environment.
2. Merge this PR.
3. Confirm integration / eval / doc-indexer runs are green on `main`.

## Note
`jq '. * $override'` **replaces** arrays (e.g. `models`) rather than merging
them — intended, so a suite fully controls its own model list.
