### PR TITLE
chore: remove setuptools and wheel from runtime image to reduce cve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,11 @@ RUN pip install --no-cache-dir "poetry>=2.1" \
 # minimal Alpine base. Much smaller CVE surface than any Debian variant.
 # libstdc++ is required by hdbcli (pyhdbcli.abi3.so links against it).
 FROM python:3.13-alpine
-RUN apk add --no-cache libstdc++
+RUN apk add --no-cache libstdc++ \
+  && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
+  && rm -rf /usr/local/lib/python3.13/site-packages/setuptools* \
+  && rm -rf /usr/local/lib/python3.13/site-packages/wheel* \
+  && rm -rf /usr/local/lib/python3.13/ensurepip
 WORKDIR /app
 
 COPY --from=builder /app/.venv ./venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,19 +25,19 @@ RUN pip install --no-cache-dir "poetry>=2.1" \
   && find /app/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \
   && find /app/.venv -type f -name "*.pyc" -delete \
   && find /app/.venv -type f -name "*.pyo" -delete \
-  && rm -rf /app/.venv/lib/python3.13/site-packages/pip* \
-  && rm -rf /app/.venv/lib/python3.13/site-packages/setuptools* \
-  && rm -rf /app/.venv/lib/python3.13/site-packages/wheel*
+  && rm -rf /app/.venv/lib/python3.*/site-packages/pip* \
+  && rm -rf /app/.venv/lib/python3.*/site-packages/setuptools* \
+  && rm -rf /app/.venv/lib/python3.*/site-packages/wheel*
 
 # Runtime stage: plain Alpine — no shell package manager baggage beyond the
 # minimal Alpine base. Much smaller CVE surface than any Debian variant.
 # libstdc++ is required by hdbcli (pyhdbcli.abi3.so links against it).
 FROM python:3.13-alpine
 RUN apk add --no-cache libstdc++ \
-  && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
-  && rm -rf /usr/local/lib/python3.13/site-packages/setuptools* \
-  && rm -rf /usr/local/lib/python3.13/site-packages/wheel* \
-  && rm -rf /usr/local/lib/python3.13/ensurepip
+  && rm -rf /usr/local/lib/python3.*/site-packages/pip* \
+  && rm -rf /usr/local/lib/python3.*/site-packages/setuptools* \
+  && rm -rf /usr/local/lib/python3.*/site-packages/wheel* \
+  && rm -rf /usr/local/lib/python3.*/ensurepip
 WORKDIR /app
 
 COPY --from=builder /app/.venv ./venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN pip install --no-cache-dir "poetry>=2.1" \
   && find /app/.venv -type f -name "*.pyo" -delete \
   && rm -rf /app/.venv/lib/python3.*/site-packages/pip* \
   && rm -rf /app/.venv/lib/python3.*/site-packages/setuptools* \
-  && rm -rf /app/.venv/lib/python3.*/site-packages/wheel*
+  && rm -rf /app/.venv/lib/python3.*/site-packages/wheel* \
+  && rm -f /app/.venv/bin/pip* /app/.venv/bin/wheel /app/.venv/bin/easy_install*
 
 # Runtime stage: plain Alpine — no shell package manager baggage beyond the
 # minimal Alpine base. Much smaller CVE surface than any Debian variant.
@@ -37,7 +38,8 @@ RUN apk add --no-cache libstdc++ \
   && rm -rf /usr/local/lib/python3.*/site-packages/pip* \
   && rm -rf /usr/local/lib/python3.*/site-packages/setuptools* \
   && rm -rf /usr/local/lib/python3.*/site-packages/wheel* \
-  && rm -rf /usr/local/lib/python3.*/ensurepip
+  && rm -rf /usr/local/lib/python3.*/ensurepip \
+  && rm -f /usr/local/bin/pip* /usr/local/bin/wheel /usr/local/bin/easy_install*
 WORKDIR /app
 
 COPY --from=builder /app/.venv ./venv


### PR DESCRIPTION
# Remove `setuptools`, `wheel`, and `pip` from Runtime Docker Image to Reduce CVE Surface

### Chore

🔧 Chore: Removes unnecessary Python packaging tools (`pip`, `setuptools`, `wheel`, and `ensurepip`) from both the builder virtual environment and the runtime stage of the Docker image, reducing its attack surface and minimizing CVE exposure.

### Changes

* `Dockerfile`: Two targeted improvements:
  - **Builder stage**: Widened the cleanup glob from `python3.13` to `python3.*` for future-proofing, and added removal of `pip*`, `wheel`, and `easy_install*` binaries from `.venv/bin/`.
  - **Runtime stage** (`python:3.13-alpine`): Added explicit cleanup of `pip*`, `setuptools*`, `wheel*`, `ensurepip`, and related binaries from `/usr/local/lib/python3.*/site-packages/` and `/usr/local/bin/`. Previously, these were only removed from the builder's `.venv`, leaving the base image copies intact in the final runtime image.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `ea65b880-9b06-11f1-9f0b-974f5367c457`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
