### PR TITLE
chore: switch Companion base image to Alpine to reduce CVE surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ config/config.json
 config/encryption_key.pem
 config/k8s-clusters.json
 config/config-integration.json
+config/config-evaluation.json
 kubeconfig.yaml
 *.kubeconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,55 @@
-# Build stage: install dependencies
-FROM ghcr.io/gardenlinux/gardenlinux:2150.7.0 AS builder
+# syntax=docker/dockerfile:1
+
+# Build stage: Alpine-based Python with build tools for compiling C-extensions.
+# Alpine uses musl libc. Key runtime deps ship musl wheels: pydantic-core has
+# musllinux wheels for x86_64 and aarch64; hdbcli only has musllinux_1_2_x86_64.
+# This image must therefore be built for linux/amd64 (the production target).
+FROM python:3.13-alpine AS builder
 WORKDIR /app
 
-# Copy necessary files for dependency installation
+# gcc + musl-dev + libffi-dev cover C-extension fallback builds (cryptography,
+# aiohttp). git is excluded — not needed by the Companion at runtime.
+RUN apk add --no-cache gcc musl-dev libffi-dev
+
 COPY pyproject.toml poetry.lock ./
 COPY src ./src
 COPY config ./config
 
-# Install dependencies with Poetry and aggressively clean up
-RUN apt update && apt upgrade -y \
-  && apt install -y --no-install-recommends build-essential gcc python3.13 python3.13-dev python3.13-venv \
-  && python3.13 -m venv ./venv \
-  && ./venv/bin/pip install --no-cache-dir poetry>=2.1 \
-  && ./venv/bin/poetry config virtualenvs.in-project true \
-  && ./venv/bin/poetry install --only main --no-interaction --no-ansi \
-  && cd /app/.venv && ../venv/bin/pip uninstall -y poetry pip setuptools wheel \
-  && find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \
-  && find . -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
-  && find . -type d -name "test" -exec rm -rf {} + 2>/dev/null || true \
-  && find . -type f -name "*.pyc" -delete \
-  && find . -type f -name "*.pyo" -delete \
-  && rm -rf ./lib/python3.13/site-packages/pip* \
-  && rm -rf ./lib/python3.13/site-packages/setuptools* \
-  && rm -rf ./lib/python3.13/site-packages/wheel* \
-  && find . -name "*.so" -exec strip --strip-debug {} + 2>/dev/null || true
+# Install into a venv with --copies so the interpreter is a real binary (not a
+# symlink), making the venv fully self-contained in the runtime stage.
+RUN pip install --no-cache-dir "poetry>=2.1" \
+  && poetry config virtualenvs.in-project true \
+  && poetry config virtualenvs.options.always-copy true \
+  && poetry install --only main --no-interaction --no-ansi \
+  && pip uninstall -y poetry \
+  && find /app/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \
+  && find /app/.venv -type f -name "*.pyc" -delete \
+  && find /app/.venv -type f -name "*.pyo" -delete \
+  && rm -rf /app/.venv/lib/python3.13/site-packages/pip* \
+  && rm -rf /app/.venv/lib/python3.13/site-packages/setuptools* \
+  && rm -rf /app/.venv/lib/python3.13/site-packages/wheel*
 
-# Runtime stage: fresh GardenLinux with only runtime files
-FROM ghcr.io/gardenlinux/gardenlinux:2150.7.0
+# Runtime stage: plain Alpine — no shell package manager baggage beyond the
+# minimal Alpine base. Much smaller CVE surface than any Debian variant.
+# libstdc++ is required by hdbcli (pyhdbcli.abi3.so links against it).
+FROM python:3.13-alpine
+RUN apk add --no-cache libstdc++
 WORKDIR /app
 
-# Install Python runtime (needed for venv symlinks)
-RUN apt update && apt upgrade -y \
-  && apt install -y --no-install-recommends python3.13 \
-  && rm -rf /var/lib/apt/lists/*
-
-# Copy virtual environment from builder (Poetry creates .venv with in-project)
 COPY --from=builder /app/.venv ./venv
-
-# Copy application code
 COPY src ./src
 COPY config ./config
 
-# Create non-root user and set ownership
-RUN groupadd -g 5678 appuser \
-  && useradd -u 5678 -g appuser -s /bin/sh appuser \
+# Non-root user matching the prior image's uid/gid.
+RUN addgroup -g 5678 appuser \
+  && adduser -u 5678 -G appuser -s /bin/sh -D appuser \
   && chown -R appuser:appuser /app
 
 USER appuser
 
-# Set PYTHONPATH so Python can find src modules
-ENV PYTHONPATH=/app/src
+ENV PATH="/app/venv/bin:$PATH" \
+    PYTHONPATH=/app/src \
+    PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 8000
-CMD ["./venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
**Description**

- Replaces GardenLinux builder + runtime with `python:3.13-alpine`, following the same approach applied to the Indexer in #1307
- Adds `gcc`, `musl-dev`, `libffi-dev` in builder stage to cover C-extension builds (`cryptography`, `aiohttp`)
- Adds `libstdc++` in runtime stage — required by `hdbcli` (`pyhdbcli.abi3.so`)
- Uses `virtualenvs.options.always-copy=true` so the venv is fully self-contained (no symlinks to the builder stage)
- Replaces Debian `groupadd`/`useradd` with Alpine `addgroup`/`adduser`; uid/gid 5678 unchanged
- Sets `PATH` to `/app/venv/bin` and `PYTHONDONTWRITEBYTECODE=1`
- Adds `config/config-evaluation.json` to `.gitignore` (file contains secrets, was previously untracked)

No writable-dir / OpenShift arbitrary-uid changes needed: unlike the Indexer (Job/CronJob with runtime writes), the Companion is a stateless HTTP server that never writes to local directories.

**Related issue(s)**

Closes #1313

**Definition of done**

- [x] The PR is linked to a GitHub issue.
- [x] Related issues are linked.
- [x] All necessary steps are delivered:
  - [x] Unit tests — 581 passed (5 pre-existing failures unrelated to this change)
  - [ ] Integration tests (add label `run-integration-test` to the PR to run)
  - [ ] Evaluation tests — not applicable for a Dockerfile change
  - [ ] API tests — not applicable for a Dockerfile change
  - [x] Acceptance Criteria: Companion image CVE surface reduced by switching off GardenLinux