### PR TITLE
feat: implement global THINKING_EFFORT setting

### DIFF
--- a/config/config-example.json
+++ b/config/config-example.json
@@ -48,5 +48,6 @@
   ],
   "MAIN_MODEL_NAME": "gpt-4.1",
   "MAIN_MODEL_MINI_NAME": "gpt-4.1-mini",
-  "MAIN_EMBEDDING_MODEL_NAME": "text-embedding-3-large"
+  "MAIN_EMBEDDING_MODEL_NAME": "text-embedding-3-large",
+  "THINKING_EFFORT": "OFF"
 }

--- a/src/utils/models/anthropic.py
+++ b/src/utils/models/anthropic.py
@@ -3,7 +3,13 @@ from gen_ai_hub.proxy.langchain.amazon import ChatBedrockConverse
 from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
 from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAIClient
 
+from utils import settings
 from utils.config import ModelConfig
+from utils.logging import get_logger
+from utils.models.thinking import get_anthropic_thinking_fields
+from utils.settings import ThinkingEffort
+
+logger = get_logger(__name__)
 
 
 class AnthropicModel:
@@ -14,11 +20,19 @@ class AnthropicModel:
 
     def __init__(self, config: ModelConfig, proxy_client: BaseProxyClient):
         self._name = config.name
+        thinking_enabled = settings.THINKING_EFFORT != ThinkingEffort.OFF
+        # Anthropic requires temperature=1 whenever extended thinking is enabled.
+        temperature = 1.0 if thinking_enabled else config.temperature
+        logger.info(
+            f"Loading Anthropic model '{config.name}' with THINKING_EFFORT={settings.THINKING_EFFORT} "
+            f"(thinking {'enabled' if thinking_enabled else 'disabled'})."
+        )
         self._llm = ChatBedrockConverse(
             model_name=config.name,
             deployment_id=config.deployment_id,
             proxy_client=proxy_client,
-            temperature=config.temperature,
+            temperature=temperature,
+            additional_model_request_fields=get_anthropic_thinking_fields(settings.THINKING_EFFORT),
         )
 
     def invoke(self, content: str):  # noqa

--- a/src/utils/models/openai.py
+++ b/src/utils/models/openai.py
@@ -5,6 +5,10 @@ from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAICl
 
 from utils import settings
 from utils.config import ModelConfig
+from utils.logging import get_logger
+from utils.models.thinking import get_openai_reasoning_effort, supports_openai_reasoning
+
+logger = get_logger(__name__)
 
 
 class OpenAIModel:
@@ -15,6 +19,20 @@ class OpenAIModel:
 
     def __init__(self, config: ModelConfig, proxy_client: BaseProxyClient):
         self._name = config.name
+        extra_kwargs: dict = {}
+        # reasoning_effort is only valid for reasoning-capable models (e.g. gpt-5+).
+        if supports_openai_reasoning(config.name):
+            reasoning_effort = get_openai_reasoning_effort(settings.THINKING_EFFORT)
+            extra_kwargs["reasoning_effort"] = reasoning_effort
+            logger.info(
+                f"Loading OpenAI model '{config.name}' with THINKING_EFFORT={settings.THINKING_EFFORT} "
+                f"(reasoning_effort='{reasoning_effort}')."
+            )
+        else:
+            logger.info(
+                f"Loading OpenAI model '{config.name}' without reasoning "
+                f"(model does not support reasoning_effort)."
+            )
         self._llm = ChatOpenAI(
             proxy_model_name=config.name,
             deployment_id=config.deployment_id,
@@ -22,6 +40,7 @@ class OpenAIModel:
             temperature=config.temperature,
             request_timeout=settings.LLM_REQUEST_TIMEOUT_SECONDS,
             timeout=settings.LLM_REQUEST_TIMEOUT_SECONDS,
+            **extra_kwargs,
         )
 
     def invoke(self, content: str):  # noqa

--- a/src/utils/models/openai.py
+++ b/src/utils/models/openai.py
@@ -30,8 +30,7 @@ class OpenAIModel:
             )
         else:
             logger.info(
-                f"Loading OpenAI model '{config.name}' without reasoning "
-                f"(model does not support reasoning_effort)."
+                f"Loading OpenAI model '{config.name}' without reasoning (model does not support reasoning_effort)."
             )
         self._llm = ChatOpenAI(
             proxy_model_name=config.name,

--- a/src/utils/models/thinking.py
+++ b/src/utils/models/thinking.py
@@ -1,0 +1,71 @@
+"""Translate the global ``THINKING_EFFORT`` setting into provider-specific
+reasoning parameters for OpenAI and Anthropic (Bedrock Converse) models.
+
+This keeps the reasoning-effort mapping in a single place so the same global
+setting behaves consistently across every provider.
+"""
+
+import re
+
+from utils.settings import ThinkingEffort
+
+# Non-GPT OpenAI reasoning model prefixes (o-series).
+OPENAI_REASONING_MODEL_PREFIXES: tuple[str, ...] = ("o1", "o3", "o4")
+
+# Minimum GPT major version (inclusive) that supports the ``reasoning_effort`` param.
+# Anything at or above this is treated as reasoning-capable (gpt-5, gpt-5.5, gpt-6, ...).
+OPENAI_REASONING_MIN_GPT_VERSION = 5.0
+
+# Matches the leading version number of a GPT model name, e.g. "gpt-5.5-mini" -> "5.5".
+_GPT_VERSION_PATTERN = re.compile(r"^gpt-(\d+(?:\.\d+)?)")
+
+# Anthropic (Bedrock Converse) extended-thinking token budgets per effort level.
+_ANTHROPIC_THINKING_BUDGET_TOKENS: dict[ThinkingEffort, int] = {
+    ThinkingEffort.LOW: 2048,
+    ThinkingEffort.MEDIUM: 8192,
+    ThinkingEffort.HIGH: 16384,
+}
+
+# OpenAI reasoning models ``reasoning_effort`` values per effort level.
+_OPENAI_REASONING_EFFORT: dict[ThinkingEffort, str] = {
+    ThinkingEffort.OFF: "minimal",
+    ThinkingEffort.LOW: "low",
+    ThinkingEffort.MEDIUM: "medium",
+    ThinkingEffort.HIGH: "high",
+}
+
+
+def supports_openai_reasoning(model_name: str) -> bool:
+    """Return whether the given OpenAI model supports the reasoning_effort param.
+
+    True for the o-series (o1/o3/o4) and for any GPT model at or above version 5
+    (e.g. gpt-5, gpt-5-mini, gpt-5.5, gpt-6, gpt-7). Older GPT models such as
+    gpt-4.1 or gpt-4o are excluded because they reject the parameter.
+    """
+    if model_name.startswith(OPENAI_REASONING_MODEL_PREFIXES):
+        return True
+    match = _GPT_VERSION_PATTERN.match(model_name)
+    if match is None:
+        return False
+    return float(match.group(1)) >= OPENAI_REASONING_MIN_GPT_VERSION
+
+
+def get_openai_reasoning_effort(effort: ThinkingEffort) -> str:
+    """Return the OpenAI ``reasoning_effort`` value for the given thinking effort."""
+    return _OPENAI_REASONING_EFFORT[effort]
+
+
+def get_anthropic_thinking_fields(effort: ThinkingEffort) -> dict:
+    """Return ``additional_model_request_fields`` for Claude models.
+
+    OFF explicitly disables (adaptive/extended) thinking; the other levels enable
+    extended thinking with an increasing token budget.
+    """
+    if effort == ThinkingEffort.OFF:
+        return {"thinking": {"type": "disabled"}}
+    return {
+        "thinking": {
+            "type": "enabled",
+            "budget_tokens": _ANTHROPIC_THINKING_BUDGET_TOKENS[effort],
+        }
+    }

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -17,6 +17,19 @@ class LangfuseMaskingModes(StrEnum):
     REDACTED = "REDACTED"  # Everything is redacted.
 
 
+class ThinkingEffort(StrEnum):
+    """Global reasoning/thinking effort applied across all supported LLM providers.
+
+    OFF disables extended/adaptive thinking; LOW/MEDIUM/HIGH progressively allow
+    the model to spend more tokens on internal reasoning.
+    """
+
+    OFF = "OFF"
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+
+
 def load_env_from_json() -> Path:
     """Load the configuration from the config.json file. Returns the path to the config file used."""
     # if running tests with pytest, use config_test.json
@@ -83,6 +96,14 @@ MAIN_MODEL_NAME = config("MAIN_MODEL_NAME", default="gpt-4.1")
 MAIN_MODEL_MINI_NAME = config("MAIN_MODEL_MINI_NAME", default="gpt-4o-mini")
 MAIN_EMBEDDING_MODEL_NAME = config("MAIN_EMBEDDING_MODEL_NAME", default="text-embedding-3-large")
 LLM_REQUEST_TIMEOUT_SECONDS = config("LLM_REQUEST_TIMEOUT_SECONDS", default=120, cast=int)
+
+# Global reasoning/thinking effort applied to all reasoning-capable models
+# (OpenAI reasoning models and Anthropic Claude). One of: OFF, LOW, MEDIUM, HIGH.
+THINKING_EFFORT = config(
+    "THINKING_EFFORT",
+    default=ThinkingEffort.OFF,
+    cast=lambda v: ThinkingEffort(str(v).strip().upper()),
+)
 
 # Redis
 # A Redis URL has the format "redis://<username>:<password>@<host>:<port>/<db_number>

--- a/tests/unit/utils/test_thinking.py
+++ b/tests/unit/utils/test_thinking.py
@@ -1,0 +1,70 @@
+import pytest
+
+from utils.models.thinking import (
+    get_anthropic_thinking_fields,
+    get_openai_reasoning_effort,
+    supports_openai_reasoning,
+)
+from utils.settings import ThinkingEffort
+
+
+class TestSupportsOpenAIReasoning:
+    """Test suite for supports_openai_reasoning."""
+
+    @pytest.mark.parametrize(
+        ("model_name", "expected"),
+        [
+            ("gpt-5", True),
+            ("gpt-5-mini", True),
+            ("gpt-5.5", True),
+            ("gpt-5.5-mini", True),
+            ("gpt-6", True),
+            ("gpt-7", True),
+            ("gpt-10", True),
+            ("o1", True),
+            ("o3-mini", True),
+            ("o4", True),
+            ("gpt-4.1", False),
+            ("gpt-4.1-mini", False),
+            ("gpt-4o", False),
+            ("anthropic--claude-4.6-sonnet", False),
+        ],
+    )
+    def test_supports_openai_reasoning(self, model_name, expected):
+        assert supports_openai_reasoning(model_name) is expected
+
+
+class TestGetOpenAIReasoningEffort:
+    """Test suite for get_openai_reasoning_effort."""
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            (ThinkingEffort.OFF, "minimal"),
+            (ThinkingEffort.LOW, "low"),
+            (ThinkingEffort.MEDIUM, "medium"),
+            (ThinkingEffort.HIGH, "high"),
+        ],
+    )
+    def test_get_openai_reasoning_effort(self, effort, expected):
+        assert get_openai_reasoning_effort(effort) == expected
+
+
+class TestGetAnthropicThinkingFields:
+    """Test suite for get_anthropic_thinking_fields."""
+
+    def test_off_disables_thinking(self):
+        assert get_anthropic_thinking_fields(ThinkingEffort.OFF) == {"thinking": {"type": "disabled"}}
+
+    @pytest.mark.parametrize(
+        ("effort", "expected_budget"),
+        [
+            (ThinkingEffort.LOW, 2048),
+            (ThinkingEffort.MEDIUM, 8192),
+            (ThinkingEffort.HIGH, 16384),
+        ],
+    )
+    def test_enabled_levels_set_budget(self, effort, expected_budget):
+        assert get_anthropic_thinking_fields(effort) == {
+            "thinking": {"type": "enabled", "budget_tokens": expected_budget}
+        }


### PR DESCRIPTION
# Implement Global `THINKING_EFFORT` Setting for LLM Reasoning Control

### New Features

✨ Introduces a global `THINKING_EFFORT` configuration setting that controls reasoning/thinking behavior across all supported LLM providers (OpenAI and Anthropic Claude). The setting accepts four levels — `OFF`, `LOW`, `MEDIUM`, `HIGH` — and is translated into provider-specific parameters, keeping the mapping consistent in a single module.

### Changes

* `config/config-example.json`: Added `THINKING_EFFORT: "OFF"` as a new top-level configuration field with a default of `OFF`.

* `src/utils/settings.py`: Introduced the `ThinkingEffort` enum (`OFF`, `LOW`, `MEDIUM`, `HIGH`) and a new `THINKING_EFFORT` setting loaded from the environment/config, defaulting to `ThinkingEffort.OFF`.

* `src/utils/models/thinking.py` _(new file)_: Central module that translates the global `THINKING_EFFORT` setting into provider-specific parameters:
  - `supports_openai_reasoning(model_name)`: Detects whether a model supports `reasoning_effort` (o-series and GPT ≥ 5.0).
  - `get_openai_reasoning_effort(effort)`: Maps effort levels to OpenAI's `"minimal"` / `"low"` / `"medium"` / `"high"` strings.
  - `get_anthropic_thinking_fields(effort)`: Returns Bedrock Converse `additional_model_request_fields` — disables thinking for `OFF`, or enables it with token budgets of 2048 / 8192 / 16384 for `LOW` / `MEDIUM` / `HIGH`.

* `src/utils/models/anthropic.py`: Updated `AnthropicModel.__init__` to read `THINKING_EFFORT`, force `temperature=1.0` when thinking is enabled (as required by Anthropic), and pass the thinking fields to `ChatBedrockConverse`.

* `src/utils/models/openai.py`: Updated `OpenAIModel.__init__` to conditionally pass `reasoning_effort` to `ChatOpenAI` only for reasoning-capable models, with appropriate log messages.

* `tests/unit/utils/test_thinking.py` _(new file)_: Unit tests covering `supports_openai_reasoning`, `get_openai_reasoning_effort`, and `get_anthropic_thinking_fields` across all effort levels and various model names.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.33`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `c331d880-9c95-11f1-9285-5f1bad11994c`
</details>
