### PR TITLE
refactor: replace sap-ai-sdk-gen with hand-rolled AI Core client

### DIFF
--- a/doc_indexer/poetry.lock
+++ b/doc_indexer/poetry.lock
@@ -14,6 +14,28 @@ files = [
 ]
 
 [[package]]
+name = "aicore"
+version = "0.1.0"
+description = "Hand-rolled SAP AI Core client and LangChain model adapters"
+optional = false
+python-versions = "==3.14.*"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+google-genai = ">=2.0.0,<3.0.0"
+httpx = ">=0.28.1,<0.29.0"
+langchain-aws = ">=1.0.0,<2.0.0"
+langchain-core = ">=1.0.0,<2.0.0"
+langchain-openai = ">=0.3.0,<2.0.0"
+python-decouple = ">=3.8,<4.0"
+
+[package.source]
+type = "directory"
+url = "../packages/aicore"
+
+[[package]]
 name = "aiobotocore"
 version = "3.7.0"
 description = "Async client for aws services using botocore and aiohttp"
@@ -5058,4 +5080,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.14.*"
-content-hash = "20cc3462cd8012c30c2cd80f72b658572e5dd7eae66d96ea69fb3840ade99039"
+content-hash = "33d93d200ae62b8996a1b2e534a07a6f3d80073a92357cd6536a250dcd43d8ee"

--- a/doc_indexer/pyproject.toml
+++ b/doc_indexer/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "pydantic (>=2.13.4,<3.0.0)",
   "python-decouple (>=3.8,<4.0)",
   "python-json-logger (>=4.2.0,<5.0.0)",
-  "sap-ai-sdk-gen[all] (>=7.0,<8.0)"
+  "aicore @ file:///Users/I549741/claude/kyma/kyma-companion/remove-sap-ai-sdk/packages/aicore"
 ]
 
 [tool.poetry]

--- a/doc_indexer/src/utils/models.py
+++ b/doc_indexer/src/utils/models.py
@@ -1,15 +1,20 @@
 import time
 from collections.abc import Callable
+from functools import lru_cache
 from typing import cast
 
-from gen_ai_hub.proxy.core.proxy_clients import get_proxy_client
-from gen_ai_hub.proxy.langchain import OpenAIEmbeddings
+from aicore import AICoreClient, OpenAIEmbeddingsAdapter
 from langchain_core.embeddings import Embeddings
 
 from utils.logging import get_logger
 from utils.settings import get_embedding_model_config
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_aicore_client() -> AICoreClient:
+    return AICoreClient()
 
 
 def create_embedding_factory(
@@ -27,7 +32,7 @@ def openai_embedding_creator(model_name: str) -> Embeddings:
     """Create an OpenAI embedding model using SAP AI Core.
 
     Reads model configuration from settings to map model names to SAP AI Core
-    deployment IDs, then uses the gen_ai_hub proxy for authentication.
+    deployment IDs, then uses the AICoreClient for authentication.
 
     Args:
         model_name: Model name as defined in config.json (e.g., "text-embedding-3-large")
@@ -41,20 +46,16 @@ def openai_embedding_creator(model_name: str) -> Embeddings:
     try:
         time.sleep(1)  # Sleep to avoid rate limiting
 
-        # Look up deployment_id from settings
         model_config = get_embedding_model_config(model_name)
+        client = _get_aicore_client()
 
-        # Initialize SAP AI Core proxy client
-        proxy_client = get_proxy_client("gen-ai-hub")
-
-        # Create embeddings with model name and deployment_id
         llm = cast(
             Embeddings,
-            OpenAIEmbeddings(
-                model=model_name,
+            OpenAIEmbeddingsAdapter(
+                client=client,
                 deployment_id=model_config.deployment_id,
-                proxy_client=proxy_client,
-            ),
+                model_name=model_name,
+            ).embeddings,
         )
     except Exception:
         logger.exception("Error while creating OpenAI embedding model")

--- a/packages/aicore/pyproject.toml
+++ b/packages/aicore/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "aicore"
+version = "0.1.0"
+description = "Hand-rolled SAP AI Core client and LangChain model adapters"
+license = "Apache-2.0"
+requires-python = "==3.14.*"
+dependencies = [
+  "google-genai (>=2.0.0,<3.0.0)",
+  "httpx (>=0.28.1,<0.29.0)",
+  "langchain-aws (>=1.0.0,<2.0.0)",
+  "langchain-core (>=1.0.0,<2.0.0)",
+  "langchain-openai (>=0.3.0,<2.0.0)",
+  "python-decouple (>=3.8,<4.0)",
+]
+
+[tool.poetry]
+package-mode = true
+packages = [{include = "aicore", from = "src"}]
+
+[tool.poetry.group.dev.dependencies]
+mypy = "^2.3.0"
+poethepoet = "^0.48.0"
+ruff = "^0.16.3"

--- a/packages/aicore/src/aicore/__init__.py
+++ b/packages/aicore/src/aicore/__init__.py
@@ -1,0 +1,15 @@
+"""SAP AI Core client and LangChain model adapters."""
+
+from aicore.client import AICoreClient
+from aicore.models.anthropic import AnthropicAdapter
+from aicore.models.embeddings import OpenAIEmbeddingsAdapter
+from aicore.models.gemini import GeminiAdapter
+from aicore.models.openai import OpenAIAdapter
+
+__all__ = [
+    "AICoreClient",
+    "AnthropicAdapter",
+    "GeminiAdapter",
+    "OpenAIAdapter",
+    "OpenAIEmbeddingsAdapter",
+]

--- a/packages/aicore/src/aicore/client.py
+++ b/packages/aicore/src/aicore/client.py
@@ -1,0 +1,70 @@
+"""SAP AI Core OAuth2 token fetching and deployment URL resolution."""
+
+import threading
+import time
+
+import httpx
+from decouple import config
+
+
+class AICoreClient:
+    """Fetches OAuth2 tokens and resolves deployment URLs for SAP AI Core.
+
+    Credentials are read from environment variables (or config.json keys):
+      AICORE_AUTH_URL, AICORE_BASE_URL, AICORE_CLIENT_ID,
+      AICORE_CLIENT_SECRET, AICORE_RESOURCE_GROUP
+    """
+
+    def __init__(self) -> None:
+        self._auth_url: str = config("AICORE_AUTH_URL")
+        self._base_url: str = config("AICORE_BASE_URL").rstrip("/")
+        self._client_id: str = config("AICORE_CLIENT_ID")
+        self._client_secret: str = config("AICORE_CLIENT_SECRET")
+        self._resource_group: str = config("AICORE_RESOURCE_GROUP", default="default")
+
+        self._lock = threading.Lock()
+        self._token: str = ""
+        self._token_exp: float = 0.0
+        self._deployment_cache: dict[str, str] = {}
+
+    def get_token(self) -> str:
+        """Return a cached or freshly fetched OAuth2 bearer token."""
+        with self._lock:
+            if self._token and time.time() < self._token_exp:
+                return self._token
+
+            resp = httpx.post(
+                f"{self._auth_url}/oauth/token",
+                data={"grant_type": "client_credentials"},
+                auth=(self._client_id, self._client_secret),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            self._token = body["access_token"]
+            self._token_exp = time.time() + body["expires_in"] - 60
+            return self._token
+
+    def get_deployment_url(self, deployment_id: str) -> str:
+        """Return the deploymentUrl for the given deployment ID (cached)."""
+        with self._lock:
+            if deployment_id in self._deployment_cache:
+                return self._deployment_cache[deployment_id]
+
+        token = self.get_token()
+        resp = httpx.get(
+            f"{self._base_url}/lm/deployments/{deployment_id}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "AI-Resource-Group": self._resource_group,
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        url: str = body.get("deploymentUrl", "")
+        if not url:
+            raise ValueError(f"Deployment {deployment_id!r} has no deploymentUrl (not running?)")
+
+        with self._lock:
+            self._deployment_cache[deployment_id] = url
+        return url

--- a/packages/aicore/src/aicore/models/__init__.py
+++ b/packages/aicore/src/aicore/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model adapters backed by AICoreClient."""

--- a/packages/aicore/src/aicore/models/anthropic.py
+++ b/packages/aicore/src/aicore/models/anthropic.py
@@ -1,0 +1,29 @@
+"""Anthropic (Bedrock Converse) adapter for SAP AI Core."""
+
+from typing import Any
+
+from langchain_aws import ChatBedrockConverse
+from pydantic import SecretStr
+
+from aicore.client import AICoreClient
+
+
+class AnthropicAdapter:
+    """Wraps ChatBedrockConverse with SAP AI Core deployment URL and bearer token."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str, model_name: str, **kwargs: Any) -> None:
+        deployment_url = client.get_deployment_url(deployment_id)
+        token = client.get_token()
+        self._llm = ChatBedrockConverse(
+            base_url=deployment_url,
+            aws_access_key_id=SecretStr("dummy"),
+            aws_secret_access_key=SecretStr(token),
+            region_name="us-east-1",
+            model=model_name,
+            **kwargs,
+        )
+
+    @property
+    def llm(self) -> ChatBedrockConverse:
+        """Return the underlying ChatBedrockConverse instance."""
+        return self._llm

--- a/packages/aicore/src/aicore/models/embeddings.py
+++ b/packages/aicore/src/aicore/models/embeddings.py
@@ -1,0 +1,23 @@
+"""OpenAI embeddings adapter for SAP AI Core."""
+
+from langchain_openai import OpenAIEmbeddings
+
+from aicore.client import AICoreClient
+
+
+class OpenAIEmbeddingsAdapter:
+    """Wraps OpenAIEmbeddings with SAP AI Core deployment URL and bearer token."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str, model_name: str) -> None:
+        deployment_url = client.get_deployment_url(deployment_id)
+        token = client.get_token()
+        self._embeddings = OpenAIEmbeddings(
+            base_url=f"{deployment_url}",
+            api_key=token,  # type: ignore[arg-type]
+            model=model_name,
+        )
+
+    @property
+    def embeddings(self) -> OpenAIEmbeddings:
+        """Return the underlying OpenAIEmbeddings instance."""
+        return self._embeddings

--- a/packages/aicore/src/aicore/models/gemini.py
+++ b/packages/aicore/src/aicore/models/gemini.py
@@ -1,0 +1,89 @@
+"""Gemini adapter for SAP AI Core via custom httpx transport."""
+
+import httpx
+from google import genai
+from google.genai import types
+from google.oauth2.credentials import Credentials
+
+from aicore.client import AICoreClient
+
+
+class _AICoreTransport(httpx.BaseTransport):
+    """Synchronous httpx transport that rewrites Google GenAI requests to route through AI Core."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str) -> None:
+        self._client = client
+        self._deployment_id = deployment_id
+        self._inner = httpx.HTTPTransport()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """Rewrite URL and inject auth header, then forward."""
+        _rewrite(request, self._client, self._deployment_id)
+        return self._inner.handle_request(request)
+
+    def close(self) -> None:
+        """Close the inner transport."""
+        self._inner.close()
+
+
+class _AsyncAICoreTransport(httpx.AsyncBaseTransport):
+    """Async httpx transport that rewrites Google GenAI requests to route through AI Core."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str) -> None:
+        self._client = client
+        self._deployment_id = deployment_id
+        self._inner = httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Rewrite URL and inject auth header, then forward."""
+        _rewrite(request, self._client, self._deployment_id)
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        """Close the inner transport."""
+        await self._inner.aclose()
+
+
+def _rewrite(request: httpx.Request, client: AICoreClient, deployment_id: str) -> None:
+    """Rewrite a Google GenAI httpx request to route through AI Core in-place."""
+    path = request.url.path
+    if "/models/" not in path:
+        return
+
+    _, suffix = path.split("/models/", 1)
+    if not suffix or suffix.startswith(("/", "?")):
+        return
+
+    deployment_url = httpx.URL(client.get_deployment_url(deployment_id))
+    new_path = f"{deployment_url.path.rstrip('/')}/models/{suffix}"
+    request.url = request.url.copy_with(
+        scheme=deployment_url.scheme,
+        host=deployment_url.host,
+        port=deployment_url.port,
+        path=new_path,
+    )
+    token = client.get_token()
+    request.headers["Host"] = deployment_url.host
+    request.headers["Authorization"] = f"Bearer {token}"
+
+
+class GeminiAdapter:
+    """Wraps google.genai.Client with SAP AI Core routing."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str) -> None:
+        self._name: str = ""
+        self._model = genai.Client(
+            vertexai=True,
+            project="placeholder",
+            location="placeholder",
+            credentials=Credentials(token="placeholder"),
+            http_options=types.HttpOptions(
+                client_args={"transport": _AICoreTransport(client, deployment_id)},
+                async_client_args={"transport": _AsyncAICoreTransport(client, deployment_id)},
+            ),
+        )
+
+    @property
+    def llm(self) -> genai.Client:
+        """Return the underlying google.genai.Client instance."""
+        return self._model

--- a/packages/aicore/src/aicore/models/openai.py
+++ b/packages/aicore/src/aicore/models/openai.py
@@ -1,0 +1,26 @@
+"""OpenAI chat model adapter for SAP AI Core."""
+
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+
+from aicore.client import AICoreClient
+
+
+class OpenAIAdapter:
+    """Wraps ChatOpenAI with SAP AI Core deployment URL and bearer token."""
+
+    def __init__(self, client: AICoreClient, deployment_id: str, model_name: str, **kwargs: Any) -> None:
+        deployment_url = client.get_deployment_url(deployment_id)
+        token = client.get_token()
+        self._llm = ChatOpenAI(
+            base_url=f"{deployment_url}/chat/completions",
+            api_key=token,  # type: ignore[arg-type]
+            model=model_name,
+            **kwargs,
+        )
+
+    @property
+    def llm(self) -> ChatOpenAI:
+        """Return the underlying ChatOpenAI instance."""
+        return self._llm

--- a/poetry.lock
+++ b/poetry.lock
@@ -38,42 +38,26 @@ sqlite = ["sqlalchemy[aiosqlite,asyncio] (>=2.0.0)"]
 telemetry = ["opentelemetry-api (>=1.33.0)", "opentelemetry-sdk (>=1.33.0)"]
 
 [[package]]
-name = "aenum"
-version = "3.1.17"
-description = "Advanced Enumerations (compatible with Python's stdlib Enum), NamedTuples, and NamedConstants"
+name = "aicore"
+version = "0.1.0"
+description = "Hand-rolled SAP AI Core client and LangChain model adapters"
 optional = false
-python-versions = "*"
+python-versions = "==3.14.*"
 groups = ["main"]
-files = [
-    {file = "aenum-3.1.17-py2-none-any.whl", hash = "sha256:0dad0421b2fbe30e3fb623b2a0a23eff823407df53829d6a72595e7f76f3d872"},
-    {file = "aenum-3.1.17-py3-none-any.whl", hash = "sha256:8b883a37a04e74cc838ac442bdd28c266eae5bbf13e1342c7ef123ed25230139"},
-    {file = "aenum-3.1.17.tar.gz", hash = "sha256:a969a4516b194895de72c875ece355f17c0d272146f7fda346ef74f93cf4d5ba"},
-]
-
-[[package]]
-name = "aiobotocore"
-version = "3.9.0"
-description = "Async client for aws services using botocore and aiohttp"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "aiobotocore-3.9.0-py3-none-any.whl", hash = "sha256:7354659eac9ba6034675b3ea178330b7de97c45989d6fda1bf01d3da167b6135"},
-    {file = "aiobotocore-3.9.0.tar.gz", hash = "sha256:5d344e97c518b010bea167c7f7ba4f9e785f9d2b8ac7af4fd00846c62f2c0a10"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-aiohttp = ">=3.14.0,<4.0.0"
-aioitertools = ">=0.5.1,<1.0.0"
-botocore = ">=1.43.3,<1.43.57"
-jmespath = ">=0.7.1,<2.0.0"
-multidict = ">=6.0.0,<7.0.0"
-python-dateutil = ">=2.1,<3.0.0"
-wrapt = ">=1.10.10,<3.0.0"
+google-genai = ">=2.0.0,<3.0.0"
+httpx = ">=0.28.1,<0.29.0"
+langchain-aws = ">=1.0.0,<2.0.0"
+langchain-core = ">=1.0.0,<2.0.0"
+langchain-openai = ">=0.3.0,<2.0.0"
+python-decouple = ">=3.8,<4.0"
 
-[package.extras]
-httpx = ["anyio (>=4.11.0,<5)", "httpx (>=0.25.1,<0.29)"]
-httpx2 = ["anyio (>=4.11.0,<5)", "httpx2 (>=2.0,<3.0.0)"]
+[package.source]
+type = "directory"
+url = "packages/aicore"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -227,18 +211,6 @@ yarl = ">=1.17.0,<2.0"
 
 [package.extras]
 speedups = ["Brotli (>=1.2) ; platform_python_implementation == \"CPython\" and sys_platform != \"android\" and sys_platform != \"ios\"", "aiodns (>=3.3.0) ; sys_platform != \"android\" and sys_platform != \"ios\"", "backports.zstd ; platform_python_implementation == \"CPython\" and python_version < \"3.14\" and sys_platform != \"android\" and sys_platform != \"ios\"", "brotlicffi (>=1.2) ; platform_python_implementation != \"CPython\""]
-
-[[package]]
-name = "aioitertools"
-version = "0.13.0"
-description = "itertools and builtins for AsyncIO and mixed iterables"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be"},
-    {file = "aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c"},
-]
 
 [[package]]
 name = "aioresponses"
@@ -999,21 +971,6 @@ cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy
 ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
-name = "dacite"
-version = "1.9.2"
-description = "Simple creation of data classes from dictionaries."
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "dacite-1.9.2-py3-none-any.whl", hash = "sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0"},
-    {file = "dacite-1.9.2.tar.gz", hash = "sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09"},
-]
-
-[package.extras]
-dev = ["black", "coveralls", "mypy", "pre-commit", "pylint", "pytest (>=5)", "pytest-benchmark", "pytest-cov"]
-
-[[package]]
 name = "datasets"
 version = "5.0.1"
 description = "HuggingFace community-driven open-source library of datasets"
@@ -1614,18 +1571,6 @@ groups = ["dev", "test"]
 files = [
     {file = "filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82"},
     {file = "filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8"},
-]
-
-[[package]]
-name = "filetype"
-version = "1.2.0"
-description = "Infer file type and MIME type of any file/buffer. No external dependencies."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
-    {file = "filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb"},
 ]
 
 [[package]]
@@ -2262,7 +2207,7 @@ version = "0.4.3"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "test"]
+groups = ["test"]
 files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
@@ -2889,7 +2834,7 @@ version = "0.4.2"
 description = "Community contributed LangChain integrations."
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
-groups = ["main", "test"]
+groups = ["test"]
 files = [
     {file = "langchain_community-0.4.2-py3-none-any.whl", hash = "sha256:84dd8c5122532394d5b6849a5fc9995ef28e4f77227daeb09f24b3d942e9e466"},
     {file = "langchain_community-0.4.2.tar.gz", hash = "sha256:a99308160d53d7e9b5965ee665e5173709914338210089fd5788ad724432c21e"},
@@ -2931,24 +2876,6 @@ pyyaml = ">=5.3.0,<7.0.0"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 typing-extensions = ">=4.7.0,<5.0.0"
 uuid-utils = ">=0.12.0,<1.0"
-
-[[package]]
-name = "langchain-google-genai"
-version = "4.2.7"
-description = "An integration package connecting Google's genai package and LangChain"
-optional = false
-python-versions = "<4.0.0,>=3.10.0"
-groups = ["main"]
-files = [
-    {file = "langchain_google_genai-4.2.7-py3-none-any.whl", hash = "sha256:0d9c388d0e6c629718fca6abb19c6fdca728a9a7873d0324c1ec821288b5b571"},
-    {file = "langchain_google_genai-4.2.7.tar.gz", hash = "sha256:03b1463ffe4d42435f43c7870467f2215f684bb46400d2543435d10157c80ac7"},
-]
-
-[package.dependencies]
-filetype = ">=1.2.0,<2.0.0"
-google-genai = ">=1.65.0,<3.0.0"
-langchain-core = ">=1.4.7,<2.0.0"
-pydantic = ">=2.0.0,<3.0.0"
 
 [[package]]
 name = "langchain-hana"
@@ -3016,23 +2943,6 @@ files = [
 
 [package.dependencies]
 langchain-core = ">=1.2.31,<2.0.0"
-
-[[package]]
-name = "langcodes"
-version = "3.5.1"
-description = "Tools for labeling human languages with IETF language tags"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72"},
-    {file = "langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731"},
-]
-
-[package.extras]
-build = ["build", "twine"]
-data = ["language-data (>=1.2)"]
-test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "langfuse"
@@ -4217,18 +4127,6 @@ files = [
 ]
 
 [[package]]
-name = "overloading"
-version = "0.5.0"
-description = "Function overloading for Python 3"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "overloading-0.5.0-py3-none-any.whl", hash = "sha256:c28d2a227cfb6bdefcfe0ded055bc620a5c784a52ecadc441f8d6c281b8bb1c1"},
-    {file = "overloading-0.5.0.tar.gz", hash = "sha256:493f0f67211244ed6bf2acf9f3ac61fb38e8aa87834c4f0f84d8943512066588"},
-]
-
-[[package]]
 name = "packaging"
 version = "26.3"
 description = "Core utilities for Python packages"
@@ -4246,7 +4144,7 @@ version = "3.0.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "test"]
+groups = ["test"]
 files = [
     {file = "pandas-3.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2946e77e4a53cd248cbde631a12f0e51c8324ce354c3eba4d20147c1ad6f4282"},
     {file = "pandas-3.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71ecc8fb7ed1a7aa4392316b5309a6347e8e7f832f38fd897846b3a1457a9298"},
@@ -5298,18 +5196,6 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
-name = "pyhumps"
-version = "3.8.0"
-description = "🐫  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6"},
-    {file = "pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3"},
-]
-
-[[package]]
 name = "pyjwt"
 version = "2.13.0"
 description = "JSON Web Token implementation in Python"
@@ -6354,76 +6240,6 @@ botocore = ">=1.37.4,<2.0a0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
 
 [[package]]
-name = "sap-ai-sdk-base"
-version = "3.4.0"
-description = "SAP Cloud SDK for AI (Python): Base Client"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "sap_ai_sdk_base-3.4.0-py3-none-any.whl", hash = "sha256:0f820e5b4976989d9d178c64bc989d0f80fc61442b64e96851628ddacfadb366"},
-]
-
-[package.dependencies]
-aenum = ">=3.1,<4.0"
-pyhumps = ">=3.0,<4.0"
-requests = ">=2.32,<3.0"
-
-[[package]]
-name = "sap-ai-sdk-core"
-version = "3.3.0"
-description = "SAP Cloud SDK for AI (Python): Core SDK"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "sap_ai_sdk_core-3.3.0-py3-none-any.whl", hash = "sha256:f13552ab3525bc559a212951b4ae02d992722e355ae0e997cd129199bdad64e3"},
-]
-
-[package.dependencies]
-click = ">=8.3,<9.0"
-sap-ai-sdk-base = ">=3.4,<4.0"
-
-[[package]]
-name = "sap-ai-sdk-gen"
-version = "7.2.0"
-description = "SAP Cloud SDK for AI (Python): generative AI SDK"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "sap_ai_sdk_gen-7.2.0-py3-none-any.whl", hash = "sha256:5b534e2b3780ecd13dd0820961d3dd2b8ebb8a2fc9069169d6d684e9bc5c7cec"},
-]
-
-[package.dependencies]
-aiobotocore = {version = ">=3.2.0", optional = true, markers = "extra == \"all\""}
-boto3 = {version = ">=1.40.61", optional = true, markers = "extra == \"all\""}
-click = ">=8.1.7"
-dacite = ">=1.8.1"
-google-genai = {version = ">=2.9.0,<2.10.0", optional = true, markers = "extra == \"all\""}
-h11 = ">=0.16.0"
-httpx = ">=0.27.0"
-langchain = ">=1.3.11,<1.4.0"
-langchain-aws = {version = ">=1.6.0,<1.7.0", optional = true, markers = "extra == \"all\""}
-langchain-classic = ">=1.0.0,<1.1.0"
-langchain-community = ">=0.4.1,<0.5.0"
-langchain-google-genai = {version = ">=4.2.5,<4.3.0", optional = true, markers = "extra == \"all\""}
-langchain-openai = ">=1.3.3,<1.4.0"
-langcodes = ">=3.5.1,<3.6.0"
-openai = ">=1.66.0"
-overloading = "0.5.0"
-packaging = ">=23.2"
-pandas = ">=2.2.0"
-pydantic = ">=2.12,<3.0"
-sap-ai-sdk-core = ">=3.3.0"
-setuptools = "50.3.1"
-
-[package.extras]
-all = ["aiobotocore (>=3.2.0)", "boto3 (>=1.40.61)", "google-genai (>=2.9.0,<2.10.0)", "langchain-aws (>=1.6.0,<1.7.0)", "langchain-google-genai (>=4.2.5,<4.3.0)"]
-amazon = ["aiobotocore (>=3.2.0)", "boto3 (>=1.40.61)", "langchain-aws (>=1.6.0,<1.7.0)"]
-google = ["google-genai (>=2.9.0,<2.10.0)", "langchain-google-genai (>=4.2.5,<4.3.0)"]
-
-[[package]]
 name = "scikit-network"
 version = "0.33.5"
 description = "Graph algorithms"
@@ -6607,7 +6423,7 @@ version = "50.3.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.5"
-groups = ["main", "test"]
+groups = ["test"]
 files = [
     {file = "setuptools-50.3.1-py3-none-any.whl", hash = "sha256:8d057d7a928a82cdc985654355fc9e5431def7b6bdfc9e0f32d1e388a63c8ec6"},
     {file = "setuptools-50.3.1.zip", hash = "sha256:0e9772768fa6e9d3cf818a3e6e24dd2236f319d2c478312995edcb30ddeb8343"},
@@ -7091,7 +6907,7 @@ version = "2026.3"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main", "test"]
+groups = ["test"]
 markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
 files = [
     {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
@@ -8172,4 +7988,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.14.*"
-content-hash = "2485fb7b509f82f3472e1fefb10167a45dac87a5bc85a9cefd95307b36f716e9"
+content-hash = "cfa5de41b43594b0da81cc7250c0f26f643629536154fc530e70b82403041f67"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ authors = [
 requires-python = "==3.14.*"
 dependencies = [
   "a2a-sdk[http-server] (>=1.1.0,<2.0)",
+  "aicore @ file:///Users/I549741/claude/kyma/kyma-companion/remove-sap-ai-sdk/packages/aicore",
   "aiohttp (>=3.14.1,<3.15.0)",
   "cryptography (>=50.0.0,<51.0.0)",
   "fastapi[standard] (>=0.141.1,<0.142.0)",
@@ -34,7 +35,6 @@ dependencies = [
   "python-json-logger (>=4.2.0,<5.0.0)",
   "python-multipart (>=0.0.32,<0.0.33)",
   "redis (>=8.0.1,<9.0.0)",
-  "sap-ai-sdk-gen[all] (>=7.0.0,<8.0.0)",
   "tenacity (>=9.1.4,<10.0.0)",
   "tiktoken (>=0.14.0,<0.15.0)",
   "uvicorn (>=0.52.3,<0.53.0)"

--- a/src/utils/chain.py
+++ b/src/utils/chain.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from langchain_core.runnables import RunnableConfig, RunnableSequence
+from langchain_core.runnables import RunnableConfig, RunnableSerializable
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
     reraise=True,
 )
 async def ainvoke_chain(
-    chain: RunnableSequence,
+    chain: RunnableSerializable[Any, Any],
     inputs: dict[str, Any] | Any,
     *,
     config: RunnableConfig | None = None,

--- a/src/utils/models/anthropic.py
+++ b/src/utils/models/anthropic.py
@@ -1,7 +1,5 @@
-from gen_ai_hub.proxy.core.base import BaseProxyClient
-from gen_ai_hub.proxy.langchain.amazon import ChatBedrockConverse
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
-from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAIClient
+from aicore import AICoreClient, AnthropicAdapter
+from langchain_core.language_models import BaseChatModel
 
 from utils.config import ModelConfig
 
@@ -10,16 +8,17 @@ class AnthropicModel:
     """Anthropic Claude model via AWS Bedrock Converse API."""
 
     _name: str
-    _llm: ChatBedrockConverse
+    _llm: BaseChatModel
 
-    def __init__(self, config: ModelConfig, proxy_client: BaseProxyClient):
+    def __init__(self, config: ModelConfig, client: AICoreClient) -> None:
         self._name = config.name
-        self._llm = ChatBedrockConverse(
-            model_name=config.name,
+        adapter = AnthropicAdapter(
+            client=client,
             deployment_id=config.deployment_id,
-            proxy_client=proxy_client,
+            model_name=config.name,
             temperature=config.temperature,
         )
+        self._llm = adapter.llm
 
     def invoke(self, content: str):  # noqa
         """Generate content using the model."""
@@ -31,6 +30,6 @@ class AnthropicModel:
         return self._name
 
     @property
-    def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
+    def llm(self) -> BaseChatModel:
         """Returns the instance of the Anthropic model."""
         return self._llm

--- a/src/utils/models/factory.py
+++ b/src/utils/models/factory.py
@@ -2,12 +2,9 @@ from enum import StrEnum
 from functools import lru_cache
 from typing import Protocol, cast, runtime_checkable
 
-from gen_ai_hub.proxy.core.base import BaseProxyClient
-from gen_ai_hub.proxy.core.proxy_clients import get_proxy_client
-from gen_ai_hub.proxy.langchain.amazon import ChatBedrockConverse
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI, OpenAIEmbeddings
-from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAIClient
+from aicore import AICoreClient, OpenAIEmbeddingsAdapter
 from langchain_core.embeddings import Embeddings
+from langchain_core.language_models import BaseChatModel
 
 from utils.config import Config
 from utils.models.anthropic import AnthropicModel
@@ -61,14 +58,14 @@ class IModel(Protocol):
         """The name of the model."""
 
     @property
-    def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
+    def llm(self) -> BaseChatModel:
         """The instance of the model."""
 
 
 @lru_cache(maxsize=1)
-def init_proxy_client() -> BaseProxyClient:
-    """Initialize the proxy client for the GenAI Hub only once."""
-    return get_proxy_client("gen-ai-hub")
+def init_aicore_client() -> AICoreClient:
+    """Initialize the AICoreClient only once."""
+    return AICoreClient()
 
 
 class IModelFactory(Protocol):
@@ -85,7 +82,7 @@ class ModelFactory:
     """Model Factory for LLM and Embedding models."""
 
     def __init__(self, config: Config):
-        self._proxy_client = init_proxy_client()
+        self._aicore_client = init_aicore_client()
         self._models: dict[str, IModel | Embeddings] = {}
         self._config = config
 
@@ -106,16 +103,16 @@ class ModelFactory:
 
         # Dispatch mechanism for model creation.
         model_prefix_dispatch = {
-            ModelPrefix.GPT: lambda: OpenAIModel(model_config, self._proxy_client),
-            ModelPrefix.GEMINI: lambda: GeminiModel(model_config, self._proxy_client),
-            ModelPrefix.ANTHROPIC: lambda: AnthropicModel(model_config, self._proxy_client),
+            ModelPrefix.GPT: lambda: OpenAIModel(model_config, self._aicore_client),
+            ModelPrefix.GEMINI: lambda: GeminiModel(model_config, self._aicore_client),
+            ModelPrefix.ANTHROPIC: lambda: AnthropicModel(model_config, self._aicore_client),
             ModelPrefix.TEXT_EMBEDDING: lambda: cast(
                 Embeddings,
-                OpenAIEmbeddings(
-                    model=name,
+                OpenAIEmbeddingsAdapter(
+                    client=self._aicore_client,
                     deployment_id=model_config.deployment_id,
-                    proxy_client=self._proxy_client,
-                ),
+                    model_name=name,
+                ).embeddings,
             ),
         }
 

--- a/src/utils/models/gemini.py
+++ b/src/utils/models/gemini.py
@@ -1,31 +1,26 @@
-from gen_ai_hub.proxy.core.base import BaseProxyClient
-from gen_ai_hub.proxy.langchain.amazon import ChatBedrockConverse
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
-from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAIClient
+from aicore import AICoreClient, GeminiAdapter
+from google.genai import Client as GoogleGenAIClient
 
 from utils.config import ModelConfig
 
 
 class GeminiModel:
-    """Gemini Model."""
+    """Gemini Model -- uses google.genai.Client directly, not a LangChain BaseChatModel."""
 
     _name: str
     _model: GoogleGenAIClient
 
-    def __init__(self, config: ModelConfig, proxy_client: BaseProxyClient):
+    def __init__(self, config: ModelConfig, client: AICoreClient) -> None:
         self._name = config.name
-        self._model = GoogleGenAIClient(
-            proxy_client=proxy_client,
-            deployment_id=config.deployment_id,
-        )
+        adapter = GeminiAdapter(client=client, deployment_id=config.deployment_id)
+        self._model = adapter.llm
 
     def invoke(self, content: str):  # noqa
         """Generate content using the model"""
-        response = self._model.models.generate_content(
+        return self._model.models.generate_content(
             model=self._name,
             contents=content,
         )
-        return response
 
     @property
     def name(self) -> str:
@@ -33,6 +28,6 @@ class GeminiModel:
         return self._name
 
     @property
-    def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
-        """Returns the instance of Gemini model."""
+    def llm(self) -> GoogleGenAIClient:
+        """Returns the underlying google.genai.Client instance."""
         return self._model

--- a/src/utils/models/openai.py
+++ b/src/utils/models/openai.py
@@ -1,7 +1,5 @@
-from gen_ai_hub.proxy.core.base import BaseProxyClient
-from gen_ai_hub.proxy.langchain.amazon import ChatBedrockConverse
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
-from gen_ai_hub.proxy.native.google_genai.clients import Client as GoogleGenAIClient
+from aicore import AICoreClient, OpenAIAdapter
+from langchain_core.language_models import BaseChatModel
 
 from utils import settings
 from utils.config import ModelConfig
@@ -11,23 +9,23 @@ class OpenAIModel:
     """OpenAI Model."""
 
     _name: str
-    _llm: ChatOpenAI
+    _llm: BaseChatModel
 
-    def __init__(self, config: ModelConfig, proxy_client: BaseProxyClient):
+    def __init__(self, config: ModelConfig, client: AICoreClient) -> None:
         self._name = config.name
-        self._llm = ChatOpenAI(
-            proxy_model_name=config.name,
+        adapter = OpenAIAdapter(
+            client=client,
             deployment_id=config.deployment_id,
-            proxy_client=proxy_client,
+            model_name=config.name,
             temperature=config.temperature,
             request_timeout=settings.LLM_REQUEST_TIMEOUT_SECONDS,
             timeout=settings.LLM_REQUEST_TIMEOUT_SECONDS,
         )
+        self._llm = adapter.llm
 
     def invoke(self, content: str):  # noqa
         """Generate content using the model"""
-        response = self.llm.invoke(content)
-        return response
+        return self._llm.invoke(content)
 
     @property
     def name(self) -> str:
@@ -35,6 +33,6 @@ class OpenAIModel:
         return self._name
 
     @property
-    def llm(self) -> ChatOpenAI | GoogleGenAIClient | ChatBedrockConverse:
+    def llm(self) -> BaseChatModel:
         """Returns the instance of OpenAI model."""
         return self._llm

--- a/tests/blackbox/poetry.lock
+++ b/tests/blackbox/poetry.lock
@@ -14,6 +14,28 @@ files = [
 ]
 
 [[package]]
+name = "aicore"
+version = "0.1.0"
+description = "Hand-rolled SAP AI Core client and LangChain model adapters"
+optional = false
+python-versions = "==3.14.*"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+google-genai = ">=2.0.0,<3.0.0"
+httpx = ">=0.28.1,<0.29.0"
+langchain-aws = ">=1.0.0,<2.0.0"
+langchain-core = ">=1.0.0,<2.0.0"
+langchain-openai = ">=0.3.0,<2.0.0"
+python-decouple = ">=3.8,<4.0"
+
+[package.source]
+type = "directory"
+url = "../../packages/aicore"
+
+[[package]]
 name = "aiobotocore"
 version = "3.9.0"
 description = "Async client for aws services using botocore and aiohttp"
@@ -5717,4 +5739,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = "==3.14.*"
-content-hash = "3f086865324f2db30945031882ba5cfa03767be5570a9a3d11d0ac1885396ce6"
+content-hash = "063e5fe42a86a7d2febfc2d7dc900c681de2bf89008a0f74ac0cea0c1d95f323"

--- a/tests/blackbox/pyproject.toml
+++ b/tests/blackbox/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "python-decouple (>=3.8,<4.0)",
   "redis (>=8.0.1,<9.0.0)",
   "requests (>=2.34.2,<3.0.0)",
-  "sap-ai-sdk-gen[all] (>=7.0.0,<8.0.0)"
+  "aicore @ file:///Users/I549741/claude/kyma/kyma-companion/remove-sap-ai-sdk/packages/aicore"
 ]
 [tool.poetry]
 package-mode = false

--- a/tests/blackbox/src/evaluation/validator/validator.py
+++ b/tests/blackbox/src/evaluation/validator/validator.py
@@ -1,12 +1,13 @@
 from typing import Any, Protocol
 
+from aicore import AICoreClient, OpenAIAdapter
 from deepeval.evaluate.configs import AsyncConfig, CacheConfig, DisplayConfig
 from deepeval.evaluate.evaluate import evaluate
 from deepeval.evaluate.types import EvaluationResult
 from deepeval.metrics import BaseMetric, GEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import LLMTestCase, LLMTestCaseParams
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 from evaluation.scenario.scenario import Query
 
@@ -52,12 +53,15 @@ class ChatOpenAIValidator:
     model: LangChainOpenAI
 
     def __init__(self, name: str, temperature: str, deployment_id: str) -> None:
-        model = ChatOpenAI(
+        client = AICoreClient()
+        adapter = OpenAIAdapter(
+            client=client,
+            deployment_id=deployment_id,
             model_name=name,
             temperature=temperature,
-            deployment_id=deployment_id,
         )
-        self.model = LangChainOpenAI(model=model)
+        llm: ChatOpenAI = adapter.llm
+        self.model = LangChainOpenAI(model=llm)
 
     def get_deepeval_evaluate(self, query: Query) -> EvaluationResult:
         """Evaluate the query using the model and expectations."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,10 +49,10 @@ def mock_config():
 
 @pytest.fixture
 def mock_get_proxy_client():
-    with patch("utils.models.factory.get_proxy_client") as mock_get_proxy_client:
-        mock_proxy_client = MagicMock()
-        mock_get_proxy_client.return_value = mock_proxy_client
-        yield mock_proxy_client
+    with patch("utils.models.factory.init_aicore_client") as mock_init:
+        mock_client = MagicMock()
+        mock_init.return_value = mock_client
+        yield mock_client
 
 
 @pytest.fixture

--- a/tests/unit/rag/test_query_generator.py
+++ b/tests/unit/rag/test_query_generator.py
@@ -1,8 +1,8 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from gen_ai_hub.proxy.langchain.openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
 
 from rag.prompts import QUERY_GENERATOR_PROMPT_TEMPLATE
 from rag.query_generator import Queries, QueryGenerator

--- a/tests/unit/utils/test_gemini.py
+++ b/tests/unit/utils/test_gemini.py
@@ -1,19 +1,19 @@
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from utils.config import ModelConfig
-from utils.models.factory import (
-    GeminiModel,
-)
+from utils.models.factory import GeminiModel
 
 
 @pytest.fixture
-def gemini_model(mock_get_proxy_client):
+def gemini_model():
     config = ModelConfig(name="gemini-1.0-pro", deployment_id="dep2", temperature=0)
-    with patch("utils.models.gemini.GoogleGenAIClient") as mock_client:
-        model = GeminiModel(config, mock_get_proxy_client)
-        model._model = mock_client.return_value
+    mock_client = MagicMock()
+    with patch("utils.models.gemini.GeminiAdapter") as mock_adapter_cls:
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        model = GeminiModel(config, mock_client)
         return model
 
 

--- a/tests/unit/utils/test_openai.py
+++ b/tests/unit/utils/test_openai.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -7,11 +7,13 @@ from utils.models.openai import OpenAIModel
 
 
 @pytest.fixture
-def openai_model(mock_get_proxy_client):
-    config = ModelConfig(name="gpt-4", deployment_id="deployment-123", temperature=0.7, type="openai")
-    with patch("utils.models.openai.ChatOpenAI") as mock_chat_openai:
-        model = OpenAIModel(config, mock_get_proxy_client)
-        model._llm = mock_chat_openai.return_value
+def openai_model():
+    config = ModelConfig(name="gpt-4", deployment_id="deployment-123", temperature=0.7)
+    mock_client = MagicMock()
+    with patch("utils.models.openai.OpenAIAdapter") as mock_adapter_cls:
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        model = OpenAIModel(config, mock_client)
         return model
 
 


### PR DESCRIPTION
## Summary

- Adds `packages/aicore/` -- a minimal internal Poetry package with an `AICoreClient` (OAuth2 token + deployment URL resolution) and LangChain adapters for OpenAI, Anthropic (Bedrock Converse), Gemini, and OpenAI Embeddings
- Removes `sap-ai-sdk-gen[all]` from the main app, `doc_indexer`, and `tests/blackbox` -- replacing all `gen_ai_hub` imports with `aicore`
- Broadens `ainvoke_chain` parameter type from `RunnableSequence` to `RunnableSerializable` to match actual usage (surfaced by updated langchain-core stubs)

## Motivation

`sap-ai-sdk-gen[all]` pulls in `pandas`, `langchain-community`, `langchain-classic`, `dacite`, `overloading`, and the full `sap-ai-sdk-base`/`sap-ai-sdk-core` chain -- none of which we use. Removing it reduces the transitive dependency surface and eliminates recurring CVE noise from unused packages.

`AICoreClient` does exactly two things: fetch an OAuth2 token via client-credentials grant, and resolve a deployment URL via `GET /lm/deployments/{id}`. Both are cached. The Go `kyma-companion-tools` service already proved this pattern works -- `packages/aicore/` is the direct Python equivalent.

## Testing

- Unit tests updated to mock `init_aicore_client` instead of `get_proxy_client`
- `test_query_generator.py` updated to import `ChatOpenAI` from `langchain_openai` instead of `gen_ai_hub`
- 863 unit tests passing locally; 7 pre-existing failures in `test_k8s.py` (domain validation, unrelated -- also failing on `main`)